### PR TITLE
Add Namespace, DaemonSet, StatefulSet, ReplicaSet, HorizontalPodAutoscaler, PersistentVolume, PersistentVolumeClaim, ResourceQuota and NetworkPolicy to openapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ http = "0.1.17"
 url = "1.7.2"
 log = "0.4.6"
 time = "0.1.42"
-k8s-openapi = { version = "0.4.0", optional = true }
+k8s-openapi = { version = "0.5.0", optional = true }
 either = "1.5.2"
 
 [features]
@@ -36,6 +36,6 @@ default = []
 openapi = ["k8s-openapi"]
 
 [dev-dependencies]
-k8s-openapi = { version = "0.4.0", features = ["v1_13"] }
+k8s-openapi = { version = "0.5.0", features = ["v1_14"] }
 tempfile = "3.0.7"
 env_logger = "0.6.1"

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -170,14 +170,3 @@ impl Api<Object<HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus>> {
         }
     }
 }
-
-use k8s_openapi::api::networking::v1::{NetworkPolicySpec, NetworkPolicyStatus};
-impl Api<Object<NetworkPolicySpec, NetworkPolicyStatus>> {
-    pub fn v1NetworkPolicy(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1NetworkPolicy(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -149,6 +149,17 @@ impl Api<Object<PersistentVolumeSpec, PersistentVolumeStatus>> {
     }
 }
 
+use k8s_openapi::api::core::v1::{ResourceQuotaSpec, ResourceQuotaStatus};
+impl Api<Object<ResourceQuotaSpec, ResourceQuotaStatus>> {
+    pub fn v1ResourceQuota(client: APIClient) -> Self {
+        Api {
+            api: RawApi::v1ResourceQuota(),
+            client,
+            phantom: PhantomData,
+        }
+    }
+}
+
 use k8s_openapi::api::autoscaling::v1::{HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus};
 impl Api<Object<HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus>> {
     pub fn v1HorizontalPodAutoscaler(client: APIClient) -> Self {

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -104,3 +104,14 @@ impl Api<Object<DaemonSetSpec, DaemonSetStatus>> {
         }
     }
 }
+
+use k8s_openapi::api::apps::v1::{StatefulSetSpec, StatefulSetStatus};
+impl Api<Object<StatefulSetSpec, StatefulSetStatus>> {
+    pub fn v1StatefulSet(client: APIClient) -> Self {
+        Api {
+            api: RawApi::v1Statefulset(),
+            client,
+            phantom: PhantomData,
+        }
+    }
+}

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -93,3 +93,14 @@ impl Api<Object<NamespaceSpec, NamespaceStatus>> {
         }
     }
 }
+
+use k8s_openapi::api::apps::v1::{DaemonSetSpec, DaemonSetStatus};
+impl Api<Object<DaemonSetSpec, DaemonSetStatus>> {
+    pub fn v1DaemonSet(client: APIClient) -> Self {
+        Api {
+            api: RawApi::v1DaemonSet(),
+            client,
+            phantom: PhantomData,
+        }
+    }
+}

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -138,6 +138,17 @@ impl Api<Object<PersistentVolumeClaimSpec, PersistentVolumeClaimStatus>> {
     }
 }
 
+use k8s_openapi::api::core::v1::{PersistentVolumeSpec, PersistentVolumeStatus};
+impl Api<Object<PersistentVolumeSpec, PersistentVolumeStatus>> {
+    pub fn v1PersistentVolume(client: APIClient) -> Self {
+        Api {
+            api: RawApi::v1PersistentVolume(),
+            client,
+            phantom: PhantomData,
+        }
+    }
+}
+
 use k8s_openapi::api::autoscaling::v1::{HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus};
 impl Api<Object<HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus>> {
     pub fn v1HorizontalPodAutoscaler(client: APIClient) -> Self {

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -137,3 +137,14 @@ impl Api<Object<PersistentVolumeClaimSpec, PersistentVolumeClaimStatus>> {
         }
     }
 }
+
+use k8s_openapi::api::autoscaling::v1::{HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus};
+impl Api<Object<HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus>> {
+    pub fn v1HorizontalPodAutoscaler(client: APIClient) -> Self {
+        Api {
+            api: RawApi::v1HorizontalPodAutoscaler(),
+            client,
+            phantom: PhantomData,
+        }
+    }
+}

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -126,3 +126,14 @@ impl Api<Object<ReplicaSetSpec, ReplicaSetStatus>> {
         }
     }
 }
+
+use k8s_openapi::api::core::v1::{PersistentVolumeClaimSpec, PersistentVolumeClaimStatus};
+impl Api<Object<PersistentVolumeClaimSpec, PersistentVolumeClaimStatus>> {
+    pub fn v1PersistentVolumeClaim(client: APIClient) -> Self {
+        Api {
+            api: RawApi::v1PersistenVolumeClaim(),
+            client,
+            phantom: PhantomData,
+        }
+    }
+}

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -171,7 +171,7 @@ impl Api<Object<HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus>> {
     }
 }
 
-use k8s_openapi::api::autoscaling::v1::{NetworkPolicySpec, NetworkPolicyStatus};
+use k8s_openapi::api::networking::v1::{NetworkPolicySpec, NetworkPolicyStatus};
 impl Api<Object<NetworkPolicySpec, NetworkPolicyStatus>> {
     pub fn v1NetworkPolicy(client: APIClient) -> Self {
         Api {

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -159,3 +159,14 @@ impl Api<Object<HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus>> {
         }
     }
 }
+
+use k8s_openapi::api::autoscaling::v1::{NetworkPolicySpec, NetworkPolicyStatus};
+impl Api<Object<NetworkPolicySpec, NetworkPolicyStatus>> {
+    pub fn v1NetworkPolicy(client: APIClient) -> Self {
+        Api {
+            api: RawApi::v1NetworkPolicy(),
+            client,
+            phantom: PhantomData,
+        }
+    }
+}

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -82,3 +82,14 @@ impl Api<Object<JobSpec, JobStatus>> {
         }
     }
 }
+
+use k8s_openapi::api::core::v1::{NamespaceSpec, NamespaceStatus};
+impl Api<Object<NamespaceSpec, NamespaceStatus>> {
+    pub fn v1Namespace(client: APIClient) -> Self {
+        Api {
+            api: RawApi::v1Namespace(),
+            client,
+            phantom: PhantomData,
+        }
+    }
+}

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -131,7 +131,7 @@ use k8s_openapi::api::core::v1::{PersistentVolumeClaimSpec, PersistentVolumeClai
 impl Api<Object<PersistentVolumeClaimSpec, PersistentVolumeClaimStatus>> {
     pub fn v1PersistentVolumeClaim(client: APIClient) -> Self {
         Api {
-            api: RawApi::v1PersistenVolumeClaim(),
+            api: RawApi::v1PersistentVolumeClaim(),
             client,
             phantom: PhantomData,
         }

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -115,3 +115,14 @@ impl Api<Object<StatefulSetSpec, StatefulSetStatus>> {
         }
     }
 }
+
+use k8s_openapi::api::apps::v1::{ReplicaSetSpec, ReplicaSetStatus};
+impl Api<Object<ReplicaSetSpec, ReplicaSetStatus>> {
+    pub fn v1ReplicaSet(client: APIClient) -> Self {
+        Api {
+            api: RawApi::v1ReplicaSet(),
+            client,
+            phantom: PhantomData,
+        }
+    }
+}

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -189,6 +189,17 @@ impl RawApi {
         }
     }
 
+    // Stable HorizontalPodAutoscaler resource constructor
+    pub fn v1HorizontalPodAutoscaler() -> Self {
+        Self {
+            group: "autoscaling".into(),
+            resource: "horizontalpodautoscalers".into(),
+            prefix: "apis".into(),
+            version: "v1".into(),
+            ..Default::default()
+        }
+    }
+
     /// Custom resource definition constructor
     pub fn v1beta1CustomResourceDefinition() -> Self {
         Self {

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -211,6 +211,17 @@ impl RawApi {
         }
     }
 
+    // Stable ResourceQuota resource constructor
+    pub fn v1ResourceQuota() -> Self {
+        Self {
+            group: "".into(),
+            resource: "resourcequotas".into(),
+            prefix: "api".into(),
+            version: "v1".into(),
+            ..Default::default()
+        }
+    }
+
     // Stable HorizontalPodAutoscaler resource constructor
     pub fn v1HorizontalPodAutoscaler() -> Self {
         Self {

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -178,6 +178,17 @@ impl RawApi {
         }
     }
 
+    // Stable PersistentVolumeClaim resource constructor
+    pub fn v1PersistenVolumeClaim() -> Self {
+        Self {
+            group: "".into(),
+            resource: "persistentvolumeclaims".into(),
+            prefix: "api".into(),
+            version: "v1".into(),
+            ..Default::default()
+        }
+    }
+
     /// Custom resource definition constructor
     pub fn v1beta1CustomResourceDefinition() -> Self {
         Self {

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -179,7 +179,7 @@ impl RawApi {
     }
 
     // Stable PersistentVolumeClaim resource constructor
-    pub fn v1PersistenVolumeClaim() -> Self {
+    pub fn v1PersistentVolumeClaim() -> Self {
         Self {
             group: "".into(),
             resource: "persistentvolumeclaims".into(),

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -189,6 +189,17 @@ impl RawApi {
         }
     }
 
+    // Stable PersistentVolume resource constructor
+    pub fn v1PersistentVolume() -> Self {
+        Self {
+            group: "".into(),
+            resource: "persistentvolumes".into(),
+            prefix: "api".into(),
+            version: "v1".into(),
+            ..Default::default()
+        }
+    }
+
     // Stable HorizontalPodAutoscaler resource constructor
     pub fn v1HorizontalPodAutoscaler() -> Self {
         Self {

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -200,6 +200,17 @@ impl RawApi {
         }
     }
 
+    // Stable NetworkPolicy resource constructor
+    pub fn v1NetworkPolicy() -> Self {
+        Self {
+            group: "networking.k8s.io".into(),
+            resource: "networkpolicies".into(),
+            prefix: "apis".into(),
+            version: "v1".into(),
+            ..Default::default()
+        }
+    }
+
     // Stable HorizontalPodAutoscaler resource constructor
     pub fn v1HorizontalPodAutoscaler() -> Self {
         Self {

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -1,7 +1,7 @@
 use crate::{Result, ErrorKind};
 use failure::ResultExt;
 
-/// RawRawApi generation data
+/// RawApi generation data
 ///
 /// This data defines the urls used by kubernetes' APIs.
 /// This struct is client agnostic, and can be passed to an Informer or a Reflector.


### PR DESCRIPTION
`Namespace`, `DaemonSet`, `StatefulSet` and `ReplicaSet` were already available in `RawApi`, hence it's a quick job to expose them in `openapi`.

I have added `HorizontalPodAutoscaler`, `PersistentVolume`, `PersistentVolumeClaim`, `ResourceQuota` and `NetworkPolicy` to both `RawApi` and `openapi`.