### PR TITLE
First pass at async log streaming

### DIFF
--- a/examples/log_follow.rs
+++ b/examples/log_follow.rs
@@ -19,18 +19,17 @@ async fn main() -> Result<()> {
     let mypod = env::args().nth(1).ok_or_else(|| {
         anyhow!("Usage: log_follow <pod>")
     })?;
-    
+
     info!("My pod is {:?}", mypod);
-    
+
     let pods = Api::v1Pod(client).within(&namespace);
     let mut lp = LogParams::default();
-    lp.follow = true;
     lp.tail_lines = Some(1);
     let mut logs = pods.log_follow(&mypod, &lp).await?.boxed();
-    
+
     while let Some(line) = logs.next().await {
         let l = line.unwrap();
         println!("{:?}", String::from_utf8_lossy(&l));
-    } 
+    }
     Ok(())
 }

--- a/examples/log_follow.rs
+++ b/examples/log_follow.rs
@@ -1,0 +1,36 @@
+#[macro_use] extern crate log;
+use kube::{
+    api::{Api, LogParams},
+    client::APIClient,
+    config,
+};
+use anyhow::{Result, anyhow};
+use std::env;
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    std::env::set_var("RUST_LOG", "info,kube=trace");
+    env_logger::init();
+    let config = config::load_kube_config().await?;
+    let client = APIClient::new(config);
+    let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
+
+    let mypod = env::args().nth(1).ok_or_else(|| {
+        anyhow!("Usage: log_follow <pod>")
+    })?;
+    
+    info!("My pod is {:?}", mypod);
+    
+    let pods = Api::v1Pod(client).within(&namespace);
+    let mut lp = LogParams::default();
+    lp.follow = true;
+    lp.tail_lines = Some(1);
+    let mut logs = pods.log_follow(&mypod, &lp).await?.boxed();
+    
+    while let Some(line) = logs.next().await {
+        let l = line.unwrap();
+        println!("{:?}", String::from_utf8_lossy(&l));
+    } 
+    Ok(())
+}

--- a/examples/log_stream.rs
+++ b/examples/log_stream.rs
@@ -24,8 +24,9 @@ async fn main() -> Result<()> {
 
     let pods = Api::v1Pod(client).within(&namespace);
     let mut lp = LogParams::default();
+    lp.follow = true;
     lp.tail_lines = Some(1);
-    let mut logs = pods.log_follow(&mypod, &lp).await?.boxed();
+    let mut logs = pods.log_stream(&mypod, &lp).await?.boxed();
 
     while let Some(line) = logs.next().await {
         let l = line.unwrap();

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -544,6 +544,8 @@ pub enum PropagationPolicy {
 pub struct LogParams {
     /// The container for which to stream logs. Defaults to only container if there is one container in the pod.
     pub container: Option<String>,
+    /// Follow the log stream of the pod. Defaults to false.
+    pub follow: bool,
     /// If set, the number of bytes to read from the server before terminating the log output.
     /// This may not display a complete final line of logging, and may return slightly more or slightly less than the specified limit.
     pub limit_bytes: Option<i64>,
@@ -816,7 +818,7 @@ impl RawApi {
 
 impl RawApi {
     /// Get a pod logs
-    pub fn log(&self, name: &str, lp: &LogParams, follow: bool) -> Result<http::Request<Vec<u8>>> {
+    pub fn log(&self, name: &str, lp: &LogParams) -> Result<http::Request<Vec<u8>>> {
         let base_url = self.make_url() + "/" + name + "/" + "log?";
         let mut qp = url::form_urlencoded::Serializer::new(base_url);
 
@@ -824,7 +826,7 @@ impl RawApi {
             qp.append_pair("container", &container);
         }
 
-        if follow {
+        if lp.follow {
             qp.append_pair("follow", "true");
         }
 

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -544,8 +544,6 @@ pub enum PropagationPolicy {
 pub struct LogParams {
     /// The container for which to stream logs. Defaults to only container if there is one container in the pod.
     pub container: Option<String>,
-    /// Follow the log stream of the pod. Defaults to false.
-    pub follow: bool,
     /// If set, the number of bytes to read from the server before terminating the log output.
     /// This may not display a complete final line of logging, and may return slightly more or slightly less than the specified limit.
     pub limit_bytes: Option<i64>,
@@ -818,7 +816,7 @@ impl RawApi {
 
 impl RawApi {
     /// Get a pod logs
-    pub fn log(&self, name: &str, lp: &LogParams) -> Result<http::Request<Vec<u8>>> {
+    pub fn log(&self, name: &str, lp: &LogParams, follow: bool) -> Result<http::Request<Vec<u8>>> {
         let base_url = self.make_url() + "/" + name + "/" + "log?";
         let mut qp = url::form_urlencoded::Serializer::new(base_url);
 
@@ -826,7 +824,7 @@ impl RawApi {
             qp.append_pair("container", &container);
         }
 
-        if lp.follow {
+        if follow {
             qp.append_pair("follow", "true");
         }
 

--- a/src/api/typed.rs
+++ b/src/api/typed.rs
@@ -117,12 +117,12 @@ where
     K: Clone + DeserializeOwned + KubeObject + LoggingObject,
 {
     pub async fn log(&self, name: &str, lp: &LogParams) -> Result<String> {
-        let req = self.api.log(name, lp)?;
+        let req = self.api.log(name, lp, false)?;
         Ok(self.client.request_text(req).await?)
     }
 
     pub async fn log_follow(&self, name: &str, lp: &LogParams) -> Result<impl Stream<Item = Result<Vec<u8>>>> {
-        let req = self.api.log(name, lp)?;
+        let req = self.api.log(name, lp, true)?;
         Ok(self.client.request_text_stream(req).await?)
     }
 }

--- a/src/api/typed.rs
+++ b/src/api/typed.rs
@@ -120,6 +120,11 @@ where
         let req = self.api.log(name, lp)?;
         Ok(self.client.request_text(req).await?)
     }
+
+    pub async fn log_follow(&self, name: &str, lp: &LogParams) -> Result<impl Stream<Item = Result<Vec<u8>>>> {
+        let req = self.api.log(name, lp)?;
+        Ok(self.client.request_text_stream(req).await?)
+    }
 }
 
 /// Scale spec from api::autoscaling::v1

--- a/src/api/typed.rs
+++ b/src/api/typed.rs
@@ -117,12 +117,12 @@ where
     K: Clone + DeserializeOwned + KubeObject + LoggingObject,
 {
     pub async fn log(&self, name: &str, lp: &LogParams) -> Result<String> {
-        let req = self.api.log(name, lp, false)?;
+        let req = self.api.log(name, lp)?;
         Ok(self.client.request_text(req).await?)
     }
 
-    pub async fn log_follow(&self, name: &str, lp: &LogParams) -> Result<impl Stream<Item = Result<Vec<u8>>>> {
-        let req = self.api.log(name, lp, true)?;
+    pub async fn log_stream(&self, name: &str, lp: &LogParams) -> Result<impl Stream<Item = Result<Vec<u8>>>> {
+        let req = self.api.log(name, lp)?;
         Ok(self.client.request_text_stream(req).await?)
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -154,8 +154,12 @@ impl APIClient {
                         }
                         Ok(None) => return None,
                         Err(e) => {
-                            let err = vec![Err(Error::ReqwestError(e))];
-                            return Some((err, (resp, buff)));
+                            warn!(
+                                "Failed to parse chunk, {}",
+                                &e,
+                            );
+                            buff.clear();
+                            return Some((Vec::new(), (resp, buff)));
                         }
                     }
                 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -115,6 +115,56 @@ impl APIClient {
         Ok(text)
     }
 
+    pub async fn request_text_stream(
+        &self,
+        request: http::Request<Vec<u8>>,
+    ) -> Result<impl Stream<Item = Result<Vec<u8>>>>
+    {
+        let res: reqwest::Response = self.send(request).await?;
+        trace!("{} {}", res.status().as_str(), res.url());
+
+        // Now use `unfold` to convert the chunked responses into a Stream
+        // We first construct a Stream of Vec<u8> as we potentially might need to
+        // yield multiple objects per loop, then we flatten it to the Stream<Result<u8>> as expected.
+        // Any reqwest errors will terminate this stream early.
+        let stream = futures::stream::unfold((res, Vec::new()), |(mut resp, mut buff)| {
+            async {
+                loop {
+                    match resp.chunk().await {
+                        Ok(Some(chunk)) => {
+                            buff.extend_from_slice(&chunk);
+
+                            if chunk.contains(&b'\n') {
+                                let mut new_buff = Vec::new();
+                                let mut items = Vec::new();
+
+                                // Split on newlines
+                                // new buff is container for items
+                                for line in buff.split(|x| x == &b'\n') {
+                                    if line.is_empty() {
+                                        continue
+                                    }
+                                    new_buff.extend_from_slice(&line);
+                                }
+                                items.push(Ok(new_buff.clone()));
+                                new_buff.clear();
+                                // Now return our items and loop
+                                return Some((items, (resp, new_buff)));
+                            }
+                        }
+                        Ok(None) => return None,
+                        Err(e) => {
+                            let err = vec![Err(Error::ReqwestError(e))];
+                            return Some((err, (resp, buff)));
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(stream.map(futures::stream::iter).flatten())
+    }
+
     pub async fn request_status<T>(
         &self,
         request: http::Request<Vec<u8>>,


### PR DESCRIPTION
I think cargo fmt may have ran on that one file 👀 i can get rid of that formatting
Addresses https://github.com/clux/kube-rs/issues/109

A few questions I have.
- Did not see any contributor rules or anything to follow, let me know what needs to be changed, etc.
- I did not know if you wanted me to standardize on using a Stream of String, or a Stream of Vec<u8>, im used to streaming bytes, so thats the implementation I went with
- I extended the trait with a log_follows method. Open to change the name
- I do not do any checking of the LogParams options. I probably should add some defensive programming around that, and probably will do so after some input from the maintainers
- I ran this fork on my open source project(https://github.com/ericmcbride/wufei), and ran 140 pods async for 3 hours, and it never crashed or cut off
