### PR TITLE
Bug/credentials id token

### DIFF
--- a/src/config/apis.rs
+++ b/src/config/apis.rs
@@ -155,7 +155,8 @@ impl AuthInfo {
     pub(crate) fn load_gcp(&mut self) -> Result<bool> {
         match &self.auth_provider {
             Some(provider) => {
-                self.token = Some(provider.config["access-token"].clone());
+                if let Some(access_token) = provider.config.get("access-token") {
+                    self.token = Some(access_token.clone());
                 if utils::is_expired(&provider.config["expiry"]) {
                     let client = oauth2::CredentialsClient::new()?;
                     let token = client.request_token(&vec![
@@ -163,6 +164,7 @@ impl AuthInfo {
                     ])?;
                     self.token = Some(token.access_token);
                 }
+            }
             }
             None => {}
         };

--- a/src/config/apis.rs
+++ b/src/config/apis.rs
@@ -157,14 +157,17 @@ impl AuthInfo {
             Some(provider) => {
                 if let Some(access_token) = provider.config.get("access-token") {
                     self.token = Some(access_token.clone());
-                if utils::is_expired(&provider.config["expiry"]) {
-                    let client = oauth2::CredentialsClient::new()?;
-                    let token = client.request_token(&vec![
-                        "https://www.googleapis.com/auth/cloud-platform".to_string(),
-                    ])?;
-                    self.token = Some(token.access_token);
+                    if utils::is_expired(&provider.config["expiry"]) {
+                        let client = oauth2::CredentialsClient::new()?;
+                        let token = client.request_token(&vec![
+                            "https://www.googleapis.com/auth/cloud-platform".to_string(),
+                        ])?;
+                        self.token = Some(token.access_token);
+                    }
                 }
-            }
+                if let Some(id_token) = provider.config.get("id-token") {
+                    self.token = Some(id_token.clone());
+                }
             }
             None => {}
         };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -65,9 +65,8 @@ pub struct ConfigOptions {
 ///     .expect("failed to load kubeconfig");
 /// ```
 pub fn load_kube_config_with(options: ConfigOptions) -> Result<Configuration> {
-    let kubeconfig = utils::kubeconfig_path()
-        .or_else(utils::default_kube_path)
-        .ok_or_else(|| ErrorKind::KubeConfig("Unable to load file".into()))?;
+    let kubeconfig = utils::find_kubeconfig()
+        .context(ErrorKind::KubeConfig("Unable to load file".into()))?;
 
     let loader =
         KubeConfigLoader::load(kubeconfig, options.context, options.cluster, options.user)?;


### PR DESCRIPTION
Our environment use OpenIDConnect (oidc) to setup some access to k8s (bare-metal).
Existing code failed because we have `auth-provider` but no `access-token` and certificate use relative inside the .kube/config.

This fix allow:
- use relative path for certificate
- use `id-token` if present
- not crash if `auth-provider` is present but `access-token` is absent

Current, auto-refresh of expired id-token is not supported 