### PR TITLE
Subresources + openapi refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.26.0 / 2020-02-XX
 ===================
   * Exposed `Config::read` and `Config::read_from` - #124
+  * Fix typo on `Api::StatefulSet`
 
 0.25.0 / 2020-02-09
 ===================

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -208,7 +208,7 @@ async fn main() -> anyhow::Result<()> {
     let req = foos.delete_collection(&lp)?;
     match client.request_status::<ObjectList<Foo>>(req).await? {
         Left(res) => {
-            let deleted = res.items.into_iter().map(|i| i.metadata.name).collect::<Vec<_>>();
+            let deleted = res.into_iter().map(|i| i.metadata.name).collect::<Vec<_>>();
             info!("Deleted collection of foos: {:?}", deleted);
         }
         Right(status) => info!("Deleted collection: {:?}", status),

--- a/examples/crd_openapi.rs
+++ b/examples/crd_openapi.rs
@@ -222,11 +222,7 @@ async fn main() -> anyhow::Result<()> {
     // Cleanup the full collection - expect a wait
     match foos.delete_collection(&lp).await? {
         Left(list) => {
-            let deleted = list
-                .items
-                .into_iter()
-                .map(|i| i.metadata.name)
-                .collect::<Vec<_>>();
+            let deleted = list.into_iter().map(|i| i.metadata.name).collect::<Vec<_>>();
             info!("Deleted collection of foos: {:?}", deleted);
         }
         Right(status) => {

--- a/examples/node_informer.rs
+++ b/examples/node_informer.rs
@@ -65,7 +65,7 @@ async fn handle_nodes(events: &Api<Event>, ne: WatchEvent<Node>) -> anyhow::Resu
                     ..Default::default()
                 };
                 let evlist = events.list(&opts).await?;
-                for e in evlist.items {
+                for e in evlist {
                     warn!("Node event: {:?}", serde_json::to_string_pretty(&e)?);
                 }
             } else {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -11,12 +11,13 @@ mod informer;
 pub use self::informer::Informer;
 
 mod raw;
-pub use raw::{
-    DeleteParams, ListParams, LogParams, PatchParams, PatchStrategy, PostParams, PropagationPolicy, RawApi,
-};
+pub use raw::{DeleteParams, ListParams, PatchParams, PatchStrategy, PostParams, PropagationPolicy, RawApi};
 
 mod typed;
-pub use typed::{Api, Scale, ScaleSpec, ScaleStatus};
+pub use typed::Api;
+
+mod subresource;
+pub use subresource::{LogParams, Scale, ScaleSpec, ScaleStatus};
 
 mod resource;
 pub use self::resource::{KubeObject, Object, ObjectList, WatchEvent};

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -19,7 +19,7 @@ macro_rules! api_ctor {
                 }
             }
         }
-    }
+    };
 }
 
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1::{
@@ -76,10 +76,18 @@ impl LoggingObject for Object<ReplicaSetSpec, ReplicaSetStatus> {}
 impl LoggingObject for Object<ReplicaSetSpec, Void> {}
 
 use k8s_openapi::api::core::v1::{ReplicationControllerSpec, ReplicationControllerStatus};
-api_ctor!(v1ReplicationController, ReplicationControllerSpec, ReplicationControllerStatus);
+api_ctor!(
+    v1ReplicationController,
+    ReplicationControllerSpec,
+    ReplicationControllerStatus
+);
 
 use k8s_openapi::api::core::v1::{PersistentVolumeClaimSpec, PersistentVolumeClaimStatus};
-api_ctor!(v1PersistentVolumeClaim, PersistentVolumeClaimSpec, PersistentVolumeClaimStatus);
+api_ctor!(
+    v1PersistentVolumeClaim,
+    PersistentVolumeClaimSpec,
+    PersistentVolumeClaimStatus
+);
 
 use k8s_openapi::api::core::v1::{PersistentVolumeSpec, PersistentVolumeStatus};
 api_ctor!(v1PersistentVolume, PersistentVolumeSpec, PersistentVolumeStatus);
@@ -94,10 +102,18 @@ use k8s_openapi::api::networking::v1::NetworkPolicySpec;
 api_ctor!(v1NetworkPolicy, NetworkPolicySpec, Void); // has no Status
 
 use k8s_openapi::api::autoscaling::v1::{HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus};
-api_ctor!(v1HorizontalPodAutoscaler, HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus);
+api_ctor!(
+    v1HorizontalPodAutoscaler,
+    HorizontalPodAutoscalerSpec,
+    HorizontalPodAutoscalerStatus
+);
 
 use k8s_openapi::api::extensions::v1beta1::{IngressSpec, IngressStatus};
 api_ctor!(v1beta1Ingress, IngressSpec, IngressStatus);
 
 use k8s_openapi::api::authorization::v1::{SelfSubjectRulesReviewSpec, SubjectRulesReviewStatus};
-api_ctor!(v1SelfSubjectRulesReview, SelfSubjectRulesReviewSpec, SubjectRulesReviewStatus);
+api_ctor!(
+    v1SelfSubjectRulesReview,
+    SelfSubjectRulesReviewSpec,
+    SubjectRulesReviewStatus
+);

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -2,232 +2,102 @@
 use std::marker::PhantomData;
 
 use crate::{
-    api::{typed::LoggingObject, Api, Object, RawApi, Void},
+    api::{subresource::LoggingObject, Api, Object, RawApi, Void},
     client::APIClient,
 };
+
+
+/// Implement a named constructor on Api, with Spec and Status types
+macro_rules! api_ctor {
+    ( $name:tt, $Spec:ty, $Status:ty ) => {
+        impl Api<Object<$Spec, $Status>> {
+            pub fn $name(client: APIClient) -> Self {
+                Api {
+                    api: RawApi::$name(),
+                    client,
+                    phantom: PhantomData,
+                }
+            }
+        }
+    }
+}
 
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1::{
     CustomResourceDefinitionSpec as CrdSpec, CustomResourceDefinitionStatus as CrdStatus,
 };
-impl Api<Object<CrdSpec, CrdStatus>> {
-    pub fn v1beta1CustomResourceDefinition(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1beta1CustomResourceDefinition(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1beta1CustomResourceDefinition, CrdSpec, CrdStatus);
 
 use k8s_openapi::api::batch::v1beta1::{CronJobSpec, CronJobStatus};
-impl Api<Object<CronJobSpec, CronJobStatus>> {
-    pub fn v1beta1CronJob(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1beta1CronJob(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1beta1CronJob, CronJobSpec, CronJobStatus);
 
 use k8s_openapi::api::core::v1::{NodeSpec, NodeStatus};
-impl Api<Object<NodeSpec, NodeStatus>> {
-    pub fn v1Node(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1Node(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1Node, NodeSpec, NodeStatus);
 
 use k8s_openapi::api::apps::v1::{DeploymentSpec, DeploymentStatus};
-impl Api<Object<DeploymentSpec, DeploymentStatus>> {
-    pub fn v1Deployment(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1Deployment(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1Deployment, DeploymentSpec, DeploymentStatus);
+
 impl LoggingObject for Object<DeploymentSpec, DeploymentStatus> {}
 impl LoggingObject for Object<DeploymentSpec, Void> {}
 
 use k8s_openapi::api::core::v1::{PodSpec, PodStatus};
-impl Api<Object<PodSpec, PodStatus>> {
-    pub fn v1Pod(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1Pod(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1Pod, PodSpec, PodStatus);
+
 impl LoggingObject for Object<PodSpec, PodStatus> {}
 impl LoggingObject for Object<PodSpec, Void> {}
 
 use k8s_openapi::api::core::v1::{ServiceSpec, ServiceStatus};
-impl Api<Object<ServiceSpec, ServiceStatus>> {
-    pub fn v1Service(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1Service(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1Service, ServiceSpec, ServiceStatus);
 
 use k8s_openapi::api::batch::v1::{JobSpec, JobStatus};
-impl Api<Object<JobSpec, JobStatus>> {
-    pub fn v1Job(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1Job(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1Job, JobSpec, JobStatus);
+
+impl LoggingObject for Object<JobSpec, JobStatus> {}
+impl LoggingObject for Object<JobSpec, Void> {}
 
 use k8s_openapi::api::core::v1::{NamespaceSpec, NamespaceStatus};
-impl Api<Object<NamespaceSpec, NamespaceStatus>> {
-    pub fn v1Namespace(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1Namespace(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1Namespace, NamespaceSpec, NamespaceStatus);
 
 use k8s_openapi::api::apps::v1::{DaemonSetSpec, DaemonSetStatus};
-impl Api<Object<DaemonSetSpec, DaemonSetStatus>> {
-    pub fn v1DaemonSet(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1DaemonSet(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1DaemonSet, DaemonSetSpec, DaemonSetStatus);
+
+impl LoggingObject for Object<DaemonSetSpec, DaemonSetStatus> {}
+impl LoggingObject for Object<DaemonSetSpec, Void> {}
 
 use k8s_openapi::api::apps::v1::{StatefulSetSpec, StatefulSetStatus};
-impl Api<Object<StatefulSetSpec, StatefulSetStatus>> {
-    pub fn v1StatefulSet(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1Statefulset(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1StatefulSet, StatefulSetSpec, StatefulSetStatus);
+
+impl LoggingObject for Object<StatefulSetSpec, StatefulSetStatus> {}
+impl LoggingObject for Object<StatefulSetSpec, Void> {}
 
 use k8s_openapi::api::apps::v1::{ReplicaSetSpec, ReplicaSetStatus};
-impl Api<Object<ReplicaSetSpec, ReplicaSetStatus>> {
-    pub fn v1ReplicaSet(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1ReplicaSet(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1ReplicaSet, ReplicaSetSpec, ReplicaSetStatus);
+
+impl LoggingObject for Object<ReplicaSetSpec, ReplicaSetStatus> {}
+impl LoggingObject for Object<ReplicaSetSpec, Void> {}
 
 use k8s_openapi::api::core::v1::{ReplicationControllerSpec, ReplicationControllerStatus};
-impl Api<Object<ReplicationControllerSpec, ReplicationControllerStatus>> {
-    pub fn v1ReplicationController(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1ReplicationController(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1ReplicationController, ReplicationControllerSpec, ReplicationControllerStatus);
 
 use k8s_openapi::api::core::v1::{PersistentVolumeClaimSpec, PersistentVolumeClaimStatus};
-impl Api<Object<PersistentVolumeClaimSpec, PersistentVolumeClaimStatus>> {
-    pub fn v1PersistentVolumeClaim(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1PersistentVolumeClaim(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1PersistentVolumeClaim, PersistentVolumeClaimSpec, PersistentVolumeClaimStatus);
 
 use k8s_openapi::api::core::v1::{PersistentVolumeSpec, PersistentVolumeStatus};
-impl Api<Object<PersistentVolumeSpec, PersistentVolumeStatus>> {
-    pub fn v1PersistentVolume(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1PersistentVolume(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1PersistentVolume, PersistentVolumeSpec, PersistentVolumeStatus);
 
 use k8s_openapi::api::storage::v1::{VolumeAttachmentSpec, VolumeAttachmentStatus};
-impl Api<Object<VolumeAttachmentSpec, VolumeAttachmentStatus>> {
-    pub fn v1VolumeAttachment(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1VolumeAttachment(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1VolumeAttachment, VolumeAttachmentSpec, VolumeAttachmentStatus);
 
 use k8s_openapi::api::core::v1::{ResourceQuotaSpec, ResourceQuotaStatus};
-impl Api<Object<ResourceQuotaSpec, ResourceQuotaStatus>> {
-    pub fn v1ResourceQuota(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1ResourceQuota(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1ResourceQuota, ResourceQuotaSpec, ResourceQuotaStatus);
 
 use k8s_openapi::api::networking::v1::NetworkPolicySpec;
-impl Api<Object<NetworkPolicySpec, Void>> {
-    pub fn v1NetworkPolicy(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1NetworkPolicy(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1NetworkPolicy, NetworkPolicySpec, Void); // has no Status
 
 use k8s_openapi::api::autoscaling::v1::{HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus};
-impl Api<Object<HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus>> {
-    pub fn v1HorizontalPodAutoscaler(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1HorizontalPodAutoscaler(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1HorizontalPodAutoscaler, HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus);
 
 use k8s_openapi::api::extensions::v1beta1::{IngressSpec, IngressStatus};
-impl Api<Object<IngressSpec, IngressStatus>> {
-    pub fn v1beta1Ingress(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1beta1Ingress(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1beta1Ingress, IngressSpec, IngressStatus);
 
 use k8s_openapi::api::authorization::v1::{SelfSubjectRulesReviewSpec, SubjectRulesReviewStatus};
-impl Api<Object<SelfSubjectRulesReviewSpec, SubjectRulesReviewStatus>> {
-    pub fn v1SelfSubjectRulesReview(client: APIClient) -> Self {
-        Api {
-            api: RawApi::v1SelfSubjectRulesReview(),
-            client,
-            phantom: PhantomData,
-        }
-    }
-}
+api_ctor!(v1SelfSubjectRulesReview, SelfSubjectRulesReviewSpec, SubjectRulesReviewStatus);

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -395,7 +395,7 @@ impl RawApi {
 // -------------------------------------------------------
 
 impl RawApi {
-    fn make_url(&self) -> String {
+    pub(crate) fn make_url(&self) -> String {
         let pref = if self.prefix == "" {
             "".into()
         } else {
@@ -552,30 +552,6 @@ pub enum PropagationPolicy {
     Foreground,
 }
 
-#[derive(Default, Clone, Debug)]
-pub struct LogParams {
-    /// The container for which to stream logs. Defaults to only container if there is one container in the pod.
-    pub container: Option<String>,
-    /// Follow the log stream of the pod. Defaults to false.
-    pub follow: bool,
-    /// If set, the number of bytes to read from the server before terminating the log output.
-    /// This may not display a complete final line of logging, and may return slightly more or slightly less than the specified limit.
-    pub limit_bytes: Option<i64>,
-    /// If 'true', then the output is pretty printed.
-    pub pretty: bool,
-    /// Return previous terminated container logs. Defaults to false.
-    pub previous: bool,
-    /// A relative time in seconds before the current time from which to show logs.
-    /// If this value precedes the time a pod was started, only logs since the pod start will be returned.
-    /// If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.
-    pub since_seconds: Option<i64>,
-    /// If set, the number of lines from the end of the logs to show.
-    /// If not specified, logs are shown from the creation of the container or sinceSeconds or sinceTime
-    pub tail_lines: Option<i64>,
-    /// If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output. Defaults to false.
-    pub timestamps: bool,
-}
-
 /// Convenience methods found from API conventions
 impl RawApi {
     /// List a collection of a resource
@@ -723,7 +699,10 @@ impl RawApi {
         let req = http::Request::put(urlstr);
         req.body(data).map_err(Error::HttpError)
     }
+}
 
+/// Scale subresource
+impl RawApi {
     /// Get an instance of the scale subresource
     pub fn get_scale(&self, name: &str) -> Result<http::Request<Vec<u8>>> {
         let base_url = self.make_url() + "/" + name + "/scale";
@@ -768,7 +747,10 @@ impl RawApi {
         let req = http::Request::put(urlstr);
         req.body(data).map_err(Error::HttpError)
     }
+}
 
+/// Status subresource
+impl RawApi {
     /// Get an instance of the status subresource
     pub fn get_status(&self, name: &str) -> Result<http::Request<Vec<u8>>> {
         let base_url = self.make_url() + "/" + name + "/status";
@@ -812,50 +794,6 @@ impl RawApi {
         let urlstr = qp.finish();
         let req = http::Request::put(urlstr);
         req.body(data).map_err(Error::HttpError)
-    }
-}
-
-impl RawApi {
-    /// Get a pod logs
-    pub fn log(&self, name: &str, lp: &LogParams) -> Result<http::Request<Vec<u8>>> {
-        let base_url = self.make_url() + "/" + name + "/" + "log?";
-        let mut qp = url::form_urlencoded::Serializer::new(base_url);
-
-        if let Some(container) = &lp.container {
-            qp.append_pair("container", &container);
-        }
-
-        if lp.follow {
-            qp.append_pair("follow", "true");
-        }
-
-        if let Some(lb) = &lp.limit_bytes {
-            qp.append_pair("limitBytes", &lb.to_string());
-        }
-
-        if lp.pretty {
-            qp.append_pair("pretty", "true");
-        }
-
-        if lp.previous {
-            qp.append_pair("previous", "true");
-        }
-
-        if let Some(ss) = &lp.since_seconds {
-            qp.append_pair("sinceSeconds", &ss.to_string());
-        }
-
-        if let Some(tl) = &lp.tail_lines {
-            qp.append_pair("tailLines", &tl.to_string());
-        }
-
-        if lp.timestamps {
-            qp.append_pair("timestamps", "true");
-        }
-
-        let urlstr = qp.finish();
-        let req = http::Request::get(urlstr);
-        req.body(vec![]).map_err(Error::HttpError)
     }
 }
 

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -140,7 +140,7 @@ impl RawApi {
     }
 
     /// Stable statefulset resource constructor
-    pub fn v1Statefulset() -> Self {
+    pub fn v1StatefulSet() -> Self {
         Self {
             group: "apps".into(),
             resource: "statefulsets".into(),

--- a/src/api/subresource.rs
+++ b/src/api/subresource.rs
@@ -1,0 +1,167 @@
+use bytes::Bytes;
+use futures::Stream;
+use serde::de::DeserializeOwned;
+
+use crate::{
+    api::{
+        resource::{KubeObject, Object},
+        Api, PatchParams, PostParams, RawApi,
+    },
+    Error, Result,
+};
+
+
+// ----------------------------------------------------------------------------
+
+/// Scale spec from api::autoscaling::v1
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct ScaleSpec {
+    pub replicas: Option<i32>,
+}
+/// Scale status from api::autoscaling::v1
+#[derive(Deserialize, Serialize, Clone, Default, Debug)]
+pub struct ScaleStatus {
+    pub replicas: i32,
+    pub selector: Option<String>,
+}
+pub type Scale = Object<ScaleSpec, ScaleStatus>;
+
+/// Scale subresource
+///
+/// https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#scale-subresource
+impl<K> Api<K>
+where
+    K: Clone + DeserializeOwned,
+{
+    pub async fn get_scale(&self, name: &str) -> Result<Scale> {
+        let req = self.api.get_scale(name)?;
+        self.client.request::<Scale>(req).await
+    }
+
+    pub async fn patch_scale(&self, name: &str, pp: &PatchParams, patch: Vec<u8>) -> Result<Scale> {
+        let req = self.api.patch_scale(name, &pp, patch)?;
+        self.client.request::<Scale>(req).await
+    }
+
+    pub async fn replace_scale(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<Scale> {
+        let req = self.api.replace_scale(name, &pp, data)?;
+        self.client.request::<Scale>(req).await
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+
+/// Status subresource
+///
+/// https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#status-subresource
+impl<K> Api<K>
+where
+    K: Clone + DeserializeOwned,
+{
+    pub async fn get_status(&self, name: &str) -> Result<K> {
+        let req = self.api.get_status(name)?;
+        self.client.request::<K>(req).await
+    }
+
+    pub async fn patch_status(&self, name: &str, pp: &PatchParams, patch: Vec<u8>) -> Result<K> {
+        let req = self.api.patch_status(name, &pp, patch)?;
+        self.client.request::<K>(req).await
+    }
+
+    pub async fn replace_status(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<K> {
+        let req = self.api.replace_status(name, &pp, data)?;
+        self.client.request::<K>(req).await
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Log subresource
+// ----------------------------------------------------------------------------
+
+#[derive(Default, Clone, Debug)]
+pub struct LogParams {
+    /// The container for which to stream logs. Defaults to only container if there is one container in the pod.
+    pub container: Option<String>,
+    /// Follow the log stream of the pod. Defaults to false.
+    pub follow: bool,
+    /// If set, the number of bytes to read from the server before terminating the log output.
+    /// This may not display a complete final line of logging, and may return slightly more or slightly less than the specified limit.
+    pub limit_bytes: Option<i64>,
+    /// If 'true', then the output is pretty printed.
+    pub pretty: bool,
+    /// Return previous terminated container logs. Defaults to false.
+    pub previous: bool,
+    /// A relative time in seconds before the current time from which to show logs.
+    /// If this value precedes the time a pod was started, only logs since the pod start will be returned.
+    /// If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.
+    pub since_seconds: Option<i64>,
+    /// If set, the number of lines from the end of the logs to show.
+    /// If not specified, logs are shown from the creation of the container or sinceSeconds or sinceTime
+    pub tail_lines: Option<i64>,
+    /// If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output. Defaults to false.
+    pub timestamps: bool,
+}
+
+
+impl RawApi {
+    /// Get a pod logs
+    pub fn logs(&self, name: &str, lp: &LogParams) -> Result<http::Request<Vec<u8>>> {
+        let base_url = self.make_url() + "/" + name + "/" + "log?";
+        let mut qp = url::form_urlencoded::Serializer::new(base_url);
+
+        if let Some(container) = &lp.container {
+            qp.append_pair("container", &container);
+        }
+
+        if lp.follow {
+            qp.append_pair("follow", "true");
+        }
+
+        if let Some(lb) = &lp.limit_bytes {
+            qp.append_pair("limitBytes", &lb.to_string());
+        }
+
+        if lp.pretty {
+            qp.append_pair("pretty", "true");
+        }
+
+        if lp.previous {
+            qp.append_pair("previous", "true");
+        }
+
+        if let Some(ss) = &lp.since_seconds {
+            qp.append_pair("sinceSeconds", &ss.to_string());
+        }
+
+        if let Some(tl) = &lp.tail_lines {
+            qp.append_pair("tailLines", &tl.to_string());
+        }
+
+        if lp.timestamps {
+            qp.append_pair("timestamps", "true");
+        }
+
+        let urlstr = qp.finish();
+        let req = http::Request::get(urlstr);
+        req.body(vec![]).map_err(Error::HttpError)
+    }
+}
+
+/// Marker trait for objects that has logs
+pub trait LoggingObject {}
+
+impl<K> Api<K>
+where
+    K: Clone + DeserializeOwned + KubeObject + LoggingObject,
+{
+    pub async fn log(&self, name: &str, lp: &LogParams) -> Result<String> {
+        let req = self.api.logs(name, lp)?;
+        Ok(self.client.request_text(req).await?)
+    }
+
+    pub async fn log_stream(&self, name: &str, lp: &LogParams) -> Result<impl Stream<Item = Result<Bytes>>> {
+        let req = self.api.logs(name, lp)?;
+        Ok(self.client.request_text_stream(req).await?)
+    }
+}

--- a/src/api/subresource.rs
+++ b/src/api/subresource.rs
@@ -148,6 +148,14 @@ impl RawApi {
     }
 }
 
+#[test]
+fn log_path() {
+    let r = RawApi::v1Deployment().within("ns");
+    let lp = LogParams::default();
+    let req = r.logs("foo", &lp).unwrap();
+    assert_eq!(req.uri(), "/apis/apps/v1/namespaces/ns/deployments/foo/log?");
+}
+
 /// Marker trait for objects that has logs
 pub trait LoggingObject {}
 


### PR DESCRIPTION
- new file for subresources
- macro for openapi bindings
- examples use Iter impls on ObjectList
- Statefulset/StatefulSet everywhere (mismatches within lib)