### PR TITLE
WIP threaded poll fix

### DIFF
--- a/src/api/reflector.rs
+++ b/src/api/reflector.rs
@@ -34,7 +34,7 @@ where
 
 impl<K> Reflector<K>
 where
-    K: Clone + DeserializeOwned,
+    K: Clone + DeserializeOwned + Send,
 {
     /// Create a reflector with a kube client on a kube resource
     pub fn new(r: Api<K>) -> Self {
@@ -50,7 +50,7 @@ where
 
 impl<K> Reflector<K>
 where
-    K: Clone + DeserializeOwned + KubeObject,
+    K: Clone + DeserializeOwned + KubeObject + Send,
 {
     /// Create a reflector with a kube client on a kube resource
     pub fn raw(client: APIClient, r: RawApi) -> Self {

--- a/src/api/resource.rs
+++ b/src/api/resource.rs
@@ -58,8 +58,8 @@ where
 #[derive(Deserialize, Serialize, Clone)]
 pub struct Object<P, U>
 where
-    P: Clone,
-    U: Clone,
+    P: Clone + Send,
+    U: Clone + Send,
 {
     #[serde(flatten)]
     pub types: TypeMeta,
@@ -86,8 +86,8 @@ where
 /// Blanked implementation for standard objects that can use Object
 impl<P, U> KubeObject for Object<P, U>
 where
-    P: Clone,
-    U: Clone,
+    P: Clone + Send,
+    U: Clone + Send,
 {
     fn meta(&self) -> &ObjectMeta {
         &self.metadata
@@ -139,7 +139,7 @@ impl<T: Clone> ObjectList<T> {
     /// `iter_mut` returns an Iterator of mutable references to the elements of this ObjectList
     ///
     /// # Example
-    ///     
+    ///
     /// ```
     /// use kube::api::{ObjectList, ListMeta};
     ///

--- a/src/api/resource.rs
+++ b/src/api/resource.rs
@@ -19,7 +19,7 @@ pub trait KubeObject {
 #[serde(tag = "type", content = "object", rename_all = "UPPERCASE")]
 pub enum WatchEvent<K>
 where
-    K: Clone + KubeObject,
+    K: Clone + KubeObject + Send,
 {
     Added(K),
     Modified(K),
@@ -29,7 +29,7 @@ where
 
 impl<K> Debug for WatchEvent<K>
 where
-    K: Clone + KubeObject,
+    K: Clone + KubeObject + Send,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match &self {


### PR DESCRIPTION
Trying to fix #97. :warning: : Not compiling yet.

Tried propagating `BoxStream` and the corresponding `Send` requirement on `K` it forced (this is reasonable because a kube object is always just raw data, no refcounts or other magic - but we might have to propagate it to k8s-openapi).

I think it got almost all the way there, but now it complains at informer in `poll()`. It wants `K` to implement `Sync` as well, and that certainly is unreasonable. But it seems to come from `Send` being required on `&K` not being satisfied, looks like in a closure?

```

error[E0277]: `K` cannot be shared between threads safely
   --> src/api/informer.rs:204:20
    |
204 |                 }).boxed())
    |                    ^^^^^ `K` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `K`
    = help: consider adding a `where K: std::marker::Sync` bound
    = note: required because of the requirements on the impl of `std::marker::Send` for `&K`
    = note: required because it appears within the type `for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7> {std::result::Result<api::resource::WatchEvent<K>, Error>, K, K, K, &'r K, K, api::metadata::ObjectMeta, &'s api::metadata::ObjectMeta, &'t0 std::option::Option<std::string::String>, std::option::Option<std::string::String>, std::option::Option<std::string::String>, std::string::String, &'t1 std::string::String, std::string::String, std::string::String, &'t2 futures_util::lock::mutex::Mutex<std::string::String>, std::sync::Arc<futures_util::lock::mutex::Mutex<std::string::String>>, futures_util::lock::mutex::MutexLockFuture<'t3, std::string::String>, futures_util::lock::mutex::MutexLockFuture<'t4, std::string::String>, (), ErrorResponse, bool, bool, bool, &'t5 futures_util::lock::mutex::Mutex<bool>, std::sync::Arc<futures_util::lock::mutex::Mutex<bool>>, futures_util::lock::mutex::MutexLockFuture<'t6, bool>, futures_util::lock::mutex::MutexLockFuture<'t7, bool>, ()}`
    = note: required because it appears within the type `[static generator@src/api/informer.rs:179:32: 203:22 event:std::result::Result<api::resource::WatchEvent<K>, Error>, version:std::sync::Arc<futures_util::lock::mutex::Mutex<std::string::String>>, needs_resync:std::sync::Arc<futures_util::lock::mutex::Mutex<bool>> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7> {std::result::Result<api::resource::WatchEvent<K>, Error>, K, K, K, &'r K, K, api::metadata::ObjectMeta, &'s api::metadata::ObjectMeta, &'t0 std::option::Option<std::string::String>, std::option::Option<std::string::String>, std::option::Option<std::string::String>, std::string::String, &'t1 std::string::String, std::string::String, std::string::String, &'t2 futures_util::lock::mutex::Mutex<std::string::String>, std::sync::Arc<futures_util::lock::mutex::Mutex<std::string::String>>, futures_util::lock::mutex::MutexLockFuture<'t3, std::string::String>, futures_util::lock::mutex::MutexLockFuture<'t4, std::string::String>, (), ErrorResponse, bool, bool, bool, &'t5 futures_util::lock::mutex::Mutex<bool>, std::sync::Arc<futures_util::lock::mutex::Mutex<bool>>, futures_util::lock::mutex::MutexLockFuture<'t6, bool>, futures_util::lock::mutex::MutexLockFuture<'t7, bool>, ()}]`
    = note: required because it appears within the type `std::future::GenFuture<[static generator@src/api/informer.rs:179:32: 203:22 event:std::result::Result<api::resource::WatchEvent<K>, Error>, version:std::sync::Arc<futures_util::lock::mutex::Mutex<std::string::String>>, needs_resync:std::sync::Arc<futures_util::lock::mutex::Mutex<bool>> for<'r, 's, 't0, 't1, 't2, 't3, 't4, 't5, 't6, 't7> {std::result::Result<api::resource::WatchEvent<K>, Error>, K, K, K, &'r K, K, api::metadata::ObjectMeta, &'s api::metadata::ObjectMeta, &'t0 std::option::Option<std::string::String>, std::option::Option<std::string::String>, std::option::Option<std::string::String>, std::string::String, &'t1 std::string::String, std::string::String, std::string::String, &'t2 futures_util::lock::mutex::Mutex<std::string::String>, std::sync::Arc<futures_util::lock::mutex::Mutex<std::string::String>>, futures_util::lock::mutex::MutexLockFuture<'t3, std::string::String>, futures_util::lock::mutex::MutexLockFuture<'t4, std::string::String>, (), ErrorResponse, bool, bool, bool, &'t5 futures_util::lock::mutex::Mutex<bool>, std::sync::Arc<futures_util::lock::mutex::Mutex<bool>>, futures_util::lock::mutex::MutexLockFuture<'t6, bool>, futures_util::lock::mutex::MutexLockFuture<'t7, bool>, ()}]>`
    = note: required because it appears within the type `impl core::future::future::Future`
    = note: required because it appears within the type `std::option::Option<impl core::future::future::Future>`
    = note: required because it appears within the type `futures_util::stream::stream::then::Then<std::pin::Pin<std::boxed::Box<dyn futures_core::stream::Stream<Item = std::result::Result<api::resource::WatchEvent<K>, Error>> + std::marker::Send>>, impl core::future::future::Future, [closure@src/api/informer.rs:175:32: 204:18 needs_resync:std::sync::Arc<futures_util::lock::mutex::Mutex<bool>>, version:std::sync::Arc<futures_util::lock::mutex::Mutex<std::string::String>>]>`

error: aborting due to previous error
```