### PR TITLE
Macro glue to reduce maintenance between k8s objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * Exposed `Config::read` and `Config::read_from` - #124
   * Fix typo on `Api::StatefulSet`
   * Fix typo on `Api::Endpoints`
+  * Add `Api::v1CustomResourceDefinition` when on k8s >= 1.17
 
 0.25.0 / 2020-02-09
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ===================
   * Exposed `Config::read` and `Config::read_from` - #124
   * Fix typo on `Api::StatefulSet`
+  * Fix typo on `Api::Endpoints`
 
 0.25.0 / 2020-02-09
 ===================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,4 @@ anyhow = "1.0.26"
 [dev-dependencies.k8s-openapi]
 version = "0.7.1"
 default-features = false
-features = ["v1_15"]
+features = ["v1_17"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ futures = "0.3.4"
 openssl = { version = "0.10.28", optional = true }
 rustls = { version = "0.16.0", optional = true }
 bytes = "0.5.4"
+paste = "0.1.6"
+Inflector = "0.11.4"
 
 [dependencies.reqwest]
 version = "0.10.1"

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ clippy:
 	touch src/lib.rs
 	cargo +nightly clippy --no-default-features --features=openapi,rustls-tls
 
-doc:
-	cargo doc --lib
-	xdg-open target/doc/kube/index.html
-
 fmt:
 	#rustup component add rustfmt --toolchain nightly
 	cargo +nightly fmt
+
+doc:
+	cargo doc --lib
+	xdg-open target/doc/kube/index.html
 
 test:
 	cargo test --lib

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -22,7 +22,7 @@ pub use subresource::{LogParams, Scale, ScaleSpec, ScaleStatus};
 mod resource;
 pub use self::resource::{KubeObject, Object, ObjectList, WatchEvent};
 
-#[cfg(feature = "openapi")] mod openapi;
+mod openapi;
 #[cfg(feature = "openapi")] mod snowflake;
 #[cfg(feature = "openapi")] pub use snowflake::{v1ConfigMap, v1Event, v1Secret};
 

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -41,8 +41,8 @@ macro_rules! k8s_obj {
 /// Bind a k8s_openapi resource struct to Api
 ///
 /// Binds Api::vxObjectName to the RawApi
+/// This uses the standard openapi path with consistent Spec and Status suffixed structs
 macro_rules! k8s_ctor {
-    // using a standard openapi path with consistent Spec and Status suffixed structs
     ( $name:ident, $version:expr, $openapi:path) => {
         #[cfg(feature = "openapi")]
         paste::item! {
@@ -64,9 +64,10 @@ macro_rules! k8s_ctor {
 }
 
 /// Binds an arbitrary Object type to a verioned name on Api
+///
+/// Good for when there are api inconsistencies
 #[cfg_attr(not(feature = "openapi"), allow(unused_macros))]
 macro_rules! k8s_custom_ctor {
-    // using a non-standard manual Object (for api inconsistencies)
     ( $versioned_name:ident, $obj:ty) => {
         paste::item! {
             impl Api<$obj> {

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -1,15 +1,14 @@
 #![allow(non_snake_case)]
 
-#[cfg(feature = "openapi")]
-use std::marker::PhantomData;
+use crate::api::RawApi;
 #[cfg(feature = "openapi")]
 use crate::{
     api::subresource::LoggingObject,
     api::{Api, Object, Void},
     client::APIClient,
 };
-use crate::api::RawApi;
 use inflector::string::pluralize::to_plural;
+#[cfg(feature = "openapi")] use std::marker::PhantomData;
 
 /// Bind typemeta properties for a k8s_openapi resource to RawApi
 ///
@@ -102,7 +101,12 @@ k8s_obj!("HorizontalPodAutoscaler", "v1", "autoscaling", "apis");
 k8s_ctor!(HorizontalPodAutoscaler, "v1", k8s_openapi::api::autoscaling);
 
 // api::admissionregistration
-k8s_obj!("ValidatingWebhookConfiguration", "v1beta1", "admissionregistration.k8s.io", "apis"); // snowflake
+k8s_obj!(
+    "ValidatingWebhookConfiguration",
+    "v1beta1",
+    "admissionregistration.k8s.io",
+    "apis"
+); // snowflake
 
 
 // api::core
@@ -128,7 +132,7 @@ k8s_obj!("Event", "v1", "api");
 k8s_obj!("ConfigMap", "v1", "api");
 k8s_obj!("ServiceAccount", "v1", "api");
 k8s_obj!("Endpoints", "v1", "api"); // yup plural!
-// subresources
+                                    // subresources
 #[cfg(feature = "openapi")]
 impl LoggingObject for Object<k8s_openapi::api::core::v1::PodSpec, k8s_openapi::api::core::v1::PodStatus> {}
 #[cfg(feature = "openapi")]
@@ -148,8 +152,17 @@ k8s_ctor!(Ingress, "v1beta1", k8s_openapi::api::extensions);
 
 
 // apiextensions_apiserver::pkg::apis::apiextensions
-k8s_obj!("CustomResourceDefinition", "v1beta1", "apiextensions.k8s.io", "apis");
-k8s_ctor!(CustomResourceDefinition, "v1beta1", k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions);
+k8s_obj!(
+    "CustomResourceDefinition",
+    "v1beta1",
+    "apiextensions.k8s.io",
+    "apis"
+);
+k8s_ctor!(
+    CustomResourceDefinition,
+    "v1beta1",
+    k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions
+);
 
 
 // api::rbac (snowflake objects in snowflake.rs)
@@ -172,7 +185,7 @@ k8s_custom_ctor!(v1NetworkPolicy, Object<k8s_openapi::api::networking::v1::Netwo
 // Macro insanity needs some sanity here..
 // There should be at least one test for each api group here to ensure no path typos
 mod test {
-    //use crate::api::{RawApi, PostParams};
+    // use crate::api::{RawApi, PostParams};
     // TODO: fixturize these tests
     // these are sanity tests for macros that create the RawApi::v1Ctors
     #[test]
@@ -191,7 +204,10 @@ mod test {
     fn api_url_role() {
         let r = RawApi::v1Role().within("ns");
         let req = r.create(&PostParams::default(), vec![]).unwrap();
-        assert_eq!(req.uri(), "/apis/rbac.authorization.k8s.io/v1/namespaces/ns/roles?");
+        assert_eq!(
+            req.uri(),
+            "/apis/rbac.authorization.k8s.io/v1/namespaces/ns/roles?"
+        );
     }
     #[test]
     fn api_url_cj() {
@@ -203,13 +219,19 @@ mod test {
     fn api_url_hpa() {
         let r = RawApi::v1HorizontalPodAutoscaler().within("ns");
         let req = r.create(&PostParams::default(), vec![]).unwrap();
-        assert_eq!(req.uri(), "/apis/autoscaling/v1/namespaces/ns/horizontalpodautoscalers?");
+        assert_eq!(
+            req.uri(),
+            "/apis/autoscaling/v1/namespaces/ns/horizontalpodautoscalers?"
+        );
     }
     #[test]
     fn api_url_np() {
         let r = RawApi::v1NetworkPolicy().within("ns");
         let req = r.create(&PostParams::default(), vec![]).unwrap();
-        assert_eq!(req.uri(), "/apis/networking.k8s.io/v1/namespaces/ns/networkpolicies?");
+        assert_eq!(
+            req.uri(),
+            "/apis/networking.k8s.io/v1/namespaces/ns/networkpolicies?"
+        );
     }
     #[test]
     fn api_url_ingress() {
@@ -227,7 +249,10 @@ mod test {
     fn api_url_admission() {
         let r = RawApi::v1beta1ValidatingWebhookConfiguration();
         let req = r.create(&PostParams::default(), vec![]).unwrap();
-        assert_eq!(req.uri(), "/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations?");
+        assert_eq!(
+            req.uri(),
+            "/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations?"
+        );
     }
 
     #[test]

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -5,12 +5,15 @@ use crate::{
     api::{subresource::LoggingObject, Api, Object, RawApi, Void},
     client::APIClient,
 };
+use inflector::string::pluralize::to_plural;
 
-
-/// Implement a named constructor on Api, with Spec and Status types
-macro_rules! api_ctor {
-    ( $name:tt, $Spec:ty, $Status:ty ) => {
-        impl Api<Object<$Spec, $Status>> {
+/// Implement a named constructor on Api for a typed kubernetes Object
+///
+/// This assumes that RawApi::$name exists first
+/// legacy, to be removed
+macro_rules! ctor {
+    ( $name:tt, $object:ty ) => {
+        impl Api<$object> {
             pub fn $name(client: APIClient) -> Self {
                 Api {
                     api: RawApi::$name(),
@@ -22,83 +25,145 @@ macro_rules! api_ctor {
     };
 }
 
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1::{
-    CustomResourceDefinitionSpec as CrdSpec, CustomResourceDefinitionStatus as CrdStatus,
-};
-api_ctor!(v1beta1CustomResourceDefinition, CrdSpec, CrdStatus);
+/// Bind typemeta properties for a k8s_openapi resource to RawApi
+///
+/// Constructs a RawApi::vxObjectName constructor with correct names, versions
+macro_rules! k8s_obj {
+    // 4 argument ver
+    ( $name:expr, $version:expr, $group:expr, $prefix:expr) => {
+        impl RawApi {
+            paste::item! {
+                #[allow(non_snake_case)]
+                pub fn [<$version $name>]() -> Self {
+                    Self {
+                        prefix: $prefix.to_string(),
+                        group: $group.to_string(),
+                        resource: to_plural(&$name.to_ascii_lowercase()),
+                        version: $version.to_string(),
+                        ..Default::default()
+                    }
+                }
+            }
+        }
+    };
+    // 3 argument version for empty prefix (lots of api::apps stuff has this)
+    ( $name:expr, $version:expr, $group:expr) => {
+        k8s_obj!($name, $version, $group, "");
+    };
+}
 
-use k8s_openapi::api::batch::v1beta1::{CronJobSpec, CronJobStatus};
-api_ctor!(v1beta1CronJob, CronJobSpec, CronJobStatus);
+/// Bind a k8s_openapi resource struct to Api
+///
+/// Binds Api::vxObjectName to the RawApi
+macro_rules! k8s_ctor {
+    // using a standard openapi path with consistent Spec and Status suffixed structs
+    ( $name:ident, $version:expr, $openapi:path) => {
+        paste::item! {
+            type [<Obj $name>] = Object<$openapi::[<$version>]::[<$name Spec>], $openapi::[<$version>]::[<$name Status>]>;
+            impl Api<[<Obj $name>]> {
+                pub fn [<$version $name>](client: APIClient) -> Self {
+                    Self {
+                        api: RawApi::[<$version $name>](),
+                        client,
+                        phantom: PhantomData
+                    }
+                }
+            }
+        }
+    };
+}
 
-use k8s_openapi::api::core::v1::{NodeSpec, NodeStatus};
-api_ctor!(v1Node, NodeSpec, NodeStatus);
+/// Binds an arbitrary Object type to a verioned name on Api
+macro_rules! k8s_custom_ctor {
+    // using a non-standard manual Object (for api inconsistencies)
+    ( $versioned_name:ident, $obj:ty) => {
+        paste::item! {
+            impl Api<$obj> {
+                pub fn [<$versioned_name>](client: APIClient) -> Self {
+                    Self {
+                        api: RawApi::[<$versioned_name>](),
+                        client,
+                        phantom: PhantomData
+                    }
+                }
+            }
+        }
+    };
+}
 
-use k8s_openapi::api::apps::v1::{DeploymentSpec, DeploymentStatus};
-api_ctor!(v1Deployment, DeploymentSpec, DeploymentStatus);
+// api::apps
+k8s_obj!("Deployment", "v1", "apps", "apis");
+k8s_ctor!(Deployment, "v1", k8s_openapi::api::apps);
+k8s_obj!("DaemonSet", "v1", "apps", "apis");
+k8s_ctor!(DaemonSet, "v1", k8s_openapi::api::apps);
+k8s_obj!("ReplicaSet", "v1", "apps", "apis");
+k8s_ctor!(ReplicaSet, "v1", k8s_openapi::api::apps);
+k8s_obj!("StatefulSet", "v1", "apps", "apis");
+k8s_ctor!(StatefulSet, "v1", k8s_openapi::api::apps);
 
-use k8s_openapi::api::core::v1::{PodSpec, PodStatus};
-api_ctor!(v1Pod, PodSpec, PodStatus);
 
-impl LoggingObject for Object<PodSpec, PodStatus> {}
-impl LoggingObject for Object<PodSpec, Void> {}
+// api::authorization
+use k8s_openapi::api::authorization::v1 as v1Auth;
+k8s_obj!("SelfSubjectRulesReview", "v1", "authorization.k8s.io", "apis");
+k8s_custom_ctor!(v1SelfSubjectRulesReview, Object<v1Auth::SelfSubjectRulesReviewSpec, v1Auth::SubjectRulesReviewStatus>);
+#[test]
+fn k8s_obj_auth() {
+    let r = RawApi::v1SelfSubjectRulesReview();
+    assert_eq!(r.group, "authorization.k8s.io");
+    assert_eq!(r.prefix, "apis");
+    assert_eq!(r.resource, "selfsubjectrulesreviews"); // lowercase pluralisation
+}
 
-use k8s_openapi::api::core::v1::{ServiceSpec, ServiceStatus};
-api_ctor!(v1Service, ServiceSpec, ServiceStatus);
 
-use k8s_openapi::api::batch::v1::{JobSpec, JobStatus};
-api_ctor!(v1Job, JobSpec, JobStatus);
+// api::autoscaling
+k8s_obj!("HorizontalPodAutoscaler", "v1", "autoscaling", "apis");
+k8s_ctor!(HorizontalPodAutoscaler, "v1", k8s_openapi::api::autoscaling);
 
-use k8s_openapi::api::core::v1::{NamespaceSpec, NamespaceStatus};
-api_ctor!(v1Namespace, NamespaceSpec, NamespaceStatus);
 
-use k8s_openapi::api::apps::v1::{DaemonSetSpec, DaemonSetStatus};
-api_ctor!(v1DaemonSet, DaemonSetSpec, DaemonSetStatus);
+// api::core
+k8s_obj!("Pod", "v1", "api");
+k8s_ctor!(Pod, "v1", k8s_openapi::api::core);
+k8s_obj!("Node", "v1", "api");
+k8s_ctor!(Node, "v1", k8s_openapi::api::core);
+k8s_obj!("Service", "v1", "api");
+k8s_ctor!(Service, "v1", k8s_openapi::api::core);
+k8s_obj!("Namespace", "v1", "api");
+k8s_ctor!(Namespace, "v1", k8s_openapi::api::core);
+k8s_obj!("PersistentVolume", "v1", "api");
+k8s_ctor!(PersistentVolume, "v1", k8s_openapi::api::core);
+k8s_obj!("ResourceQuota", "v1", "api");
+k8s_ctor!(ResourceQuota, "v1", k8s_openapi::api::core);
 
-use k8s_openapi::api::apps::v1::{StatefulSetSpec, StatefulSetStatus};
-api_ctor!(v1StatefulSet, StatefulSetSpec, StatefulSetStatus);
+k8s_obj!("PersistentVolumeClaim", "v1", "api");
+k8s_ctor!(PersistentVolumeClaim, "v1", k8s_openapi::api::core);
 
-use k8s_openapi::api::apps::v1::{ReplicaSetSpec, ReplicaSetStatus};
-api_ctor!(v1ReplicaSet, ReplicaSetSpec, ReplicaSetStatus);
+k8s_obj!("ReplicationController", "v1", "api");
+k8s_ctor!(ReplicationController, "v1", k8s_openapi::api::core);
 
-use k8s_openapi::api::core::v1::{ReplicationControllerSpec, ReplicationControllerStatus};
-api_ctor!(
-    v1ReplicationController,
-    ReplicationControllerSpec,
-    ReplicationControllerStatus
-);
+use k8s_openapi::api::core::v1 as v1Core;
+impl LoggingObject for Object<v1Core::PodSpec, v1Core::PodStatus> {}
+impl LoggingObject for Object<v1Core::PodSpec, Void> {}
 
-use k8s_openapi::api::core::v1::{PersistentVolumeClaimSpec, PersistentVolumeClaimStatus};
-api_ctor!(
-    v1PersistentVolumeClaim,
-    PersistentVolumeClaimSpec,
-    PersistentVolumeClaimStatus
-);
 
-use k8s_openapi::api::core::v1::{PersistentVolumeSpec, PersistentVolumeStatus};
-api_ctor!(v1PersistentVolume, PersistentVolumeSpec, PersistentVolumeStatus);
+// api::batch
+k8s_obj!("CronJob", "v1beta1", "batch", "apis");
+k8s_ctor!(CronJob, "v1beta1", k8s_openapi::api::batch);
+k8s_obj!("Job", "v1", "batch", "apis");
+k8s_ctor!(Job, "v1", k8s_openapi::api::batch);
 
+
+// api::extensions
+k8s_obj!("Ingress", "v1beta1", "extensions", "apis");
+k8s_ctor!(Ingress, "v1beta1", k8s_openapi::api::extensions);
+
+// apiextensions_apiserver::pkg::apis::apiextensions
+k8s_obj!("CustomResourceDefinition", "v1beta1", "apiextensions.k8s.io", "apis");
+k8s_ctor!(CustomResourceDefinition, "v1beta1", k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions);
+
+// api::storage::v1
 use k8s_openapi::api::storage::v1::{VolumeAttachmentSpec, VolumeAttachmentStatus};
-api_ctor!(v1VolumeAttachment, VolumeAttachmentSpec, VolumeAttachmentStatus);
+ctor!(v1VolumeAttachment, Object<VolumeAttachmentSpec, VolumeAttachmentStatus>);
 
-use k8s_openapi::api::core::v1::{ResourceQuotaSpec, ResourceQuotaStatus};
-api_ctor!(v1ResourceQuota, ResourceQuotaSpec, ResourceQuotaStatus);
-
+// api::networking::v1
 use k8s_openapi::api::networking::v1::NetworkPolicySpec;
-api_ctor!(v1NetworkPolicy, NetworkPolicySpec, Void); // has no Status
-
-use k8s_openapi::api::autoscaling::v1::{HorizontalPodAutoscalerSpec, HorizontalPodAutoscalerStatus};
-api_ctor!(
-    v1HorizontalPodAutoscaler,
-    HorizontalPodAutoscalerSpec,
-    HorizontalPodAutoscalerStatus
-);
-
-use k8s_openapi::api::extensions::v1beta1::{IngressSpec, IngressStatus};
-api_ctor!(v1beta1Ingress, IngressSpec, IngressStatus);
-
-use k8s_openapi::api::authorization::v1::{SelfSubjectRulesReviewSpec, SubjectRulesReviewStatus};
-api_ctor!(
-    v1SelfSubjectRulesReview,
-    SelfSubjectRulesReviewSpec,
-    SubjectRulesReviewStatus
-);
+ctor!(v1NetworkPolicy, Object<NetworkPolicySpec, Void>); // has no Status

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -46,8 +46,8 @@ macro_rules! k8s_ctor {
     ( $name:ident, $version:expr, $openapi:path) => {
         #[cfg(feature = "openapi")]
         paste::item! {
-            type [<Obj $name>] = Object<$openapi::[<$version>]::[<$name Spec>], $openapi::[<$version>]::[<$name Status>]>;
-            impl Api<[<Obj $name>]> {
+            type [<Obj $version $name>] = Object<$openapi::[<$version>]::[<$name Spec>], $openapi::[<$version>]::[<$name Status>]>;
+            impl Api<[<Obj $version $name>]> {
                 pub fn [<$version $name>](client: APIClient) -> Self {
                     Self {
                         api: RawApi::[<$version $name>](),
@@ -163,6 +163,21 @@ k8s_ctor!(
     "v1beta1",
     k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions
 );
+
+#[cfg(feature = "openapi")]
+k8s_openapi::k8s_if_ge_1_17! {
+    k8s_obj!(
+        "CustomResourceDefinition",
+        "v1",
+        "apiextensions.k8s.io",
+        "apis"
+    );
+    k8s_ctor!(
+        CustomResourceDefinition,
+        "v1",
+        k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions
+    );
+}
 
 
 // api::rbac (snowflake objects in snowflake.rs)

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -185,7 +185,7 @@ k8s_custom_ctor!(v1NetworkPolicy, Object<k8s_openapi::api::networking::v1::Netwo
 // Macro insanity needs some sanity here..
 // There should be at least one test for each api group here to ensure no path typos
 mod test {
-    // use crate::api::{RawApi, PostParams};
+     use crate::api::{RawApi, PostParams};
     // TODO: fixturize these tests
     // these are sanity tests for macros that create the RawApi::v1Ctors
     #[test]

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -46,7 +46,10 @@ macro_rules! k8s_ctor {
     ( $name:ident, $version:expr, $openapi:path) => {
         #[cfg(feature = "openapi")]
         paste::item! {
-            type [<Obj $version $name>] = Object<$openapi::[<$version>]::[<$name Spec>], $openapi::[<$version>]::[<$name Status>]>;
+            type [<Obj $version $name>] = Object<
+                $openapi::[<$version>]::[<$name Spec>],
+                $openapi::[<$version>]::[<$name Status>]
+                >;
             impl Api<[<Obj $version $name>]> {
                 pub fn [<$version $name>](client: APIClient) -> Self {
                     Self {

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -185,7 +185,7 @@ k8s_custom_ctor!(v1NetworkPolicy, Object<k8s_openapi::api::networking::v1::Netwo
 // Macro insanity needs some sanity here..
 // There should be at least one test for each api group here to ensure no path typos
 mod test {
-     use crate::api::{RawApi, PostParams};
+    use crate::api::{PostParams, RawApi};
     // TODO: fixturize these tests
     // these are sanity tests for macros that create the RawApi::v1Ctors
     #[test]

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -38,7 +38,6 @@ impl Default for RawApi {
 ///
 /// Note: constructors such as RawApi::v1Deployment are implemented via the k8s_obj macro
 /// Find those invocations to see how to add more objects (not fully automated yet)
-#[allow(non_snake_case)]
 impl RawApi {
     /// Set as namespaced resource within a specified namespace
     pub fn within(mut self, ns: &str) -> Self {
@@ -68,79 +67,6 @@ impl RawApi {
         self
     }
 
-    // Stable event resource constructor
-    pub fn v1Event() -> Self {
-        Self {
-            group: "".into(),
-            resource: "events".into(),
-            prefix: "api".into(),
-            ..Default::default()
-        }
-    }
-
-    // Stable Secret resource constructor
-    pub fn v1Secret() -> Self {
-        Self {
-            group: "".into(),
-            resource: "secrets".into(),
-            prefix: "api".into(),
-            ..Default::default()
-        }
-    }
-
-    // Stable ConfigMap resource constructor
-    pub fn v1ConfigMap() -> Self {
-        Self {
-            group: "".into(),
-            resource: "configmaps".into(),
-            prefix: "api".into(),
-            ..Default::default()
-        }
-    }
-
-    // Stable VolumeAttachment resource constructor
-    pub fn v1VolumeAttachment() -> Self {
-        Self {
-            group: "storage.k8s.io".into(),
-            resource: "volumeattachments".into(),
-            prefix: "apis".into(),
-            version: "v1".into(),
-            ..Default::default()
-        }
-    }
-
-    // Stable NetworkPolicy resource constructor
-    pub fn v1NetworkPolicy() -> Self {
-        Self {
-            group: "networking.k8s.io".into(),
-            resource: "networkpolicies".into(),
-            prefix: "apis".into(),
-            version: "v1".into(),
-            ..Default::default()
-        }
-    }
-
-    /// ValidatingWebhookConfiguration constructor
-    pub fn v1beta1ValidatingWebhookConfiguration() -> Self {
-        Self {
-            group: "admissionregistration.k8s.io".into(),
-            resource: "validatingwebhookconfigurations".into(),
-            prefix: "apis".into(),
-            version: "v1beta1".into(), // latest available in 1.14.0
-            ..Default::default()
-        }
-    }
-
-    /// ValidatingWebhookConfiguration constructor
-    pub fn v1Endpoint() -> Self {
-        Self {
-            group: "".into(),
-            resource: "endpoints".into(),
-            prefix: "api".into(),
-            ..Default::default()
-        }
-    }
-
     /// Instance of a CRD
     ///
     /// The version, and group must be set by the user:
@@ -151,53 +77,10 @@ impl RawApi {
     ///    .group("clux.dev") // <.spec.group>
     ///    .version("v1");
     /// ```
+    #[allow(non_snake_case)]
     pub fn customResource(name: &str) -> Self {
         Self {
             resource: name.into(),
-            ..Default::default()
-        }
-    }
-
-    // Stable Role resource constructor
-    pub fn v1Role() -> Self {
-        Self {
-            group: "rbac.authorization.k8s.io".into(),
-            resource: "roles".into(),
-            prefix: "apis".into(),
-            version: "v1".into(),
-            ..Default::default()
-        }
-    }
-
-    // Stable ClusterRole resource constructor
-    pub fn v1ClusterRole() -> Self {
-        Self {
-            group: "rbac.authorization.k8s.io".into(),
-            resource: "clusterroles".into(),
-            prefix: "apis".into(),
-            version: "v1".into(),
-            ..Default::default()
-        }
-    }
-
-    // Stable Role resource constructor
-    pub fn v1RoleBinding() -> Self {
-        Self {
-            group: "rbac.authorization.k8s.io".into(),
-            resource: "rolebindings".into(),
-            prefix: "apis".into(),
-            version: "v1".into(),
-            ..Default::default()
-        }
-    }
-
-    // Stable Service Account resource constructor
-    pub fn v1ServiceAccount() -> Self {
-        Self {
-            group: "".into(),
-            resource: "serviceaccounts".into(),
-            prefix: "api".into(),
-            version: "v1".into(),
             ..Default::default()
         }
     }
@@ -635,30 +518,7 @@ fn replace_path() {
     let req = r.replace("myds", &pp, vec![]).unwrap();
     assert_eq!(req.uri(), "/apis/apps/v1/daemonsets/myds?&dryRun=All");
 }
-#[test]
-fn create_path_rs() {
-    let r = RawApi::v1ReplicaSet().within("ns");
-    let req = r.create(&PostParams::default(), vec![]).unwrap();
-    assert_eq!(req.uri(), "/apis/apps/v1/namespaces/ns/replicasets?");
-}
-#[test]
-fn create_path_cj() {
-    let r = RawApi::v1beta1CronJob().within("ns");
-    let req = r.create(&PostParams::default(), vec![]).unwrap();
-    assert_eq!(req.uri(), "/apis/batch/v1beta1/namespaces/ns/cronjobs?");
-}
-#[test]
-fn create_path_hpa() {
-    let r = RawApi::v1HorizontalPodAutoscaler().within("ns");
-    let req = r.create(&PostParams::default(), vec![]).unwrap();
-    assert_eq!(req.uri(), "/apis/autoscaling/v1/namespaces/ns/horizontalpodautoscalers?");
-}
-#[test]
-fn create_path_ingress() {
-    let r = RawApi::v1beta1Ingress().within("ns");
-    let req = r.create(&PostParams::default(), vec![]).unwrap();
-    assert_eq!(req.uri(), "/apis/extensions/v1beta1/namespaces/ns/ingresses?");
-}
+
 #[test]
 fn delete_path() {
     let r = RawApi::v1ReplicaSet().within("ns");

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -34,10 +34,10 @@ impl Default for RawApi {
     }
 }
 
-/// Constructors for most kubernetes objects
+/// RawApi root implementations
 ///
-/// Don't see all objects in here? Please submit a PR.
-/// You can extract the data needed from the [openapi spec](https://docs.rs/k8s-openapi/0.4.0/k8s_openapi/api/).
+/// Note: constructors such as RawApi::v1Deployment are implemented via the k8s_obj macro
+/// Find those invocations to see how to add more objects (not fully automated yet)
 #[allow(non_snake_case)]
 impl RawApi {
     /// Set as namespaced resource within a specified namespace
@@ -68,102 +68,11 @@ impl RawApi {
         self
     }
 
-    /// Stable namespace resource constructor
-    pub fn v1Namespace() -> Self {
-        Self {
-            group: "".into(),
-            resource: "namespaces".into(),
-            prefix: "api".into(),
-            ..Default::default()
-        }
-    }
-
-    /// Stable deployment resource constructor
-    pub fn v1Deployment() -> Self {
-        Self {
-            group: "apps".into(),
-            resource: "deployments".into(),
-            prefix: "apis".into(),
-            ..Default::default()
-        }
-    }
-
-    /// Stable pod resource constructor
-    pub fn v1Pod() -> Self {
-        Self {
-            group: "".into(),
-            resource: "pods".into(),
-            prefix: "api".into(),
-            ..Default::default()
-        }
-    }
-
-    /// Stable daemonset resource constructor
-    pub fn v1DaemonSet() -> Self {
-        Self {
-            group: "apps".into(),
-            resource: "daemonsets".into(),
-            prefix: "apis".into(),
-            ..Default::default()
-        }
-    }
-
-    /// Stable replicaset resource constructor
-    pub fn v1ReplicaSet() -> Self {
-        Self {
-            group: "apps".into(),
-            resource: "replicasets".into(),
-            prefix: "apis".into(),
-            ..Default::default()
-        }
-    }
-
-    /// Stable ReplicationController resource constructor
-    pub fn v1ReplicationController() -> Self {
-        Self {
-            group: "".into(),
-            resource: "replicationcontrollers".into(),
-            prefix: "api".into(),
-            version: "v1".into(),
-            ..Default::default()
-        }
-    }
-
-    /// Stable node resource constructor
-    pub fn v1Node() -> Self {
-        Self {
-            group: "".into(),
-            resource: "nodes".into(),
-            prefix: "api".into(),
-            ..Default::default()
-        }
-    }
-
-    /// Stable statefulset resource constructor
-    pub fn v1StatefulSet() -> Self {
-        Self {
-            group: "apps".into(),
-            resource: "statefulsets".into(),
-            prefix: "apis".into(),
-            ..Default::default()
-        }
-    }
-
     // Stable event resource constructor
     pub fn v1Event() -> Self {
         Self {
             group: "".into(),
             resource: "events".into(),
-            prefix: "api".into(),
-            ..Default::default()
-        }
-    }
-
-    // Stable Service resource constructor
-    pub fn v1Service() -> Self {
-        Self {
-            group: "".into(),
-            resource: "services".into(),
             prefix: "api".into(),
             ..Default::default()
         }
@@ -185,38 +94,6 @@ impl RawApi {
             group: "".into(),
             resource: "configmaps".into(),
             prefix: "api".into(),
-            ..Default::default()
-        }
-    }
-
-    pub fn v1Job() -> Self {
-        Self {
-            group: "batch".into(),
-            resource: "jobs".into(),
-            prefix: "apis".into(),
-            version: "v1".into(),
-            ..Default::default()
-        }
-    }
-
-    // Stable PersistentVolumeClaim resource constructor
-    pub fn v1PersistentVolumeClaim() -> Self {
-        Self {
-            group: "".into(),
-            resource: "persistentvolumeclaims".into(),
-            prefix: "api".into(),
-            version: "v1".into(),
-            ..Default::default()
-        }
-    }
-
-    // Stable PersistentVolume resource constructor
-    pub fn v1PersistentVolume() -> Self {
-        Self {
-            group: "".into(),
-            resource: "persistentvolumes".into(),
-            prefix: "api".into(),
-            version: "v1".into(),
             ..Default::default()
         }
     }
@@ -243,61 +120,6 @@ impl RawApi {
         }
     }
 
-    // Stable ResourceQuota resource constructor
-    pub fn v1ResourceQuota() -> Self {
-        Self {
-            group: "".into(),
-            resource: "resourcequotas".into(),
-            prefix: "api".into(),
-            version: "v1".into(),
-            ..Default::default()
-        }
-    }
-
-    // Stable HorizontalPodAutoscaler resource constructor
-    pub fn v1HorizontalPodAutoscaler() -> Self {
-        Self {
-            group: "autoscaling".into(),
-            resource: "horizontalpodautoscalers".into(),
-            prefix: "apis".into(),
-            version: "v1".into(),
-            ..Default::default()
-        }
-    }
-
-    /// CronJob constructor
-    pub fn v1beta1CronJob() -> Self {
-        Self {
-            group: "batch".into(),
-            resource: "cronjobs".into(),
-            prefix: "apis".into(),
-            version: "v1beta1".into(), // latest available in 1.14.0
-            ..Default::default()
-        }
-    }
-
-    /// Ingress constructor
-    pub fn v1beta1Ingress() -> Self {
-        Self {
-            group: "extensions".into(),
-            resource: "ingresses".into(),
-            prefix: "apis".into(),
-            version: "v1beta1".into(),
-            ..Default::default()
-        }
-    }
-
-    /// SelfSubjectRulesReview constructor
-    pub fn v1SelfSubjectRulesReview() -> Self {
-        Self {
-            group: "authorization.k8s.io".into(),
-            resource: "selfsubjectrulesreviews".into(),
-            prefix: "apis".into(),
-            version: "v1".into(),
-            ..Default::default()
-        }
-    }
-
     /// ValidatingWebhookConfiguration constructor
     pub fn v1beta1ValidatingWebhookConfiguration() -> Self {
         Self {
@@ -315,17 +137,6 @@ impl RawApi {
             group: "".into(),
             resource: "endpoints".into(),
             prefix: "api".into(),
-            ..Default::default()
-        }
-    }
-
-    /// Custom resource definition constructor
-    pub fn v1beta1CustomResourceDefinition() -> Self {
-        Self {
-            group: "apiextensions.k8s.io".into(),
-            resource: "customresourcedefinitions".into(),
-            prefix: "apis".into(),
-            version: "v1beta1".into(), // latest available in 1.14.0
             ..Default::default()
         }
     }
@@ -825,11 +636,28 @@ fn replace_path() {
     assert_eq!(req.uri(), "/apis/apps/v1/daemonsets/myds?&dryRun=All");
 }
 #[test]
-fn create_path() {
+fn create_path_rs() {
     let r = RawApi::v1ReplicaSet().within("ns");
-    let pp = PostParams::default();
-    let req = r.create(&pp, vec![]).unwrap();
+    let req = r.create(&PostParams::default(), vec![]).unwrap();
     assert_eq!(req.uri(), "/apis/apps/v1/namespaces/ns/replicasets?");
+}
+#[test]
+fn create_path_cj() {
+    let r = RawApi::v1beta1CronJob().within("ns");
+    let req = r.create(&PostParams::default(), vec![]).unwrap();
+    assert_eq!(req.uri(), "/apis/batch/v1beta1/namespaces/ns/cronjobs?");
+}
+#[test]
+fn create_path_hpa() {
+    let r = RawApi::v1HorizontalPodAutoscaler().within("ns");
+    let req = r.create(&PostParams::default(), vec![]).unwrap();
+    assert_eq!(req.uri(), "/apis/autoscaling/v1/namespaces/ns/horizontalpodautoscalers?");
+}
+#[test]
+fn create_path_ingress() {
+    let r = RawApi::v1beta1Ingress().within("ns");
+    let req = r.create(&PostParams::default(), vec![]).unwrap();
+    assert_eq!(req.uri(), "/apis/extensions/v1beta1/namespaces/ns/ingresses?");
 }
 #[test]
 fn delete_path() {

--- a/src/api/snowflake.rs
+++ b/src/api/snowflake.rs
@@ -262,23 +262,23 @@ use k8s_openapi::api::core::v1::EndpointSubset;
 /// Endpoint
 /// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#endpoints-v1-core
 #[derive(Deserialize, Serialize, Clone)]
-pub struct v1Endpoint {
+pub struct v1Endpoints {
     pub metadata: ObjectMeta,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub subsets: Vec<EndpointSubset>,
 }
 
-impl KubeObject for v1Endpoint {
+impl KubeObject for v1Endpoints {
     fn meta(&self) -> &ObjectMeta {
         &self.metadata
     }
 }
 
-impl Api<v1Endpoint> {
-    pub fn v1Endpoint(client: APIClient) -> Self {
+impl Api<v1Endpoints> {
+    pub fn v1Endpoints(client: APIClient) -> Self {
         Api {
-            api: RawApi::v1Endpoint(),
+            api: RawApi::v1Endpoints(),
             client,
             phantom: PhantomData,
         }


### PR DESCRIPTION
Now should only be two lines to add for each type, and we can link them by api group.

A bit of magic with the [paste crate](https://github.com/dtolnay/paste/) to get it to inject the right `RawApi::v1Deployment` style ctors, and bind the k8s-openapi types to `impl Api<Object<..., ...>>` but it should be a lot less code to maintain.