### PR TITLE
config: add support for loading multiple CAs

### DIFF
--- a/src/config/kube_config.rs
+++ b/src/config/kube_config.rs
@@ -74,4 +74,9 @@ impl KubeConfigLoader {
         let ca = self.cluster.load_certificate_authority().ok()?;
         Some(X509::from_pem(&ca).map_err(|_| Error::from(ErrorKind::SslError)))
     }
+
+    pub fn ca_bundle(&self) -> Option<Result<Vec<X509>>> {
+        let bundle = self.cluster.load_certificate_authority().ok()?;
+        Some(X509::stack_from_pem(&bundle).map_err(|_| Error::from(ErrorKind::SslError)))
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -83,10 +83,12 @@ pub fn load_kube_config_with(options: ConfigOptions) -> Result<Configuration> {
 
     let mut client_builder = Client::builder();
 
-    if let Some(ca) = loader.ca() {
-        let req_ca = Certificate::from_der(&ca?.to_der().context(ErrorKind::SslError)?)
-            .context(ErrorKind::SslError)?;
-        client_builder = client_builder.add_root_certificate(req_ca);
+    if let Some(bundle) = loader.ca_bundle() {
+        for ca in bundle? {
+            let cert = Certificate::from_der(&ca.to_der().context(ErrorKind::SslError)?)
+                .context(ErrorKind::SslError)?;
+            client_builder = client_builder.add_root_certificate(cert);
+        }
     }
     match loader.p12(" ") {
         Ok(p12) => {


### PR DESCRIPTION
OpenShift uses more than one CA in its kubeconfigs. Without this change,
the client will get errors like "self signed certificate in certificate
chain".