### PR TITLE
Added `iter` methods to `ObjectList`

### DIFF
--- a/examples/pod_openapi.rs
+++ b/examples/pod_openapi.rs
@@ -1,9 +1,10 @@
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 use serde_json::json;
 
 use kube::{
-    api::{Api, PostParams, DeleteParams, ListParams, PatchParams},
-    client::{APIClient},
+    api::{Api, DeleteParams, ListParams, PatchParams, PostParams},
+    client::APIClient,
     config,
 };
 
@@ -38,9 +39,9 @@ async fn main() -> anyhow::Result<()> {
             info!("Created {}", o.metadata.name);
             // wait for it..
             std::thread::sleep(std::time::Duration::from_millis(5_000));
-        },
+        }
         Err(kube::Error::Api(ae)) => assert_eq!(ae.code, 409), // if you skipped delete, for instance
-        Err(e) =>return Err(e.into()), // any other case is probably bad
+        Err(e) => return Err(e.into()),                        // any other case is probably bad
     }
 
     // Verify we can get it
@@ -60,10 +61,12 @@ async fn main() -> anyhow::Result<()> {
         }
     });
     let patch_params = PatchParams::default();
-    let p_patched = pods.patch("blog", &patch_params, serde_json::to_vec(&patch)?).await?;
+    let p_patched = pods
+        .patch("blog", &patch_params, serde_json::to_vec(&patch)?)
+        .await?;
     assert_eq!(p_patched.spec.active_deadline_seconds, Some(5));
 
-    for p in pods.list(&ListParams::default()).await?.items {
+    for p in pods.list(&ListParams::default()).await? {
         println!("Got Pod: {}", p.metadata.name);
     }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,20 +8,12 @@ mod reflector;
 pub use self::reflector::Reflector;
 
 mod informer;
-pub use self::informer::{
-    Informer,
-};
+pub use self::informer::Informer;
 
 mod raw;
 pub use raw::{
+    DeleteParams, ListParams, LogParams, PatchParams, PatchStrategy, PostParams, PropagationPolicy,
     RawApi,
-    ListParams,
-    PostParams,
-    PatchParams,
-    DeleteParams,
-    PropagationPolicy,
-    PatchStrategy,
-    LogParams
 };
 
 mod typed;
@@ -34,24 +26,14 @@ pub use typed::{
 };
 
 mod resource;
-pub use self::resource::{
-    Object,
-    ObjectList,
-    WatchEvent,
-    KubeObject,
-};
+pub use self::resource::{KubeObject, Object, ObjectList, WatchEvent};
 
 #[cfg(feature = "openapi")]
 mod openapi;
 #[cfg(feature = "openapi")]
 mod snowflake;
 #[cfg(feature = "openapi")]
-pub use snowflake::{v1Event, v1Secret, v1ConfigMap};
+pub use snowflake::{v1ConfigMap, v1Event, v1Secret};
 
 mod metadata;
-pub use self::metadata::{
-    ObjectMeta,
-    TypeMeta,
-    Initializers,
-    OwnerReference,
-};
+pub use self::metadata::{Initializers, ListMeta, ObjectMeta, OwnerReference, TypeMeta};

--- a/src/api/resource.rs
+++ b/src/api/resource.rs
@@ -152,8 +152,9 @@ impl<T: Clone> ObjectList<T> {
     /// // Reassign the value in first
     /// if let Some(elem) = first {
     ///     *elem = 2;
+    ///     println!("First element: {:?}", elem); // prints "First element: 2"
     /// }
-    /// println!("First element: {:?}", first); // prints "First element: Some(2)"
+
     pub fn iter_mut<'a>(&'a mut self) -> impl Iterator<Item = &mut T> + 'a {
         self.items.iter_mut()
     }

--- a/src/api/resource.rs
+++ b/src/api/resource.rs
@@ -123,8 +123,7 @@ impl<T: Clone> ObjectList<T> {
     /// # Example
     ///
     /// ```
-    /// use kube::api::metadata::ListMeta;
-    /// use kube::api::resouce::ObjectList;
+    /// use kube::api::{ListMeta, ObjectList};
     ///
     /// let metadata: ListMeta = Default::default();
     /// let items = vec![1, 2, 3];
@@ -142,8 +141,7 @@ impl<T: Clone> ObjectList<T> {
     /// # Example
     ///     
     /// ```
-    /// use kube::api::metadata::ListMeta;
-    /// use kube::api::resouce::ObjectList;
+    /// use kube::api::{ObjectList, ListMeta};
     ///
     /// let metadata: ListMeta = Default::default();
     /// let items = vec![1, 2, 3];


### PR DESCRIPTION
Added `iter` and `iter_mut` methods to `ObjectList` to provide Iterators, as well as implementations of `IntoIterator` for `ObjectList`, `&ObjectList` and `&mut ObjectList`

#41 