### PR TITLE
use TryStream in client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-0.26.0 / 2020-02-XX
+0.26.0 / 2020-02-25
 ===================
+  * Fix a large percentage of EOFs from watches #146
+  * => default timeout down to 290s from 300s
+  * => `Reflector` now re-lists a lot less #146
+  * `Informer::poll` can now be used with `TryStream`
   * Exposed `Config::read` and `Config::read_from` - #124
   * Fix typo on `Api::StatefulSet`
   * Fix typo on `Api::Endpoints`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kube"
-version = "0.25.0"
+version = "0.26.0"
 description = "Kubernetes client in the style of client-go"
 authors = [
   "clux <sszynrae@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ paste = "0.1.6"
 Inflector = "0.11.4"
 
 [dependencies.reqwest]
-version = "0.10.1"
+version = "0.10.2"
 default-features = false
 features = ["json", "gzip", "stream"]
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ rf.state().await.into_iter().for_each(|(name, p)| {
 });
 ```
 
-Note that `poll` holds the future for 300s by default, but you can (and should) get `.state()` from another async context (see reflector examples for how to spawn an async task to do this).
+Note that `poll` holds the future for [290s by default](https://github.com/kubernetes/kubernetes/issues/6513), but you can (and should) get `.state()` from another async context (see reflector examples for how to spawn an async task to do this).
 
 If you need the details of just a single object, you can use the more efficient, `Reflector::get` and `Reflector::get_within`.
 

--- a/examples/pod_informer.rs
+++ b/examples/pod_informer.rs
@@ -11,7 +11,7 @@ type Pod = Object<PodSpec, PodStatus>;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    env::set_var("RUST_LOG", "info,kube=trace");
+    env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
     let config = config::load_kube_config().await?;
     let client = APIClient::new(config);

--- a/examples/pod_informer.rs
+++ b/examples/pod_informer.rs
@@ -1,5 +1,5 @@
 #[macro_use] extern crate log;
-use futures::{TryStreamExt, StreamExt};
+use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::{PodSpec, PodStatus};
 use kube::{
     api::{Api, Informer, Object, WatchEvent},

--- a/examples/pod_informer.rs
+++ b/examples/pod_informer.rs
@@ -1,5 +1,5 @@
 #[macro_use] extern crate log;
-use futures::StreamExt;
+use futures::{TryStreamExt, StreamExt};
 use k8s_openapi::api::core::v1::{PodSpec, PodStatus};
 use kube::{
     api::{Api, Informer, Object, WatchEvent},
@@ -23,8 +23,7 @@ async fn main() -> anyhow::Result<()> {
     loop {
         let mut pods = inf.poll().await?.boxed();
 
-        while let Some(event) = pods.next().await {
-            let event = event?;
+        while let Some(event) = pods.try_next().await? {
             handle_node(&resource, event)?;
         }
     }

--- a/src/api/informer.rs
+++ b/src/api/informer.rs
@@ -7,7 +7,7 @@ use crate::{
     Result,
 };
 
-use futures::{lock::Mutex, Stream, StreamExt};
+use futures::{lock::Mutex, TryStream, StreamExt};
 use futures_timer::Delay;
 use serde::de::DeserializeOwned;
 use std::{sync::Arc, time::Duration};
@@ -138,7 +138,7 @@ where
     /// In the retry/reset cases we wait 10s between each attempt.
     ///
     /// If you need to track the `resourceVersion` you can use `Informer::version()`.
-    pub async fn poll(&self) -> Result<impl Stream<Item = Result<WatchEvent<K>>>> {
+    pub async fn poll(&self) -> Result<impl TryStream<Item = Result<WatchEvent<K>>>> {
         trace!("Watching {:?}", self.resource);
 
         // First check if we need to backoff or reset our resourceVersion from last time

--- a/src/api/informer.rs
+++ b/src/api/informer.rs
@@ -7,7 +7,7 @@ use crate::{
     Result,
 };
 
-use futures::{lock::Mutex, TryStream, StreamExt};
+use futures::{lock::Mutex, StreamExt, TryStream};
 use futures_timer::Delay;
 use serde::de::DeserializeOwned;
 use std::{sync::Arc, time::Duration};

--- a/src/api/informer.rs
+++ b/src/api/informer.rs
@@ -72,7 +72,7 @@ where
     /// Configure the timeout for the list/watch call.
     ///
     /// This limits the duration of the call, regardless of any activity or inactivity.
-    /// Defaults to 300s
+    /// Defaults to 290s
     pub fn timeout(mut self, timeout_secs: u32) -> Self {
         self.params.timeout = Some(timeout_secs);
         self

--- a/src/api/raw.rs
+++ b/src/api/raw.rs
@@ -521,7 +521,7 @@ fn watch_path() {
     let req = r.watch(&gp, "0").unwrap();
     assert_eq!(
         req.uri(),
-        "/api/v1/namespaces/ns/pods?&watch=true&resourceVersion=0&timeoutSeconds=300"
+        "/api/v1/namespaces/ns/pods?&watch=true&resourceVersion=0&timeoutSeconds=290"
     );
 }
 #[test]

--- a/src/api/reflector.rs
+++ b/src/api/reflector.rs
@@ -130,7 +130,8 @@ where
     /// This is meant to be run continually in a thread/task. Spawn one.
     pub async fn poll(&self) -> Result<()> {
         trace!("Watching {:?}", self.resource);
-        if let Err(_e) = self.single_watch().await {
+        if let Err(e) = self.single_watch().await {
+            warn!("Poll error on {:?}: {}: {:?}", self.resource, e, e);
             // If desynched due to mismatching resourceVersion, retry in a bit
             let dur = Duration::from_secs(10);
             Delay::new(dur).await;

--- a/src/api/reflector.rs
+++ b/src/api/reflector.rs
@@ -6,7 +6,7 @@ use crate::{
     client::APIClient,
     Error, Result,
 };
-use futures::{lock::Mutex, TryStreamExt, StreamExt};
+use futures::{lock::Mutex, StreamExt, TryStreamExt};
 use futures_timer::Delay;
 use serde::de::DeserializeOwned;
 

--- a/src/api/reflector.rs
+++ b/src/api/reflector.rs
@@ -84,7 +84,7 @@ where
     /// Configure the timeout for the list/watch call.
     ///
     /// This limits the duration of the call, regardless of any activity or inactivity.
-    /// Defaults to 300s
+    /// Defaults to 290s
     pub fn timeout(mut self, timeout_secs: u32) -> Self {
         self.params.timeout = Some(timeout_secs);
         self

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -165,7 +165,7 @@ impl APIClient {
         // Any reqwest errors will terminate this stream early.
         let stream = futures::stream::try_unfold((res, Vec::new()), |(mut resp, _buff)| {
             async {
-                let mut buff = _buff;
+                let mut buff = _buff; // can be avoided, see #145
                 loop {
                     trace!("Await chunk");
                     match resp.chunk().await {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -156,7 +156,7 @@ impl APIClient {
         T: DeserializeOwned,
     {
         let res: reqwest::Response = self.send(request).await?;
-        debug!("start stream {} {}", res.status().as_str(), res.url());
+        trace!("Streaming from {} -> {}", res.url(), res.status().as_str());
         trace!("headers: {:?}", res.headers());
 
         // Now unfold the chunked responses into a Stream

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -113,7 +113,9 @@ pub async fn create_client_builder(options: ConfigOptions) -> Result<(ClientBuil
         }
     };
 
-    let mut client_builder = Client::builder();
+    let mut client_builder = Client::builder()
+        // hard disallow more than 5 minute polls due to kubernetes limitations
+        .timeout(std::time::Duration::new(295, 0));
 
     for ca in loader.ca_bundle()? {
         client_builder = hacky_cert_lifetime_for_macos(client_builder, &ca);


### PR DESCRIPTION
So that rather than what we have now:

```rust
while let Some(event) = pods.next().await {
    let event = event?;
    handle_node(&resource, event)?;
}
```

we can instead:

```rust
while let Some(event) = pods.try_next().await? {
    handle_node(&resource, event)?;
}
```

you just gotta import the `TryStreamExt` trait.

WIP: See https://docs.rs/futures/0.3.4/futures/stream/trait.TryStreamExt.html#method.try_next
