### PR TITLE
Fix stream not being `Send`

### DIFF
--- a/src/api/reflector.rs
+++ b/src/api/reflector.rs
@@ -23,7 +23,7 @@ type Cache<K> = BTreeMap<ObjectId, K>;
 #[derive(Clone)]
 pub struct Reflector<K>
 where
-    K: Clone + DeserializeOwned,
+    K: Clone + DeserializeOwned + Send,
 {
     data: Arc<Mutex<Cache<K>>>,
     version: Arc<Mutex<String>>,
@@ -34,7 +34,7 @@ where
 
 impl<K> Reflector<K>
 where
-    K: Clone + DeserializeOwned,
+    K: Clone + DeserializeOwned + Send,
 {
     /// Create a reflector with a kube client on a kube resource
     pub fn new(r: Api<K>) -> Self {
@@ -50,7 +50,7 @@ where
 
 impl<K> Reflector<K>
 where
-    K: Clone + DeserializeOwned + KubeObject,
+    K: Clone + DeserializeOwned + KubeObject + Send,
 {
     /// Create a reflector with a kube client on a kube resource
     pub fn raw(client: APIClient, r: RawApi) -> Self {
@@ -207,7 +207,7 @@ where
             .client
             .request_events::<WatchEvent<K>>(req)
             .await?
-            .boxed_local(); // We use boxed_local to remove the Send requirement as we're not shipping this between threads
+            .boxed(); // We use boxed_local to remove the Send requirement as we're not shipping this between threads
 
         // Update in place:
         let mut data = self.data.lock().await;


### PR DESCRIPTION
#97 

Looks like the culprit here was the `boxed_local` in the reflect, which ironically was added to prevent an explicit `Send` dependency haha. Switching that to plain old `boxed` and then adding some `Send` requirements in the `WatchEvent` seems to have done the trick. I've updated the `node_reflector` example to poll in a different task to help cover this test case. 

Also cursorily looking over the `openapi` generated repo, all that should be `Send`, so I don't think we'll need to upstream any changes