### PR TITLE
Support generic use of native kube objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: rust
-
 rust:
   - stable
-
 script:
   - cargo build
   - cargo test -v
+notifications:
+  email:
+    on_success: change
+    on_failure: always
+branches:
+  only:
+    - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+0.3.0 / 2019-05-09
+==================
+  * `Named` trait removed (inferring from metadata.name now)
+  * Reflectors now take two type parameters (unless you use `ReflectorSpec` or `ReflectorStatus`) - see examples for usage
+  * Native kube types supported via `ApiResource`
+  * Some native kube resources have easy converters to `ApiResource`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kube"
-version = "0.2.0"
+version = "0.3.0"
 description = "Kubernetes rust client with a reflector"
 authors = [
   "clux <sszynrae@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ log = "0.4.6"
 
 [dev-dependencies]
 tempfile = "3.0.4"
+k8s-openapi = { version = "0.4.0", features = ["v1_13"] }

--- a/README.md
+++ b/README.md
@@ -6,39 +6,9 @@
 
 Rust client for [Kubernetes](http://kubernetes.io) API forking [ynqa/kubernetes-rust](https://github.com/ynqa/kubernetes-rust).
 
-This version has more error handling and a `Reflector` for easy caching of CRD state. It aims to cater to the more common operator case, but allows you sticking in dependencies like [k8s-openapi](https://github.com/Arnavion/k8s-openapi).
+This version has more error handling and a `Reflector` for easy caching of CRD state. It aims to cater to the more common operator case, but allows you sticking in dependencies like [k8s-openapi](https://github.com/Arnavion/k8s-openapi) for accurate struct representations.
 
-## Example
+## Examples
+See the [examples directory](./examples) for how to watch over resources in a simplistic way.
 
-See [operator-rs](https://github.com/clux/operator-rs) for ideas.
-
-Main ideas, depending on how complicated your need is:
-
-### Watch calls on a resource
-You probably want a reflector? See [operator-rs](https://github.com/clux/operator-rs).
-
-### Basic calls
-Use the exposed `APIClient` herein, and write Request functions directly:
-
-```rust
-pub fn list_all_crd_entries(r: &ApiResource) -> Result<http::Request<Vec<u8>>> {
-    let urlstr = format!("/apis/{group}/v1/namespaces/{ns}/{resource}?",
-        group = r.group, resource = r.resource, ns = r.namespace);
-    let urlstr = url::form_urlencoded::Serializer::new(urlstr).finish();
-    let mut req = http::Request::get(urlstr);
-    req.body(vec![]).map_err(Error::from)
-}
-```
-
-Then call them with:
-
-```rust
-let res = client.request::<ResourceList<Resource<T>>>(req)?;
-```
-
-where `Resource` + `ResourceList` can be constructed analogously to what's in [./src/api](https://github.com/clux/kubernetes-rust/tree/master/src/api).
-
-You can also look at the [documentation for k8s-openapi](https://docs.rs/crate/k8s-openapi) is generating. The functions that return `http::Request` are compatible.
-
-### Many basic calls
-Pull in [k8s-openapi](https://github.com/Arnavion/k8s-openapi) and call it from the client herein. Note that not everything is available from k8s-openapi anyway. Watching Crd entries (not the core definitions) was missing in 0.4.0.
+See [operator-rs](https://github.com/clux/operator-rs) for a full example with [actix](https://actix.rs/).

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -19,6 +19,7 @@ fn main() -> Result<(), failure::Error> {
     let config = config::load_kube_config().expect("failed to load kubeconfig");
     let client = APIClient::new(config);
 
+    // This example requires `kubectl apply -f examples/foo.yaml` run first
     let resource = ApiResource {
         group: "clux.dev".into(),
         resource: "foos".into(),

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -1,0 +1,44 @@
+extern crate failure;
+extern crate kube;
+#[macro_use] extern crate serde_derive;
+
+use kube::{
+    api::{ApiResource, ReflectorSpec as Reflector},
+    client::APIClient,
+    config,
+};
+
+// Own custom resource
+#[derive(Deserialize, Serialize, Clone)]
+pub struct FooResource {
+  name: String,
+  info: String,
+}
+
+fn main() -> Result<(), failure::Error> {
+    let config = config::load_kube_config().expect("failed to load kubeconfig");
+    let client = APIClient::new(config);
+
+    let resource = ApiResource {
+        group: "clux.dev".into(),
+        resource: "foos".into(),
+        version: "v1".into(),
+        namespace: Some("kube-system".into()),
+        ..Default::default()
+    };
+    let rf : Reflector<FooResource> = Reflector::new(client, resource)?;
+
+    // rf is initialized with full state, which can be extracted on demand.
+    // Output is Map of name -> (FooResource, _)
+    rf.read()?.into_iter().for_each(|(name, (spec, _))| {
+        println!("Found foo {}: {}", name, spec.info);
+    });
+
+    // r needs to have `r.poll()?` called continuosly to keep state up to date:
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(10));
+        rf.poll()?;
+        let deploys = rf.read()?.into_iter().map(|(name, _)| name).collect::<Vec<_>>();
+        println!("Current foos: {:?}", deploys);
+    }
+}

--- a/examples/deployment_reflector.rs
+++ b/examples/deployment_reflector.rs
@@ -1,0 +1,39 @@
+extern crate failure;
+extern crate k8s_openapi;
+extern crate kube;
+
+use kube::{
+    api::{ResourceType, Reflector},
+    client::APIClient,
+    config,
+};
+
+// You can fill in the parts of the structs you want
+// but for full info, you probably want k8s_openapi
+use k8s_openapi::api::apps::v1::{DeploymentSpec, DeploymentStatus};
+
+fn main() -> Result<(), failure::Error> {
+    let config = config::load_kube_config().expect("failed to load kubeconfig");
+    let client = APIClient::new(config);
+
+    let resource = ResourceType::Deploys(Some("kube-system".into()));
+    let rf : Reflector<DeploymentSpec, DeploymentStatus> = Reflector::new(client, resource.into())?;
+
+    // rf is initialized with full state, which can be extracted on demand.
+    // Output is Map of name -> (DeploymentSpec, DeploymentStatus)
+    rf.read()?.into_iter().for_each(|(name, (spec, status))| {
+        println!("Found deployment for {} - {} replicas running {:?}",
+            name, status.replicas.unwrap(),
+            spec.template.spec.unwrap().containers
+                .into_iter().map(|c| c.image.unwrap()).collect::<Vec<_>>()
+        );
+    });
+
+    // r needs to have `r.poll()?` called continuosly to keep state up to date:
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(10));
+        rf.poll()?;
+        let deploys = rf.read()?.into_iter().map(|(name, _)| name).collect::<Vec<_>>();
+        println!("Current deploys: {:?}", deploys);
+    }
+}

--- a/examples/foo.yaml
+++ b/examples/foo.yaml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.clux.dev
+spec:
+  group: clux.dev
+  names:
+    kind: Foo
+    listKind: FooList
+    plural: foos
+    singular: foo
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -1,0 +1,38 @@
+extern crate failure;
+extern crate k8s_openapi;
+extern crate kube;
+
+use kube::{
+    api::{ResourceType, Reflector},
+    client::APIClient,
+    config,
+};
+
+// You can fill in the parts of the structs you want
+// but for full info, you probably want k8s_openapi
+use k8s_openapi::api::core::v1::{NodeSpec, NodeStatus};
+
+fn main() -> Result<(), failure::Error> {
+    let config = config::load_kube_config().expect("failed to load kubeconfig");
+    let client = APIClient::new(config);
+
+    let resource = ResourceType::Nodes;
+    let rf : Reflector<NodeSpec, NodeStatus> = Reflector::new(client, resource.into())?;
+
+    // rf is initialized with full state, which can be extracted on demand.
+    // Output is Map of name -> (NodeSpec, NodeStatus)
+    rf.read()?.into_iter().for_each(|(name, (spec, status))| {
+        println!("Found node {} ({:?}) running {:?}",
+            name, spec.provider_id.unwrap(),
+            status.conditions.unwrap(),
+        );
+    });
+
+    // r needs to have `r.poll()?` called continuosly to keep state up to date:
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(10));
+        rf.poll()?;
+        let deploys = rf.read()?.into_iter().map(|(name, _)| name).collect::<Vec<_>>();
+        println!("Current nodes: {:?}", deploys);
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,8 +1,11 @@
 mod reflector;
 pub use self::reflector::{
   Reflector,
-  Cache,
+  ReflectorSpec,
+  ReflectorStatus,
   ResourceMap,
+  ResourceSpecMap,
+  ResourceStatusMap
 };
 
 mod resource;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,11 +5,12 @@ pub use self::reflector::{
   ReflectorStatus,
   ResourceMap,
   ResourceSpecMap,
-  ResourceStatusMap
+  ResourceStatusMap,
 };
 
 mod resource;
 pub use self::resource::{
   ApiResource,
+  ResourceType,
   ApiError,
 };

--- a/src/api/reflector.rs
+++ b/src/api/reflector.rs
@@ -138,9 +138,7 @@ fn get_resource_entries<T, U>(client: &APIClient, rg: &ApiResource) -> Result<Ca
     debug!("Got {} {} at resourceVersion={}", res.items.len(), rg.resource, version);
 
     for i in res.items {
-        // deployment for instance has status field outside .spec
-        // .spec isn't general enough - only works for CRDs
-        // also not every metadata has names
+        // The non-generic parts we care about are spec + status
         data.insert(i.metadata.name, (i.spec, i.status));
     }
     let keys = data.keys().cloned().collect::<Vec<_>>().join(", ");

--- a/src/api/reflector.rs
+++ b/src/api/reflector.rs
@@ -126,7 +126,7 @@ pub fn get_resource_entries<T>(client: &APIClient, rg: &ApiResource) -> Result<C
     let res = client.request::<ResourceList<Resource<T>>>(req)?;
     let mut data = BTreeMap::new();
     let version = res.metadata.resourceVersion;
-    info!("Got {} with {} elements at resourceVersion={}", res.kind, res.items.len(), version);
+    debug!("Got {} {} at resourceVersion={}", res.items.len(), rg.resource, version);
 
     for i in res.items {
         // deployment for instance has status field outside .spec

--- a/src/api/resource.rs
+++ b/src/api/resource.rs
@@ -13,6 +13,7 @@ use std::collections::BTreeMap;
 /// The optional arg is always the namespace.
 ///
 /// CustomResource purposefully ignored from this list.
+#[derive(Debug, Clone)]
 pub enum ResourceType {
     Nodes,
     Deploys(Option<String>),

--- a/src/api/resource.rs
+++ b/src/api/resource.rs
@@ -109,21 +109,24 @@ impl<T> Debug for WatchEvent<T> where
     }
 }
 
-/// Basic resource result wrapper struct
+/// Resource wrapper that cares about status
 ///
 /// Expected to be used by `ResourceList` and `WatchEvent`
 /// Because it's experimental, it's not exposed outside the crate.
 #[derive(Deserialize, Clone)]
-pub struct Resource<T> where
-  T: Clone
+pub struct Resource<T, U> where
+  T: Clone, U: Clone
 {
     pub apiVersion: Option<String>,
     pub kind: Option<String>,
     pub metadata: Metadata,
     pub spec: T,
-    // Status?
+    pub status: U,
 }
 
+/// Empty struct used as U when status is not present
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct Discard {}
 
 /// Basic Metadata struct
 ///

--- a/src/api/resource.rs
+++ b/src/api/resource.rs
@@ -128,6 +128,9 @@ pub struct Resource<T> where
 ///
 /// Only parses a few fields relevant to a reflector.
 /// Because it's experimental, it's not exposed outside the crate.
+///
+/// It's a simplified version of:
+/// `[k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta](https://docs.rs/k8s-openapi/0.4.0/k8s_openapi/apimachinery/pkg/apis/meta/v1/struct.ObjectMeta.html)`
 #[derive(Deserialize, Clone, Default)]
 pub struct Metadata {
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -143,12 +146,13 @@ pub struct Metadata {
 ///
 /// Expected to be returned by a query from `list_all_resource_entries`
 /// Because it's experimental, it's not exposed outside the crate.
+///
+/// It can generally be used in place of DeploymentList, NodeList, etc
+/// because [they all tend to have these fields](https://docs.rs/k8s-openapi/0.4.0/k8s_openapi/apimachinery/pkg/apis/meta/v1/struct.ObjectMeta.html?search=List).
 #[derive(Deserialize)]
 pub struct ResourceList<T> where
   T: Clone
 {
-    pub apiVersion: String,
-    pub kind: String,
     pub metadata: Metadata,
     #[serde(bound(deserialize = "Vec<T>: Deserialize<'de>"))]
     pub items: Vec<T>,


### PR DESCRIPTION
Extends `Reflector` to a two argument generic version (although you don't have to use both arguments).

See https://github.com/clux/operator-rs/pull/1 for how it currently works. Probably need to think about this some more. Having `Reflector<T,U>`, and `ReflectorSpec<T>` + `ReflectorStatus<U>` (which Discard the unneeded param) feels a bit awkward, but not sure a macro is nicer. The duplication is also in the type alias for `ResourceMap` atm. It's not _that_ bad to keep track of these types, but it's slightly awkward.

Suggestions welcome. Leaving it here for a bit while i mull it over.