### PR TITLE
Added a ? so that getting pod logs works

### DIFF
--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -713,7 +713,7 @@ impl RawApi {
 impl RawApi {
     /// Get a pod logs
     pub fn log(&self, name: &str, lp: &LogParams) -> Result<http::Request<Vec<u8>>> {
-        let base_url = self.make_url() + "/" + name + "/" + "log";
+        let base_url = self.make_url() + "/" + name + "/" + "log?";
         let mut qp = url::form_urlencoded::Serializer::new(base_url);
 
         if let Some(container) = &lp.container {


### PR DESCRIPTION
I noticed that getting the pod logs doesn't work and that seems to be because there is no ? at the end of the log url.

So I added one.