### PR TITLE
Change Reflector internal representation

### DIFF
--- a/examples/configmap_reflector.rs
+++ b/examples/configmap_reflector.rs
@@ -17,8 +17,8 @@ fn main() -> Result<(), failure::Error> {
     let rf = Reflector::new(resource).init()?;
 
     // Can read initial state now:
-    rf.read()?.into_iter().for_each(|(name, d)| {
-        info!("Found configmap {} with data: {:?}", name, d.data);
+    rf.read()?.into_iter().for_each(|config_map| {
+        info!("Found configmap {} with data: {:?}", config_map.metadata.name, config_map.data);
     });
 
     // Poll to keep data up to date:
@@ -26,7 +26,10 @@ fn main() -> Result<(), failure::Error> {
         rf.poll()?;
 
         // up to date state:
-        let pods = rf.read()?.into_iter().map(|(name, _)| name).collect::<Vec<_>>();
+        let pods = rf.read()?.into_iter()
+            .map(|config_map| config_map.metadata.name)
+            .collect::<Vec<_>>();
+
         info!("Current configmaps: {:?}", pods);
     }
 }

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -2,7 +2,7 @@
 #[macro_use] extern crate serde_derive;
 
 use kube::{
-    api::{RawApi, Reflector, Void, Object},
+    api::{Object, RawApi, Reflector, Void},
     client::APIClient,
     config,
 };
@@ -35,8 +35,8 @@ fn main() -> Result<(), failure::Error> {
         rf.poll()?;
 
         // Read updated internal state (instant):
-        rf.read()?.into_iter().for_each(|(name, crd)| {
-            info!("foo {}: {}", name, crd.spec.info);
+        rf.read()?.into_iter().for_each(|crd| {
+            info!("foo {}: {}", crd.metadata.name, crd.spec.info);
         });
     }
 }

--- a/examples/deployment_reflector.rs
+++ b/examples/deployment_reflector.rs
@@ -17,10 +17,11 @@ fn main() -> Result<(), failure::Error> {
 
     // rf is initialized with full state, which can be extracted on demand.
     // Output is Map of name -> Deployment
-    rf.read()?.into_iter().for_each(|(name, d)| {
+    rf.read()?.into_iter().for_each(|deployment| {
         info!("Found deployment for {} - {} replicas running {:?}",
-            name, d.status.unwrap().replicas.unwrap(),
-            d.spec.template.spec.unwrap().containers
+            deployment.metadata.name,
+            deployment.status.unwrap().replicas.unwrap(),
+            deployment.spec.template.spec.unwrap().containers
                 .into_iter().map(|c| c.image.unwrap()).collect::<Vec<_>>()
         );
     });
@@ -28,7 +29,7 @@ fn main() -> Result<(), failure::Error> {
     // r needs to have `r.poll()?` called continuosly to keep state up to date:
     loop {
         rf.poll()?;
-        let deploys = rf.read()?.into_iter().map(|(name, _)| name).collect::<Vec<_>>();
+        let deploys = rf.read()?.into_iter().map(|deployment| deployment.metadata.name).collect::<Vec<_>>();
         info!("Current deploys: {:?}", deploys);
     }
 }

--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -18,18 +18,19 @@ fn main() -> Result<(), failure::Error> {
 
     // rf is initialized with full state, which can be extracted on demand.
     // Output is Map of name -> Node
-    rf.read()?.into_iter().for_each(|(name, n)| {
+    rf.read()?.into_iter().for_each(|object| {
         info!("Found node {} ({:?}) running {:?} with labels: {:?}",
-            name, n.spec.provider_id.unwrap(),
-            n.status.unwrap().conditions.unwrap(),
-            n.metadata.labels,
+            object.metadata.name,
+            object.spec.provider_id.unwrap(),
+            object.status.unwrap().conditions.unwrap(),
+            object.metadata.labels,
         );
     });
 
     // r needs to have `r.poll()?` called continuosly to keep state up to date:
     loop {
         rf.poll()?;
-        let deploys = rf.read()?.into_iter().map(|(name, _)| name).collect::<Vec<_>>();
+        let deploys = rf.read()?.into_iter().map(|object| object.metadata.name).collect::<Vec<_>>();
         info!("Current nodes: {:?}", deploys);
     }
 }

--- a/examples/pod_reflector.rs
+++ b/examples/pod_reflector.rs
@@ -4,6 +4,7 @@ use kube::{
     client::APIClient,
     config,
 };
+
 fn main() -> Result<(), failure::Error> {
     std::env::set_var("RUST_LOG", "info,kube=trace");
     env_logger::init();
@@ -15,11 +16,11 @@ fn main() -> Result<(), failure::Error> {
     let rf = Reflector::new(resource).init()?;
 
     // Can read initial state now:
-    rf.read()?.into_iter().for_each(|(name, p)| {
+    rf.read()?.into_iter().for_each(|pod| {
         info!("Found pod {} ({}) with {:?}",
-            name,
-            p.status.unwrap().phase.unwrap(),
-            p.spec.containers.into_iter().map(|c| c.name).collect::<Vec<_>>(),
+            pod.metadata.name,
+            pod.status.unwrap().phase.unwrap(),
+            pod.spec.containers.into_iter().map(|c| c.name).collect::<Vec<_>>(),
         );
     });
 
@@ -28,7 +29,7 @@ fn main() -> Result<(), failure::Error> {
         rf.poll()?;
 
         // up to date state:
-        let pods = rf.read()?.into_iter().map(|(name, _)| name).collect::<Vec<_>>();
+        let pods = rf.read()?.into_iter().map(|pod| pod.metadata.name).collect::<Vec<_>>();
         info!("Current pods: {:?}", pods);
     }
 }

--- a/examples/secret_reflector.rs
+++ b/examples/secret_reflector.rs
@@ -27,9 +27,9 @@ fn main() -> Result<(), failure::Error> {
     let rf = Reflector::new(resource).init()?;
 
     // Can read initial state now:
-    rf.read()?.into_iter().for_each(|(name, d)| {
+    rf.read()?.into_iter().for_each(|secret| {
         let mut res = BTreeMap::new();
-        for (k, v) in d.data {
+        for (k, v) in secret.data {
             if let Ok(b) = std::str::from_utf8(&v.0) {
                 res.insert(k, Decoded::Utf8(b.to_string()));
             }
@@ -38,7 +38,7 @@ fn main() -> Result<(), failure::Error> {
             }
         }
         info!("Found secret {} with data: {:?}",
-            name,
+            secret.metadata.name,
             res,
         );
     });
@@ -48,7 +48,7 @@ fn main() -> Result<(), failure::Error> {
         rf.poll()?;
 
         // up to date state:
-        let pods = rf.read()?.into_iter().map(|(name, _)| name).collect::<Vec<_>>();
+        let pods = rf.read()?.into_iter().map(|secret| secret.metadata.name).collect::<Vec<_>>();
         info!("Current pods: {:?}", pods);
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,10 +5,7 @@
 pub struct Void {}
 
 mod reflector;
-pub use self::reflector::{
-    Cache,
-    Reflector,
-};
+pub use self::reflector::Reflector;
 
 mod informer;
 pub use self::informer::{


### PR DESCRIPTION
Change `Reflector` internal representation and index all the objects by
both `name` and `namespace`. With the previous implementation, there
were some issues with object with the same `name`, as described on:
https://github.com/clux/kube-rs/issues/55

This makes the `Cache` internal and we convert the data to a `Vec` when
it's read.

---

I think that this implementation combines the 2 ideas we discussed on the issue. Even that, I'm not convinced about returning a `Vec`. I was thinking about returning an iterator, but I would need to think about it a little bit more. What do you think?