### PR TITLE
Create public API creator

### DIFF
--- a/src/api/typed.rs
+++ b/src/api/typed.rs
@@ -54,6 +54,14 @@ pub trait Log: LogOperation {
 
 /// Expose same interface as Api for controlling scope/group/versions/ns
 impl<K> Api<K> {
+    pub fn new(api: RawApi, client: APIClient) -> Api<K> {
+        Api {
+            api,
+            client,
+            phantom: PhantomData,
+        }
+    }
+
     pub fn within(mut self, ns: &str) -> Self {
         self.api = self.api.within(ns);
         self


### PR DESCRIPTION
`Api` is a struct which is required on several public interfaces on this
crate (for example, `Reflector` or to simply fetch objects of a specific
type).

By having this public interface, one would be able to create `Api`
structs for other types which are not distributed by this crate. For
example, if one wants to create an `Api` for a custom type, now is
impossible (or I could not find a way to do it).

Another use case can be to wrap objects on a reference counted type (for
example `Rc<Object<PodSpec, PodStatus>>` or `Arc<Object<PodSpec,
PodStatus>>`). Using an `Arc` wrapped object, allows
extract objects from a `Reflector` on a cheaper way when objects are
large (as it avoids copying `Object`s that may be really large).

---

I realize that maybe is not a good idea to make publicly available this struct. What do you think?