### PR TITLE
Allow creating custom clients

### DIFF
--- a/src/config/kube_config.rs
+++ b/src/config/kube_config.rs
@@ -9,7 +9,7 @@ use crate::{Result, Error, ErrorKind};
 use crate::config::apis::{AuthInfo, Cluster, Config, Context};
 
 /// KubeConfigLoader loads current context, cluster, and authentication information.
-#[derive(Debug)]
+#[derive(Clone,Debug)]
 pub struct KubeConfigLoader {
     pub current_context: Context,
     pub cluster: Cluster,


### PR DESCRIPTION
This PR allows to re-use the existing logic of setting up a reqwest client, for custom purposes.

The intended use case is that you want to re-use the config loader logic, but want to further work with the client builder, adding your own options.