### PR TITLE
 Make `Api::create` and `Api::replace` take type-safe `KubeObject`s

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -7,7 +7,7 @@
 #[derive(Clone, Deserialize, Serialize, Default)]
 pub struct NotUsed {}
 
-/// Use [`NotUsed`](notused.struct.html) instead. Renamed to avoid confusion with [`void::Void`](https://docs.rs/void/1.0.2/void/enum.Void.html).
+/// Use [`NotUsed`](struct.NotUsed.html) instead. Renamed to avoid confusion with [`void::Void`](https://docs.rs/void/1.0.2/void/enum.Void.html).
 #[deprecated]
 pub type Void = NotUsed;
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -21,7 +21,7 @@ mod raw;
 pub use raw::{DeleteParams, ListParams, PatchParams, PatchStrategy, PostParams, PropagationPolicy, RawApi};
 
 mod typed;
-pub use typed::Api;
+pub use typed::{Api, SerializeKubeObject};
 
 mod subresource;
 pub use subresource::{LogParams, Scale, ScaleSpec, ScaleStatus};


### PR DESCRIPTION
`Vec<u8>`s are still supported, but deprecated. Sadly, `#[deprecated]` doesn't work for trait impls, so a doccomment was used instead.

Fixes #142.

This is mostly a spike to get feedback on whether it'd be a good idea. The rest of the examples should probably be ported before merging...