### PR TITLE
First pass at async logging 

### DIFF
--- a/examples/log_follow.rs
+++ b/examples/log_follow.rs
@@ -1,0 +1,36 @@
+#[macro_use] extern crate log;
+use kube::{
+    api::{Api, LogParams},
+    client::APIClient,
+    config,
+};
+use anyhow::{Result, anyhow};
+use std::env;
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    std::env::set_var("RUST_LOG", "info,kube=trace");
+    env_logger::init();
+    let config = config::load_kube_config().await?;
+    let client = APIClient::new(config);
+    let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
+
+    let mypod = env::args().nth(1).ok_or_else(|| {
+        anyhow!("Usage: log_follow <pod>")
+    })?;
+    
+    info!("My pod is {:?}", mypod);
+    
+    let pods = Api::v1Pod(client).within(&namespace);
+    let mut lp = LogParams::default();
+    lp.follow = true;
+    lp.tail_lines = Some(1);
+    let mut logs = pods.log_follow(&mypod, &lp).await?.boxed();
+    
+    while let Some(line) = logs.next().await {
+        let l = line.unwrap();
+        println!("{:?}", String::from_utf8_lossy(&l));
+    } 
+    Ok(())
+}

--- a/src/api/typed.rs
+++ b/src/api/typed.rs
@@ -120,6 +120,11 @@ where
         let req = self.api.log(name, lp)?;
         Ok(self.client.request_text(req).await?)
     }
+
+    pub async fn log_follow(&self, name: &str, lp: &LogParams) -> Result<impl Stream<Item = Result<Vec<u8>>>> {
+        let req = self.api.log(name, lp)?;
+        Ok(self.client.request_text_stream(req).await?)
+    }
 }
 
 /// Scale spec from api::autoscaling::v1

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -115,6 +115,56 @@ impl APIClient {
         Ok(text)
     }
 
+    pub async fn request_text_stream(
+        &self,
+        request: http::Request<Vec<u8>>,
+    ) -> Result<impl Stream<Item = Result<Vec<u8>>>>
+    {
+        let res: reqwest::Response = self.send(request).await?;
+        trace!("{} {}", res.status().as_str(), res.url());
+
+        // Now use `unfold` to convert the chunked responses into a Stream
+        // We first construct a Stream of Vec<u8> as we potentially might need to
+        // yield multiple objects per loop, then we flatten it to the Stream<Result<u8>> as expected.
+        // Any reqwest errors will terminate this stream early.
+        let stream = futures::stream::unfold((res, Vec::new()), |(mut resp, mut buff)| {
+            async {
+                loop {
+                    match resp.chunk().await {
+                        Ok(Some(chunk)) => {
+                            buff.extend_from_slice(&chunk);
+
+                            if chunk.contains(&b'\n') {
+                                let mut new_buff = Vec::new();
+                                let mut items = Vec::new();
+
+                                // Split on newlines
+                                // new buff is container for items
+                                for line in buff.split(|x| x == &b'\n') {
+                                    if line.is_empty() {
+                                        continue
+                                    }
+                                    new_buff.extend_from_slice(&line);
+                                }
+                                items.push(Ok(new_buff.clone()));
+                                new_buff.clear();
+                                // Now return our items and loop
+                                return Some((items, (resp, new_buff)));
+                            }
+                        }
+                        Ok(None) => return None,
+                        Err(e) => {
+                            let err = vec![Err(Error::ReqwestError(e))];
+                            return Some((err, (resp, buff)));
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(stream.map(futures::stream::iter).flatten())
+    }
+
     pub async fn request_status<T>(
         &self,
         request: http::Request<Vec<u8>>,


### PR DESCRIPTION
I think cargo fmt may have ran on that one file 👀 i can get rid of that formatting 

A few questions I have.
- Did not see any contributor rules or anything to follow, let me know what needs to be changed, etc.
- I did not know if you wanted me to standardize on using a Stream of String, or a Stream of Vec<u8>, im used to streaming bytes, so thats the implementation I went with 
- I extended the trait with a log_follows method.  Open to change the name
- I do not do any checking of the LogParams options.  I probably should add some defensive programming around that, and probably will do so after some input from the maintainers
- I ran this fork on my open source project(https://github.com/ericmcbride/wufei), and ran 140 pods async for 3 hours, and it never crashed or cut off