### PR TITLE
Always reset the Informer version to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 0.27.0 / 2020-02-XX
 ===================
  * `Reflector` + `Informer` moved from `kube::api` to `kube::runtime`
+ * `Informer` now resets the version to 0 rather than dropping events - #134
+   * Removed `Informer::init`, since it is now a no-op when building the `Informer`
 
 0.26.0 / 2020-02-25
 ===================

--- a/examples/event_informer.rs
+++ b/examples/event_informer.rs
@@ -16,7 +16,7 @@ async fn main() -> anyhow::Result<()> {
     let client = APIClient::new(config);
 
     let events = Api::v1Event(client);
-    let ei = Informer::new(events).init().await?;
+    let ei = Informer::new(events);
 
     loop {
         let mut events = ei.poll().await?.boxed();

--- a/examples/node_informer.rs
+++ b/examples/node_informer.rs
@@ -20,10 +20,8 @@ async fn main() -> anyhow::Result<()> {
 
     let nodes = RawApi::v1Node();
     let events = Api::v1Event(client.clone());
-    let ni = Informer::raw(client.clone(), nodes)
+    let ni = Informer::raw(client.clone(), nodes);
         //.labels("beta.kubernetes.io/os=linux")
-        .init()
-        .await?;
 
     loop {
         let mut nodes = ni.poll().await?.boxed();

--- a/examples/pod_informer.rs
+++ b/examples/pod_informer.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
     let namespace = env::var("NAMESPACE").unwrap_or("default".into());
 
     let resource = Api::v1Pod(client.clone()).within(&namespace);
-    let inf = Informer::new(resource.clone()).init().await?;
+    let inf = Informer::new(resource.clone());
 
     loop {
         let mut pods = inf.poll().await?.boxed();

--- a/src/runtime/informer.rs
+++ b/src/runtime/informer.rs
@@ -1,7 +1,7 @@
 use crate::{
     api::{
-        resource::{KubeObject, ObjectList, WatchEvent},
-        Api, ListParams, NotUsed, RawApi,
+        resource::{KubeObject, WatchEvent},
+        Api, ListParams, RawApi,
     },
     client::APIClient,
     Result,
@@ -142,7 +142,7 @@ where
                 Delay::new(dur).await;
                 // If we are outside history, start over from latest
                 if *needs_resync {
-                    self.reset().await?;
+                    self.reset().await;
                 }
                 *needs_resync = false;
                 *needs_retry = false;


### PR DESCRIPTION
Takes "approach 2" from https://github.com/clux/kube-rs/issues/134#issuecomment-589026965, see the noted caveats.

Deletes Informer::init, since it is no longer useful.