### PR TITLE
Rename `Void` to `NotUsed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Fix typo on `Api::StatefulSet`
   * Fix typo on `Api::Endpoints`
   * Add `Api::v1CustomResourceDefinition` when on k8s >= 1.17
+  * Renamed `Void` to `NotUsed`
 
 0.25.0 / 2020-02-09
 ===================

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ let foos = RawApi::customResource("foos")
     .group("clux.dev")
     .within("default");
 
-type Foo = Object<FooSpec, Void>;
+type Foo = Object<FooSpec, NotUsed>;
 let rf : Reflector<Foo> = Reflector::raw(client, resource).init().await?;
 
 let fdata = json!({

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -4,7 +4,7 @@ use either::Either::{Left, Right};
 use serde_json::json;
 
 use kube::{
-    api::{DeleteParams, ListParams, Object, ObjectList, PatchParams, PostParams, RawApi, Void},
+    api::{DeleteParams, ListParams, Object, ObjectList, PatchParams, PostParams, RawApi, NotUsed},
     client::APIClient,
     config,
 };
@@ -27,7 +27,7 @@ pub struct FooStatus {
 
 // shorthands
 type Foo = Object<FooSpec, FooStatus>;
-type FooMeta = Object<Void, Void>;
+type FooMeta = Object<NotUsed, NotUsed>;
 type FullCrd = Object<CrdSpec, CrdStatus>;
 
 #[tokio::main]

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -4,7 +4,7 @@ use futures_timer::Delay;
 use std::time::Duration;
 
 use kube::{
-    api::{Object, RawApi, Reflector, Void},
+    api::{Object, RawApi, Reflector, NotUsed},
     client::APIClient,
     config,
 };
@@ -16,7 +16,7 @@ pub struct FooSpec {
     info: String,
 }
 // The kubernetes generic object with our spec and no status
-type Foo = Object<FooSpec, Void>;
+type Foo = Object<FooSpec, NotUsed>;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/src/api/informer.rs
+++ b/src/api/informer.rs
@@ -1,7 +1,7 @@
 use crate::{
     api::{
         resource::{KubeObject, ObjectList, WatchEvent},
-        Api, ListParams, RawApi, Void,
+        Api, ListParams, RawApi, NotUsed,
     },
     client::APIClient,
     Result,
@@ -232,7 +232,7 @@ where
         let req = self.resource.list_zero_resource_entries(&self.params)?;
 
         // parse to void a ResourceList into void except for Metadata
-        let res = self.client.request::<ObjectList<Void>>(req).await?;
+        let res = self.client.request::<ObjectList<NotUsed>>(req).await?;
 
         let version = res.metadata.resourceVersion.unwrap_or_else(|| "0".into());
         debug!(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,8 +1,15 @@
 //! API helpers
 
 /// Empty struct for when no Spec is required
+///
+/// Not using [`()`](https://doc.rust-lang.org/stable/std/primitive.unit.html), because serde's
+/// [`Deserialize`](https://docs.rs/serde/1.0.104/serde/trait.Deserialize.html) `impl` is too strict.
 #[derive(Clone, Deserialize, Serialize, Default)]
-pub struct Void {}
+pub struct NotUsed {}
+
+/// Use [`NotUsed`](notused.struct.html) instead. Renamed to avoid confusion with [`void::Void`](https://docs.rs/void/1.0.2/void/enum.Void.html).
+#[deprecated]
+pub type Void = NotUsed;
 
 mod reflector;
 pub use self::reflector::Reflector;

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -2,7 +2,7 @@ use crate::api::RawApi;
 #[cfg(feature = "openapi")]
 use crate::{
     api::subresource::LoggingObject,
-    api::{Api, Object, Void},
+    api::{Api, Object, NotUsed},
     client::APIClient,
 };
 use inflector::string::pluralize::to_plural;
@@ -146,7 +146,7 @@ k8s_core_obj!("Endpoints", "v1", "api"); // yup plural!
 #[cfg(feature = "openapi")]
 impl LoggingObject for Object<k8s_openapi::api::core::v1::PodSpec, k8s_openapi::api::core::v1::PodStatus> {}
 #[cfg(feature = "openapi")]
-impl LoggingObject for Object<k8s_openapi::api::core::v1::PodSpec, Void> {}
+impl LoggingObject for Object<k8s_openapi::api::core::v1::PodSpec, NotUsed> {}
 
 
 // api::batch
@@ -198,7 +198,7 @@ k8s_ctor!(VolumeAttachment, "v1", k8s_openapi::api::storage);
 // api::networking::v1
 k8s_obj!("NetworkPolicy", "v1", "networking.k8s.io");
 #[cfg(feature = "openapi")]
-k8s_custom_ctor!(v1NetworkPolicy, Object<k8s_openapi::api::networking::v1::NetworkPolicySpec, Void>); // no status
+k8s_custom_ctor!(v1NetworkPolicy, Object<k8s_openapi::api::networking::v1::NetworkPolicySpec, NotUsed>); // no status
 
 
 // Macro insanity needs some sanity here..


### PR DESCRIPTION
Fixes #133.

Picked `NotUsed` over `Empty` because I think it makes the `FooMeta` pattern
clearer:

```rust
type Foo = Object<FooSpec, FooStatus>;
type FooMeta = Object<NotUsed, NotUsed>;
```

`Empty` sounds like it doesn't exist, `NotUsed` sounds like it might, we just
don't care either way.