### PR TITLE
kube-derive experimentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 default-members = ["kube"]
 members = [
   "kube",
+  "kube-derive",
 ]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ clippy:
 	#rustup component add clippy --toolchain nightly
 	touch kube/src/lib.rs
 	cd kube && cargo +nightly clippy --no-default-features --features=rustls-tls
-	cd kube && cargo +nightly clippy --no-default-features --features=rustls-tls --examples -- --allow clippy::or_fun_call
+	cd kube && cargo +nightly clippy --no-default-features --features=rustls-tls --examples -- --allow clippy::or_fun_call --allow clippy::blacklisted_name
 
 fmt:
 	#rustup component add rustfmt --toolchain nightly

--- a/README.md
+++ b/README.md
@@ -51,6 +51,38 @@ pods.delete("blog", &DeleteParams::default()).await?;
 
 See the examples ending in `_api` examples for more detail.
 
+## Custom Resource Definitions
+Working with custom resources uses automatic code-generation via [proc_macros in kube-derive](./kube-derive). You only need to `#[derive(CustomResource)]` on a struct:
+
+```rust
+#[derive(CustomResource, Serialize, Deserialize, Default, Debug, Clone)]
+#[kube(group = "clux.dev", version = "v1", namespaced)]
+pub struct FooSpec {
+    name: String,
+    info: String,
+}
+```
+
+Then you can use a lot of generated code as:
+
+```rust
+fn main() {
+    let config = config::load_kube_config().await?;
+    let client = APIClient::new(config);
+
+    println!("kind = {}", Foo::KIND); // from k8s_openapi::Resource
+    let foos: Api<Foo> = Api::namespaced(client, "default");
+    let f = Foo {
+        metadata: ObjectMeta::default(),
+        spec: FooSpec::default()
+    };
+    // Print CRD
+    println!("{}", serde_json::to_string_pretty(&foo.crd());
+}
+```
+
+There are a ton of kubebuilder like instructions that you can annotate with here. See the `crd_` prefixed [examples](./kube/examples) for more.
+
 ## Runtime
 The optional `kube::runtime` module contains sets of higher level abstractions on top of the `Api` and `Resource` types so that you don't have to do all the watch book-keeping yourself.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See the examples ending in `_api` examples for more detail.
 Working with custom resources uses automatic code-generation via [proc_macros in kube-derive](./kube-derive). You only need to `#[derive(CustomResource)]` on a struct:
 
 ```rust
-#[derive(CustomResource, Serialize, Deserialize, Default, Debug, Clone)]
+#[derive(CustomResource, Serialize, Deserialize, Default, Clone)]
 #[kube(group = "clux.dev", version = "v1", namespaced)]
 pub struct FooSpec {
     name: String,

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -14,10 +14,6 @@ quote = "1"
 syn = { version = "1", features = ["extra-traits"] }
 Inflector = "0.11.4"
 
-[dev-dependencies.k8s-openapi]
-version = "0.7.1"
-default-features = false
-
 [lib]
 proc-macro = true
 

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -13,7 +13,6 @@ proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["extra-traits"] }
 Inflector = "0.11.4"
-serde_json = "1.0.48"
 
 [dev-dependencies.k8s-openapi]
 version = "0.7.1"

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -17,7 +17,6 @@ Inflector = "0.11.4"
 [dev-dependencies.k8s-openapi]
 version = "0.7.1"
 default-features = false
-features = ["v1_17"]
 
 [lib]
 proc-macro = true

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "kube-derive"
+description = "Custom derives for the kube kubernetes client library"
+version = "0.1.0"
+authors = ["clux <sszynrae@gmail.com>"]
+edition = "2018"
+license = "Apache-2.0"
+repository = "https://github.com/clux/kube-rs"
+readme = "README.md"
+
+[dependencies]
+#http = "0.2"
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "1", features = ["extra-traits"] }
+
+[lib]
+proc-macro = true

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -9,10 +9,20 @@ repository = "https://github.com/clux/kube-rs"
 readme = "README.md"
 
 [dependencies]
-#http = "0.2"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["extra-traits"] }
+Inflector = "0.11.4"
+serde_json = "1.0.48"
+
+[dev-dependencies.k8s-openapi]
+version = "0.7.1"
+default-features = false
+features = ["v1_17"]
 
 [lib]
 proc-macro = true
+
+[features]
+default = []
+unstable-crd = []

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -80,25 +80,21 @@ impl CustomDerive for CustomResource {
                                 return Err(r#"#[kube(version = "...")] expects a string literal value"#)
                                     .spanning(meta);
                             }
-                        } else if meta.path.is_ident("subresource_scale") {
+                        } else if meta.path.is_ident("scale") {
                             if let syn::Lit::Str(lit) = &meta.lit {
                                 scale = Some(lit.value());
                                 continue;
                             } else {
-                                return Err(
-                                    r#"#[kube(subresource_scale = "...")] expects a string literal value"#,
-                                )
-                                .spanning(meta);
+                                return Err(r#"#[kube(scale = "...")] expects a string literal value"#)
+                                    .spanning(meta);
                             }
                         } else if meta.path.is_ident("crd_version") {
                             if let syn::Lit::Str(lit) = &meta.lit {
                                 crd_version = lit.value();
                                 continue;
                             } else {
-                                return Err(
-                                    r#"#[kube(crd_version = "...")] expects a string literal value"#,
-                                )
-                                .spanning(meta);
+                                return Err(r#"#[kube(crd_version = "...")] expects a string literal value"#)
+                                    .spanning(meta);
                             }
                         } else if meta.path.is_ident("printcolumn") {
                             if let syn::Lit::Str(lit) = &meta.lit {
@@ -117,7 +113,7 @@ impl CustomDerive for CustomResource {
                         if path.is_ident("namespaced") {
                             namespaced = true;
                             continue;
-                        } else if path.is_ident("subresource_status") {
+                        } else if path.is_ident("status") {
                             status = true;
                             continue;
                         } else {
@@ -247,7 +243,7 @@ impl CustomDerive for CustomResource {
 
         // Ensure it generates for the correct CRD version
         let v1ident = format_ident!("{}", crd_version);
-        let use_correct_crd = quote !{
+        let use_correct_crd = quote! {
             use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::#v1ident as apiext;
         };
 

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -1,7 +1,7 @@
 use crate::{CustomDerive, ResultExt};
+use inflector::{cases::pascalcase::is_pascal_case, string::pluralize::to_plural};
 use proc_macro2::{Ident, Span};
 use syn::{Data, DeriveInput, Result};
-use inflector::{cases::pascalcase::is_pascal_case, string::pluralize::to_plural};
 
 #[derive(Debug)]
 pub struct CustomResource {
@@ -150,8 +150,10 @@ impl CustomDerive for CustomResource {
             struct_name[..(struct_name.len() - 4)].to_owned()
         };
         if !is_pascal_case(&kind) {
-            return Err(r#"#[derive(CustomResource)] requires a PascalCase `kind = "..."` or PascalCase struct name"#)
-                    .spanning(ident);
+            return Err(
+                r#"#[derive(CustomResource)] requires a PascalCase `kind = "..."` or PascalCase struct name"#,
+            )
+            .spanning(ident);
         }
 
         let mkerror = |arg| {

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -86,8 +86,10 @@ impl CustomDerive for CustomResource {
                                 scale = Some(lit.value());
                                 continue;
                             } else {
-                                return Err(r#"#[kube(subresource_scale = "...")] expects a string literal value"#)
-                                    .spanning(meta);
+                                return Err(
+                                    r#"#[kube(subresource_scale = "...")] expects a string literal value"#,
+                                )
+                                .spanning(meta);
                             }
                         } else if meta.path.is_ident("printcolumn") {
                             if let syn::Lit::Str(lit) = &meta.lit {
@@ -145,7 +147,7 @@ impl CustomDerive for CustomResource {
             printcolums,
             status,
             unstable,
-            scale
+            scale,
         })
     }
 
@@ -161,7 +163,7 @@ impl CustomDerive for CustomResource {
             status,
             printcolums,
             unstable,
-            scale
+            scale,
         } = self;
 
 
@@ -175,10 +177,10 @@ impl CustomDerive for CustomResource {
 
         // if status set, also add that
         let statusq = if status {
-            let ident  = format_ident!("{}{}", kind, "Status");
+            let ident = format_ident!("{}{}", kind, "Status");
             quote! { status: Option<#ident>, }
         } else {
-            quote! { }
+            quote! {}
         };
 
         let root_obj = quote! {
@@ -231,11 +233,7 @@ impl CustomDerive for CustomResource {
 
         // Compute a bunch of crd props
         let printers = format!("[ {} ]", printcolums.join(",")); // hacksss
-        let scale_code = if let Some(s) = scale {
-            s
-        } else {
-            "".to_string()
-        };
+        let scale_code = if let Some(s) = scale { s } else { "".to_string() };
 
         // Ensure it generates for the correct CRD version
         let use_correct_crd = if unstable {

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -262,18 +262,6 @@ impl CustomDerive for CustomResource {
         let plural = to_plural(&name);
         let scope = if namespaced { "Namespaced" } else { "Cluster" };
 
-        // TODO: verify serialize at compile time vs current runtime check..
-        // HOWEVER.. That requires k8s_openapi dep in here..
-        // and we need to define the version feature :/
-        // ... this will clash with user selected feature :(
-        // Sketch:
-        //use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
-        //let crd : CustomResourceDefinition = serde_json::from_value(
-        //    serde_json::json!({})
-        //    ).map_err(|e| format!(r#"#[derive(CustomResource)] was unable to deserialize CustomResourceDefinition: {}"#, e))
-        //.spanning(&tokens)?;
-        //let crd_json = serde_json::to_string(&crd).unwrap();
-
         // Compute a bunch of crd props
         let mut printers = format!("[ {} ]", printcolums.join(",")); // hacksss
         if apiextensions == "v1beta1" {
@@ -298,6 +286,7 @@ impl CustomDerive for CustomResource {
         );
         let crd_meta_name = format!("{}.{}", plural, group);
         let crd_meta = quote! { { "name": #crd_meta_name } };
+        // TODO: should ::crd be from a trait?
         let impl_crd = quote! {
             #use_correct_crd
             impl #rootident {

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -1,0 +1,269 @@
+#![recursion_limit = "1024"]
+#![warn(rust_2018_idioms)]
+#![deny(clippy::all, clippy::pedantic)]
+#![allow(clippy::too_many_lines)]
+
+extern crate proc_macro;
+
+trait CustomDerive: Sized {
+    fn parse(input: syn::DeriveInput, tokens: proc_macro2::TokenStream) -> Result<Self, syn::Error>;
+    fn emit(self) -> Result<proc_macro2::TokenStream, syn::Error>;
+}
+
+fn run_custom_derive<T>(input: proc_macro::TokenStream) -> proc_macro::TokenStream
+where
+    T: CustomDerive,
+{
+    let input: proc_macro2::TokenStream = input.into();
+    let tokens = input.clone();
+    let token_stream = match syn::parse2(input)
+        .and_then(|input| <T as CustomDerive>::parse(input, tokens))
+        .and_then(<T as CustomDerive>::emit)
+    {
+        Ok(token_stream) => token_stream,
+        Err(err) => err.to_compile_error(),
+    };
+    token_stream.into()
+}
+
+trait ResultExt<T> {
+    fn spanning(self, spanned: impl quote::ToTokens) -> Result<T, syn::Error>;
+}
+
+impl<T, E> ResultExt<T> for Result<T, E>
+where
+    E: std::fmt::Display,
+{
+    fn spanning(self, spanned: impl quote::ToTokens) -> Result<T, syn::Error> {
+        self.map_err(|err| syn::Error::new_spanned(spanned, err))
+    }
+}
+
+/// A custom derive for kubernetes custom resource definitions.
+///
+/// This will implement the `k8s_openapi::Metadata` and `k8s_openapi::Resource` traits
+/// so the type can be used with the `kube` crate.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// #[derive(CustomResource, Clone, Debug, PartialEq, Deserialize, Serialize)]
+/// #[kube(group = "clux.dev", version = "v1", plural = "foos", namespaced)]
+/// struct FooSpec {
+///     prop1: String,
+///     prop2: Vec<bool>,
+///     #[serde(skip_serializing_if = "Option::is_none")]
+///     prop3: Option<i32>,
+/// }
+/// ```
+/// Try `cargo-expand` to see your own macro expansion.
+
+#[proc_macro_derive(CustomResource, attributes(kube))]
+pub fn derive_custom_resource(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    run_custom_derive::<CustomResource>(input)
+}
+
+#[derive(Debug)]
+struct CustomResource {
+    ident: proc_macro2::Ident,
+    vis: syn::Visibility,
+    tokens: proc_macro2::TokenStream,
+
+    group: String,
+    version: String,
+    plural: String,
+    namespaced: bool,
+}
+
+// TODO: create root object with ObjectMeta? if so, truncate to prefix (FooSpec -> Foo)
+/// #[derive(Clone, Debug, Default, PartialEq)]
+/// struct FooBar {
+///     metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
+///     spec: Option<FooSpec>,
+/// }
+// maybe we should force root type created? and enforce metadata..
+
+// TODO: impl k8s_openapi::Resource for the root type
+// TODO: impl k8s_openapi::Metadata<Ty=ObjectMeta> for the root type
+// impl serialize in the normal way...
+
+// TODO: infer plural uring Inflector lib (already depend on it)
+
+// TODO: create CRD spec? `apiextensions::CustomResourceDefinition`
+// ^ bother? just do what kubebuilder does for now and chuck json at it..
+// We should define a trait that can return apiextensions::CustomResourceDefinition ?
+// then impl that trait for the the root type?
+
+/// let custom_resource_spec = apiextensions::CustomResourceDefinitionSpec {
+///     group: <FooBar as k8s_openapi::Resource>::GROUP.to_owned(),
+///     names: apiextensions::CustomResourceDefinitionNames {
+///         kind: <FooBar as k8s_openapi::Resource>::KIND.to_owned(),
+///         plural: plural.to_owned(),
+///         short_names: Some(vec!["fb".to_owned()]),
+///         singular: Some("foobar".to_owned()),
+///         ..Default::default()
+///     },
+///     scope: "Namespaced".to_owned(),
+///     version: <FooBar as k8s_openapi::Resource>::VERSION.to_owned().into(),
+///     ..Default::default()
+/// };
+
+/// let custom_resource = apiextensions::CustomResourceDefinition {
+///     metadata: Some(meta::ObjectMeta {
+///         name: Some(format!("{}.{}", plural, <FooBar as k8s_openapi::Resource>::GROUP)),
+///         ..Default::default()
+///     }),
+///     spec: custom_resource_spec.into(),
+///     ..Default::default()
+/// };
+///
+
+impl CustomDerive for CustomResource {
+    fn parse(input: syn::DeriveInput, tokens: proc_macro2::TokenStream) -> Result<Self, syn::Error> {
+        let ident = input.ident;
+        let vis = input.vis;
+
+        let mut group = None;
+        let mut plural = None;
+        let mut version = None;
+
+        let mut namespaced = false;
+
+        for attr in &input.attrs {
+            if attr.style != syn::AttrStyle::Outer {
+                continue;
+            }
+
+            if !attr.path.is_ident("kube") {
+                continue;
+            }
+
+            let metas = match attr.parse_meta()? {
+                syn::Meta::List(meta) => meta.nested,
+                meta => {
+                    return Err(
+                        r#"#[kube] expects a list of metas, like `#[kube(...)]`"#,
+                    )
+                    .spanning(meta)
+                }
+            };
+
+            for meta in metas {
+                let meta: &dyn quote::ToTokens = match &meta {
+                    syn::NestedMeta::Meta(syn::Meta::NameValue(meta)) => {
+                        if meta.path.is_ident("group") {
+                            if let syn::Lit::Str(lit) = &meta.lit {
+                                group = Some(lit.value());
+                                continue;
+                            } else {
+                                return Err(
+                                    r#"#[kube(group = "...")] expects a string literal value"#,
+                                )
+                                .spanning(meta);
+                            }
+                        } else if meta.path.is_ident("plural") {
+                            if let syn::Lit::Str(lit) = &meta.lit {
+                                plural = Some(lit.value());
+                                continue;
+                            } else {
+                                return Err(
+                                    r#"#[kube(plural = "...")] expects a string literal value"#,
+                                )
+                                .spanning(meta);
+                            }
+                        } else if meta.path.is_ident("version") {
+                            if let syn::Lit::Str(lit) = &meta.lit {
+                                version = Some(lit.value());
+                                continue;
+                            } else {
+                                return Err(
+                                    r#"#[kube(version = "...")] expects a string literal value"#,
+                                )
+                                .spanning(meta);
+                            }
+                        } else {
+                            meta
+                        }
+                    }
+
+                    syn::NestedMeta::Meta(syn::Meta::Path(path)) => {
+                        if path.is_ident("namespaced") {
+                            namespaced = true;
+                            continue;
+                        } else {
+                            &meta
+                        }
+                    }
+
+                    meta => meta,
+                };
+
+                return
+                    Err(r#"#[derive(CustomResource)] found unexpected meta. Expected `group = "..."`, `namespaced`, `plural = "..."` or `version = "..."`"#)
+                    .spanning(meta);
+            }
+        }
+
+        let group =
+            group
+            .ok_or(r#"#[derive(CustomResource)] did not find a #[kube(group = "...")] attribute on the struct"#)
+            .spanning(&tokens)?;
+        let version =
+            version
+            .ok_or(r#"#[derive(CustomResource)] did not find a #[kube(version = "...")] attribute on the struct"#)
+            .spanning(&tokens)?;
+        let plural =
+            plural
+            .ok_or(r#"#[derive(CustomResource)] did not find a #[kube(plural = "...")] attribute on the struct"#)
+            .spanning(&tokens)?;
+
+        Ok(CustomResource {
+            ident,
+            vis,
+            tokens,
+
+            group,
+            version,
+            namespaced,
+            plural,
+        })
+    }
+
+    fn emit(self) -> Result<proc_macro2::TokenStream, syn::Error> {
+        let CustomResource {
+            ident: cr_spec_name,
+            vis,
+            tokens,
+            group,
+            version,
+            plural,
+            namespaced,
+        } = self;
+
+        let vis: std::borrow::Cow<'_, str> = match vis {
+            syn::Visibility::Inherited => "".into(),
+            vis => format!("{} ", quote::ToTokens::into_token_stream(vis)).into(),
+        };
+
+        let (cr_spec_name, cr_name) = {
+            let cr_spec_name_string = cr_spec_name.to_string();
+            if !cr_spec_name_string.ends_with("Spec") {
+                return Err("#[derive(CustomResource)] requires the name of the struct to end with `Spec`")
+                    .spanning(cr_spec_name);
+            }
+            let cr_name_string = cr_spec_name_string[..(cr_spec_name_string.len() - 4)].to_owned();
+            (cr_spec_name_string, cr_name_string)
+        };
+
+        let mut out = vec![];
+
+        let out = String::from_utf8(out)
+            .map_err(|err| format!("#[derive(CustomResource)] failed: {}", err))
+            .spanning(&tokens)?;
+        let result = out
+            .parse()
+            .map_err(|err| format!("#[derive(CustomResource)] failed: {:?}", err))
+            .spanning(&tokens)?;
+        Ok(result)
+    }
+}

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -1,16 +1,15 @@
 #![recursion_limit = "1024"]
-#![warn(rust_2018_idioms)]
-#![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::too_many_lines)]
-
 extern crate proc_macro;
+#[macro_use] extern crate quote;
+use proc_macro::TokenStream;
+use syn::Result;
 
 trait CustomDerive: Sized {
-    fn parse(input: syn::DeriveInput, tokens: proc_macro2::TokenStream) -> Result<Self, syn::Error>;
-    fn emit(self) -> Result<proc_macro2::TokenStream, syn::Error>;
+    fn parse(input: syn::DeriveInput, tokens: proc_macro2::TokenStream) -> Result<Self>;
+    fn emit(self) -> Result<proc_macro2::TokenStream>;
 }
 
-fn run_custom_derive<T>(input: proc_macro::TokenStream) -> proc_macro::TokenStream
+fn run_custom_derive<T>(input: TokenStream) -> TokenStream
 where
     T: CustomDerive,
 {
@@ -27,28 +26,34 @@ where
 }
 
 trait ResultExt<T> {
-    fn spanning(self, spanned: impl quote::ToTokens) -> Result<T, syn::Error>;
+    fn spanning(self, spanned: impl quote::ToTokens) -> Result<T>;
 }
 
-impl<T, E> ResultExt<T> for Result<T, E>
+impl<T, E> ResultExt<T> for std::result::Result<T, E>
 where
     E: std::fmt::Display,
 {
-    fn spanning(self, spanned: impl quote::ToTokens) -> Result<T, syn::Error> {
+    fn spanning(self, spanned: impl quote::ToTokens) -> Result<T> {
         self.map_err(|err| syn::Error::new_spanned(spanned, err))
     }
 }
 
+// #[derive(CustomResource)]
+mod custom_resource;
+use custom_resource::CustomResource;
 /// A custom derive for kubernetes custom resource definitions.
 ///
-/// This will implement the `k8s_openapi::Metadata` and `k8s_openapi::Resource` traits
-/// so the type can be used with the `kube` crate.
+/// This will generate a root object that implements the `k8s_openapi::Metadata` and
+/// `k8s_openapi::Resource` traits for this type so it can be used with `kube::Api`
+///
+/// Additionally, it will implement the `kube::CustomResourceDefinition` trait,
+/// which allows posting, or printing the CustomResourceDefinition.
 ///
 /// # Example
 ///
 /// ```rust,ignore
 /// #[derive(CustomResource, Clone, Debug, PartialEq, Deserialize, Serialize)]
-/// #[kube(group = "clux.dev", version = "v1", plural = "foos", namespaced)]
+/// #[kube(group = "clux.dev", version = "v1", namespaced)]
 /// struct FooSpec {
 ///     prop1: String,
 ///     prop2: Vec<bool>,
@@ -56,214 +61,13 @@ where
 ///     prop3: Option<i32>,
 /// }
 /// ```
+///
+/// This example creates a `struct Foo` containing metadata, the spec,
+/// and optionally status.
+///
+///
 /// Try `cargo-expand` to see your own macro expansion.
-
 #[proc_macro_derive(CustomResource, attributes(kube))]
 pub fn derive_custom_resource(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     run_custom_derive::<CustomResource>(input)
-}
-
-#[derive(Debug)]
-struct CustomResource {
-    ident: proc_macro2::Ident,
-    vis: syn::Visibility,
-    tokens: proc_macro2::TokenStream,
-
-    group: String,
-    version: String,
-    plural: String,
-    namespaced: bool,
-}
-
-// TODO: create root object with ObjectMeta? if so, truncate to prefix (FooSpec -> Foo)
-/// #[derive(Clone, Debug, Default, PartialEq)]
-/// struct FooBar {
-///     metadata: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta>,
-///     spec: Option<FooSpec>,
-/// }
-// maybe we should force root type created? and enforce metadata..
-
-// TODO: impl k8s_openapi::Resource for the root type
-// TODO: impl k8s_openapi::Metadata<Ty=ObjectMeta> for the root type
-// impl serialize in the normal way...
-
-// TODO: infer plural uring Inflector lib (already depend on it)
-
-// TODO: create CRD spec? `apiextensions::CustomResourceDefinition`
-// ^ bother? just do what kubebuilder does for now and chuck json at it..
-// We should define a trait that can return apiextensions::CustomResourceDefinition ?
-// then impl that trait for the the root type?
-
-/// let custom_resource_spec = apiextensions::CustomResourceDefinitionSpec {
-///     group: <FooBar as k8s_openapi::Resource>::GROUP.to_owned(),
-///     names: apiextensions::CustomResourceDefinitionNames {
-///         kind: <FooBar as k8s_openapi::Resource>::KIND.to_owned(),
-///         plural: plural.to_owned(),
-///         short_names: Some(vec!["fb".to_owned()]),
-///         singular: Some("foobar".to_owned()),
-///         ..Default::default()
-///     },
-///     scope: "Namespaced".to_owned(),
-///     version: <FooBar as k8s_openapi::Resource>::VERSION.to_owned().into(),
-///     ..Default::default()
-/// };
-
-/// let custom_resource = apiextensions::CustomResourceDefinition {
-///     metadata: Some(meta::ObjectMeta {
-///         name: Some(format!("{}.{}", plural, <FooBar as k8s_openapi::Resource>::GROUP)),
-///         ..Default::default()
-///     }),
-///     spec: custom_resource_spec.into(),
-///     ..Default::default()
-/// };
-///
-
-impl CustomDerive for CustomResource {
-    fn parse(input: syn::DeriveInput, tokens: proc_macro2::TokenStream) -> Result<Self, syn::Error> {
-        let ident = input.ident;
-        let vis = input.vis;
-
-        let mut group = None;
-        let mut plural = None;
-        let mut version = None;
-
-        let mut namespaced = false;
-
-        for attr in &input.attrs {
-            if attr.style != syn::AttrStyle::Outer {
-                continue;
-            }
-
-            if !attr.path.is_ident("kube") {
-                continue;
-            }
-
-            let metas = match attr.parse_meta()? {
-                syn::Meta::List(meta) => meta.nested,
-                meta => {
-                    return Err(
-                        r#"#[kube] expects a list of metas, like `#[kube(...)]`"#,
-                    )
-                    .spanning(meta)
-                }
-            };
-
-            for meta in metas {
-                let meta: &dyn quote::ToTokens = match &meta {
-                    syn::NestedMeta::Meta(syn::Meta::NameValue(meta)) => {
-                        if meta.path.is_ident("group") {
-                            if let syn::Lit::Str(lit) = &meta.lit {
-                                group = Some(lit.value());
-                                continue;
-                            } else {
-                                return Err(
-                                    r#"#[kube(group = "...")] expects a string literal value"#,
-                                )
-                                .spanning(meta);
-                            }
-                        } else if meta.path.is_ident("plural") {
-                            if let syn::Lit::Str(lit) = &meta.lit {
-                                plural = Some(lit.value());
-                                continue;
-                            } else {
-                                return Err(
-                                    r#"#[kube(plural = "...")] expects a string literal value"#,
-                                )
-                                .spanning(meta);
-                            }
-                        } else if meta.path.is_ident("version") {
-                            if let syn::Lit::Str(lit) = &meta.lit {
-                                version = Some(lit.value());
-                                continue;
-                            } else {
-                                return Err(
-                                    r#"#[kube(version = "...")] expects a string literal value"#,
-                                )
-                                .spanning(meta);
-                            }
-                        } else {
-                            meta
-                        }
-                    }
-
-                    syn::NestedMeta::Meta(syn::Meta::Path(path)) => {
-                        if path.is_ident("namespaced") {
-                            namespaced = true;
-                            continue;
-                        } else {
-                            &meta
-                        }
-                    }
-
-                    meta => meta,
-                };
-
-                return
-                    Err(r#"#[derive(CustomResource)] found unexpected meta. Expected `group = "..."`, `namespaced`, `plural = "..."` or `version = "..."`"#)
-                    .spanning(meta);
-            }
-        }
-
-        let group =
-            group
-            .ok_or(r#"#[derive(CustomResource)] did not find a #[kube(group = "...")] attribute on the struct"#)
-            .spanning(&tokens)?;
-        let version =
-            version
-            .ok_or(r#"#[derive(CustomResource)] did not find a #[kube(version = "...")] attribute on the struct"#)
-            .spanning(&tokens)?;
-        let plural =
-            plural
-            .ok_or(r#"#[derive(CustomResource)] did not find a #[kube(plural = "...")] attribute on the struct"#)
-            .spanning(&tokens)?;
-
-        Ok(CustomResource {
-            ident,
-            vis,
-            tokens,
-
-            group,
-            version,
-            namespaced,
-            plural,
-        })
-    }
-
-    fn emit(self) -> Result<proc_macro2::TokenStream, syn::Error> {
-        let CustomResource {
-            ident: cr_spec_name,
-            vis,
-            tokens,
-            group,
-            version,
-            plural,
-            namespaced,
-        } = self;
-
-        let vis: std::borrow::Cow<'_, str> = match vis {
-            syn::Visibility::Inherited => "".into(),
-            vis => format!("{} ", quote::ToTokens::into_token_stream(vis)).into(),
-        };
-
-        let (cr_spec_name, cr_name) = {
-            let cr_spec_name_string = cr_spec_name.to_string();
-            if !cr_spec_name_string.ends_with("Spec") {
-                return Err("#[derive(CustomResource)] requires the name of the struct to end with `Spec`")
-                    .spanning(cr_spec_name);
-            }
-            let cr_name_string = cr_spec_name_string[..(cr_spec_name_string.len() - 4)].to_owned();
-            (cr_spec_name_string, cr_name_string)
-        };
-
-        let mut out = vec![];
-
-        let out = String::from_utf8(out)
-            .map_err(|err| format!("#[derive(CustomResource)] failed: {}", err))
-            .spanning(&tokens)?;
-        let result = out
-            .parse()
-            .map_err(|err| format!("#[derive(CustomResource)] failed: {:?}", err))
-            .spanning(&tokens)?;
-        Ok(result)
-    }
 }

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -46,8 +46,8 @@ use custom_resource::CustomResource;
 /// This will generate a root object that implements the `k8s_openapi::Metadata` and
 /// `k8s_openapi::Resource` traits for this type so it can be used with `kube::Api`
 ///
-/// Additionally, it will implement the `kube::CustomResourceDefinition` trait,
-/// which allows posting, or printing the CustomResourceDefinition.
+/// Additionally, it will implement a `Foo::crd` function which will generate the,
+/// CustomResourceDefinition at the specified api version (or v1 if unspecified).
 ///
 /// # Example
 ///
@@ -64,6 +64,11 @@ use custom_resource::CustomResource;
 ///
 /// This example creates a `struct Foo` containing metadata, the spec,
 /// and optionally status.
+///
+/// The struct should be named MyKindSpec for it to infer the Kind is MyKind normally.
+/// But you can also use an arbitrary name if you supply `#[kube(kind = "MyFoo")]`
+///
+/// Setting printercolumns + subresources are also supported.
 ///
 ///
 /// Try `cargo-expand` to see your own macro expansion.

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -51,11 +51,11 @@ native-tls = ["openssl", "reqwest/native-tls"]
 rustls-tls = ["rustls", "reqwest/rustls-tls"]
 
 [dev-dependencies]
+kube-derive = { path = "../kube-derive" }
 tempfile = "3.1.0"
 env_logger = "0.7.1"
 tokio = { version = "0.2.11", features = ["full"] }
 anyhow = "1.0.26"
-k8s-openapi-derive = "0.7.1"
 
 [dev-dependencies.k8s-openapi]
 version = "0.7.1"

--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate log;
-#[macro_use] extern crate serde_derive;
-#[macro_use] extern crate kube_derive;
 use either::Either::{Left, Right};
+use kube_derive::CustomResource;
+use serde_derive::{Deserialize, Serialize};
 use serde_json::json;
 
 use apiexts::CustomResourceDefinition;

--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -4,8 +4,8 @@
 use either::Either::{Left, Right};
 use serde_json::json;
 
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as apiexts;
 use apiexts::CustomResourceDefinition;
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as apiexts;
 
 use kube::{
     api::{Api, DeleteParams, ListParams, Meta, PatchParams, PostParams},
@@ -17,8 +17,8 @@ use kube::{
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
 #[kube(group = "clux.dev", version = "v1", namespaced)]
 #[kube(crd_version = "v1beta1")]
-#[kube(subresource_status)]
-#[kube(subresource_scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
+#[kube(status)]
+#[kube(scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
 pub struct FooSpec {
     name: String,
     info: String,
@@ -64,10 +64,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create the CRD so we can create Foos in kube
     let foocrd = Foo::crd();
-    info!(
-        "Creating CRD foos.clux.dev: {}",
-        serde_json::to_string_pretty(&foocrd)?
-    );
+    info!("Creating Foo CRD: {}", serde_json::to_string_pretty(&foocrd)?);
     let pp = PostParams::default();
     let patch_params = PatchParams::default();
     match crds.create(&pp, serde_json::to_vec(&foocrd)?).await {

--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -18,7 +18,9 @@ use kube::{
 #[kube(group = "clux.dev", version = "v1", namespaced)]
 #[kube(unstable)] // v1beta1::CustomResourceDefinition
 #[kube(subresource_status)]
-#[kube(subresource_scale = "{\"specReplicasPath\":\".spec.replicas\", \"statusReplicasPath\":\".status.replicas\"}")]
+#[kube(
+    subresource_scale = "{\"specReplicasPath\":\".spec.replicas\", \"statusReplicasPath\":\".status.replicas\"}"
+)]
 pub struct FooSpec {
     name: String,
     info: String,
@@ -64,7 +66,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Create the CRD so we can create Foos in kube
     let foocrd = Foo::crd();
-    info!("Creating CRD foos.clux.dev: {}", serde_json::to_string_pretty(&foocrd)?);
+    info!(
+        "Creating CRD foos.clux.dev: {}",
+        serde_json::to_string_pretty(&foocrd)?
+    );
     let pp = PostParams::default();
     let patch_params = PatchParams::default();
     match crds.create(&pp, serde_json::to_vec(&foocrd)?).await {

--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -18,9 +18,7 @@ use kube::{
 #[kube(group = "clux.dev", version = "v1", namespaced)]
 #[kube(unstable)] // v1beta1::CustomResourceDefinition
 #[kube(subresource_status)]
-#[kube(
-    subresource_scale = "{\"specReplicasPath\":\".spec.replicas\", \"statusReplicasPath\":\".status.replicas\"}"
-)]
+#[kube(subresource_scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
 pub struct FooSpec {
     name: String,
     info: String,

--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -1,27 +1,30 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate serde_derive;
-#[macro_use] extern crate k8s_openapi_derive;
+#[macro_use] extern crate kube_derive;
 use either::Either::{Left, Right};
 use serde_json::json;
 
+// Note: import corresponds to #[kube(unstable)]
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1::CustomResourceDefinition;
 
 use kube::{
-    api::{Api, CustomResource, DeleteParams, ListParams, Meta, PatchParams, PostParams},
+    api::{Api, DeleteParams, ListParams, Meta, PatchParams, PostParams},
     client::APIClient,
     config,
 };
 
 // Own custom resource
-#[derive(CustomResourceDefinition, Deserialize, Serialize, Clone, Debug, PartialEq)]
-#[custom_resource_definition(group = "clux.dev", version = "v1", plural = "foos", namespaced)]
+#[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
+#[kube(group = "clux.dev", version = "v1", namespaced)]
+#[kube(unstable)] // v1beta1::CustomResourceDefinition
+#[kube(subresource_status)]
+#[kube(subresource_scale = "{\"specReplicasPath\":\".spec.replicas\", \"statusReplicasPath\":\".status.replicas\"}")]
 pub struct FooSpec {
     name: String,
     info: String,
     replicas: i32,
 }
 
-// TODO: cannot use status objects with this custom derive impl
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct FooStatus {
     is_bad: bool,
@@ -60,30 +63,8 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // Create the CRD so we can create Foos in kube
-    let foocrd = json!({
-        "metadata": {
-            "name": "foos.clux.dev"
-        },
-        "spec": {
-            "group": "clux.dev",
-            "version": "v1",
-            "scope": "Namespaced",
-            "names": {
-                "plural": "foos",
-                "singular": "foo",
-                "kind": "Foo",
-            },
-            "subresources": {
-                "status": {},
-                "scale": {
-                    "specReplicasPath": ".spec.replicas",
-                    "statusReplicasPath": ".status.replicas",
-                }
-            }
-        },
-    });
-
-    info!("Creating CRD foos.clux.dev");
+    let foocrd = Foo::crd();
+    info!("Creating CRD foos.clux.dev: {}", serde_json::to_string_pretty(&foocrd)?);
     let pp = PostParams::default();
     let patch_params = PatchParams::default();
     match crds.create(&pp, serde_json::to_vec(&foocrd)?).await {
@@ -97,11 +78,7 @@ async fn main() -> anyhow::Result<()> {
 
 
     // Manage the Foo CR
-    let foos: Api<Foo> = CustomResource::kind("Foo")
-        .group("clux.dev")
-        .version("v1")
-        .within(&namespace)
-        .into_api(client.clone());
+    let foos: Api<Foo> = Api::namespaced(client.clone(), &namespace);
 
     // Create Foo baz
     info!("Creating Foo instance baz");
@@ -118,7 +95,7 @@ async fn main() -> anyhow::Result<()> {
     // Verify we can get it
     info!("Get Foo baz");
     let f1cpy = foos.get("baz").await?;
-    assert_eq!(f1cpy.spec.as_ref().unwrap().info, "old baz");
+    assert_eq!(f1cpy.spec.info, "old baz");
 
     // Replace its spec
     info!("Replace Foo baz");
@@ -135,14 +112,13 @@ async fn main() -> anyhow::Result<()> {
     let f1_replaced = foos
         .replace("baz", &pp, serde_json::to_vec(&foo_replace)?)
         .await?;
-    let f1_replacedsspec = f1_replaced.spec.unwrap();
-    assert_eq!(f1_replacedsspec.name, "baz");
-    assert_eq!(f1_replacedsspec.info, "new baz");
-    //assert!(f1_replaced.status.is_none()); TODO: STATUS
+    assert_eq!(f1_replaced.spec.name, "baz");
+    assert_eq!(f1_replaced.spec.info, "new baz");
+    assert!(f1_replaced.status.is_none());
 
     // Delete it
     foos.delete("baz", &dp).await?.map_left(|f1del| {
-        assert_eq!(f1del.spec.unwrap().info, "old baz");
+        assert_eq!(f1del.spec.info, "old baz");
     });
 
 
@@ -159,7 +135,7 @@ async fn main() -> anyhow::Result<()> {
     info!("Created {}", Meta::name(&o));
 
     // Update status on qux
-    /*info!("Replace Status on Foo instance qux");
+    info!("Replace Status on Foo instance qux");
     let fs = json!({
         "apiVersion": "clux.dev/v1",
         "kind": "Foo",
@@ -181,12 +157,12 @@ async fn main() -> anyhow::Result<()> {
     let o = foos
         .patch_status("qux", &patch_params, serde_json::to_vec(&fs)?)
         .await?;
-    info!("Patched status {:?} for {}", o.status, o.metadata.name);
+    info!("Patched status {:?} for {}", o.status, Meta::name(&o));
     assert!(!o.status.unwrap().is_bad);
 
     info!("Get Status on Foo instance qux");
     let o = foos.get_status("qux").await?;
-    info!("Got status {:?} for {}", o.status, Meta::name(&o);
+    info!("Got status {:?} for {}", o.status, Meta::name(&o));
     assert!(!o.status.unwrap().is_bad);
 
     // Check scale subresource:
@@ -204,7 +180,8 @@ async fn main() -> anyhow::Result<()> {
         .await?;
     info!("Patched scale {:?} for {}", o.spec, Meta::name(&o));
     assert_eq!(o.status.unwrap().replicas, 1);
-    assert_eq!(o.spec.replicas.unwrap(), 2); // we only asked for more*/
+    assert_eq!(o.spec.unwrap().replicas.unwrap(), 2); // we only asked for more
+
 
     // Modify a Foo qux with a Patch
     info!("Patch Foo instance qux");
@@ -214,10 +191,9 @@ async fn main() -> anyhow::Result<()> {
     let o = foos
         .patch("qux", &patch_params, serde_json::to_vec(&patch)?)
         .await?;
-    let ospec = o.spec.as_ref().unwrap();
-    info!("Patched {} with new name: {}", Meta::name(&o), ospec.name);
-    assert_eq!(ospec.info, "patched qux");
-    assert_eq!(ospec.name, "qux"); // didn't blat existing params
+    info!("Patched {} with new name: {}", Meta::name(&o), o.spec.name);
+    assert_eq!(o.spec.info, "patched qux");
+    assert_eq!(o.spec.name, "qux"); // didn't blat existing params
 
     // Check we have 1 remaining instance
     let lp = ListParams::default();

--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -16,8 +16,8 @@ use kube::{
 // Own custom resource
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
 #[kube(group = "clux.dev", version = "v1", namespaced)]
-#[kube(crd_version = "v1beta1")]
-#[kube(status)]
+#[kube(apiextensions = "v1beta1")]
+#[kube(status = "FooStatus")]
 #[kube(scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
 pub struct FooSpec {
     name: String,

--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -4,8 +4,8 @@
 use either::Either::{Left, Right};
 use serde_json::json;
 
-// Note: import corresponds to #[kube(unstable)]
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1::CustomResourceDefinition;
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as apiexts;
+use apiexts::CustomResourceDefinition;
 
 use kube::{
     api::{Api, DeleteParams, ListParams, Meta, PatchParams, PostParams},
@@ -16,7 +16,7 @@ use kube::{
 // Own custom resource
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
 #[kube(group = "clux.dev", version = "v1", namespaced)]
-#[kube(unstable)] // v1beta1::CustomResourceDefinition
+#[kube(crd_version = "v1beta1")]
 #[kube(subresource_status)]
 #[kube(subresource_scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
 pub struct FooSpec {

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -4,16 +4,16 @@ use k8s_openapi::Resource;
 use kube::api::ObjectMeta;
 
 
-#[derive(CustomResource, Serialize, Deserialize, Default, Debug, Clone)]
+#[derive(CustomResource, Serialize, Deserialize, Debug, Clone)]
 #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
-#[kube(status)]
+#[kube(status = "FooStatus")]
 #[kube(scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
 #[kube(
     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
 )]
 pub struct MyFoo {
     name: String,
-    info: String,
+    info: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -25,9 +25,61 @@ fn main() {
     println!("Kind {}", Foo::KIND);
     let foo = Foo {
         metadata: ObjectMeta::default(),
-        spec: MyFoo::default(),
+        spec: MyFoo {
+            name: "hi".into(),
+            info: None,
+        },
         status: Some(FooStatus { is_bad: true }),
     };
-    println!("Foo: {:?}", foo);
+    println!("Spec: {:?}", foo.spec);
     println!("Foo CRD: {:?}", Foo::crd());
+}
+
+#[test]
+fn verify_resource() {
+    assert_eq!(Foo::KIND, "Foo");
+    assert_eq!(Foo::GROUP, "clux.dev");
+    assert_eq!(Foo::VERSION, "v1");
+    assert_eq!(Foo::API_VERSION, "clux.dev/v1");
+}
+
+// Verify Foo::crd
+#[test]
+fn verify_crd() {
+    use serde_json::{self, json};
+    let crd = Foo::crd();
+    let output = json!({
+      "apiVersion": "apiextensions.k8s.io/v1",
+      "kind": "CustomResourceDefinition",
+      "metadata": {
+        "name": "foos.clux.dev"
+      },
+      "spec": {
+        "group": "clux.dev",
+        "names": {
+          "kind": "Foo",
+          "plural": "foos",
+          "shortNames": [],
+          "singular": "foo"
+        },
+        "scope": "Namespaced",
+        "versions": [
+          {
+            "additionalPrinterColumns": [
+              {
+                "description": "name of foo",
+                "jsonPath": ".spec.name",
+                "name": "Spec",
+                "type": "string"
+              }
+            ],
+            "name": "v1",
+            "served": true,
+            "storage": true
+          }
+        ]
+      }
+    });
+    let outputcrd = serde_json::from_value(output).expect("expected output is valid");
+    assert_eq!(crd, outputcrd);
 }

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -6,8 +6,12 @@ use kube::api::ObjectMeta;
 #[derive(CustomResource, Serialize, Deserialize, Default, Debug, Clone)]
 #[kube(group = "clux.dev", version = "v1", namespaced)]
 #[kube(subresource_status)]
-#[kube(subresource_scale = "{\"specReplicasPath\":\".spec.replicas\", \"statusReplicasPath\":\".status.replicas\"}")]
-#[kube(printcolumn = "{\"name\":\"Spec\", \"type\":\"string\", \"description\":\"name of foo\", \"jsonPath\":\".spec.name\"}")]
+#[kube(
+    subresource_scale = "{\"specReplicasPath\":\".spec.replicas\", \"statusReplicasPath\":\".status.replicas\"}"
+)]
+#[kube(
+    printcolumn = "{\"name\":\"Spec\", \"type\":\"string\", \"description\":\"name of foo\", \"jsonPath\":\".spec.name\"}"
+)]
 pub struct FooSpec {
     name: String,
     info: String,

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -1,17 +1,19 @@
 #[macro_use] extern crate kube_derive;
+#[macro_use] extern crate serde_derive;
 use k8s_openapi::Resource;
 use kube::api::ObjectMeta;
 
-#[derive(CustomResource, Default, Debug)]
+#[derive(CustomResource, Serialize, Deserialize, Default, Debug, Clone)]
 #[kube(group = "clux.dev", version = "v1", namespaced)]
-#[kube(status)]
-#[kube(printcolumn = "{\"name\":\"Spec\",\"type\": \"string\", \"description\":\"name of foo\",\"jsonPath\": \".spec.name\"}")]
+#[kube(subresource_status)]
+#[kube(subresource_scale = "{\"specReplicasPath\":\".spec.replicas\", \"statusReplicasPath\":\".status.replicas\"}")]
+#[kube(printcolumn = "{\"name\":\"Spec\", \"type\":\"string\", \"description\":\"name of foo\", \"jsonPath\":\".spec.name\"}")]
 pub struct FooSpec {
     name: String,
     info: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FooStatus {
     is_bad: bool,
 }
@@ -24,5 +26,5 @@ fn main() {
         status: Some(FooStatus { is_bad: true }),
     };
     println!("Foo: {:?}", foo);
-    println!("Foo CRD: {:?}", foo.crd());
+    println!("Foo CRD: {:?}", Foo::crd());
 }

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -3,15 +3,13 @@
 use k8s_openapi::Resource;
 use kube::api::ObjectMeta;
 
+
+
 #[derive(CustomResource, Serialize, Deserialize, Default, Debug, Clone)]
 #[kube(group = "clux.dev", version = "v1", namespaced)]
 #[kube(subresource_status)]
-#[kube(
-    subresource_scale = "{\"specReplicasPath\":\".spec.replicas\", \"statusReplicasPath\":\".status.replicas\"}"
-)]
-#[kube(
-    printcolumn = "{\"name\":\"Spec\", \"type\":\"string\", \"description\":\"name of foo\", \"jsonPath\":\".spec.name\"}"
-)]
+#[kube(subresource_scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
+#[kube(printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#)]
 pub struct FooSpec {
     name: String,
     info: String,

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -1,0 +1,27 @@
+#[macro_use] extern crate kube_derive;
+use k8s_openapi::Resource;
+use kube::api::ObjectMeta;
+
+#[derive(CustomResource, Default, Debug)]
+#[kube(group = "clux.dev", version = "v1", namespaced)]
+#[kube(status)]
+pub struct FooSpec {
+    name: String,
+    info: String,
+}
+
+#[derive(Debug)]
+pub struct FooStatus {
+    is_bad: bool,
+}
+
+fn main() {
+    println!("Kind {}", Foo::KIND);
+    let foo = Foo {
+        metadata: ObjectMeta::default(),
+        spec: FooSpec::default(),
+        status: Some(FooStatus { is_bad: true }),
+    };
+    println!("Foo: {:?}", foo);
+    println!("Foo CRD: {:?}", foo.crd());
+}

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -11,7 +11,7 @@ use kube::api::ObjectMeta;
 #[kube(
     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
 )]
-pub struct MyFoo { // arbitrary name due to #[kube(kind = "Foo")]
+pub struct MyFoo {
     name: String,
     info: String,
 }

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -5,13 +5,13 @@ use kube::api::ObjectMeta;
 
 
 #[derive(CustomResource, Serialize, Deserialize, Default, Debug, Clone)]
-#[kube(group = "clux.dev", version = "v1", namespaced)]
+#[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
 #[kube(status)]
 #[kube(scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
 #[kube(
     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
 )]
-pub struct FooSpec {
+pub struct MyFoo { // arbitrary name due to #[kube(kind = "Foo")]
     name: String,
     info: String,
 }
@@ -25,7 +25,7 @@ fn main() {
     println!("Kind {}", Foo::KIND);
     let foo = Foo {
         metadata: ObjectMeta::default(),
-        spec: FooSpec::default(),
+        spec: MyFoo::default(),
         status: Some(FooStatus { is_bad: true }),
     };
     println!("Foo: {:?}", foo);

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -5,6 +5,7 @@ use kube::api::ObjectMeta;
 #[derive(CustomResource, Default, Debug)]
 #[kube(group = "clux.dev", version = "v1", namespaced)]
 #[kube(status)]
+#[kube(printcolumn = "{\"name\":\"Spec\",\"type\": \"string\", \"description\":\"name of foo\",\"jsonPath\": \".spec.name\"}")]
 pub struct FooSpec {
     name: String,
     info: String,

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -1,9 +1,11 @@
-#[macro_use] extern crate kube_derive;
-#[macro_use] extern crate serde_derive;
 use k8s_openapi::Resource;
 use kube::api::ObjectMeta;
+use kube_derive::CustomResource;
+use serde_derive::{Deserialize, Serialize};
 
-
+/// Our spec for Foo
+///
+/// A struct with our chosen Kind will be created for us, using the following kube attrs
 #[derive(CustomResource, Serialize, Deserialize, Debug, Clone)]
 #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
 #[kube(status = "FooStatus")]
@@ -35,14 +37,8 @@ fn main() {
     println!("Foo CRD: {:?}", Foo::crd());
 }
 
-#[test]
-fn verify_resource() {
-    assert_eq!(Foo::KIND, "Foo");
-    assert_eq!(Foo::GROUP, "clux.dev");
-    assert_eq!(Foo::VERSION, "v1");
-    assert_eq!(Foo::API_VERSION, "clux.dev/v1");
-}
 
+// some tests
 // Verify Foo::crd
 #[test]
 fn verify_crd() {
@@ -82,4 +78,12 @@ fn verify_crd() {
     });
     let outputcrd = serde_json::from_value(output).expect("expected output is valid");
     assert_eq!(crd, outputcrd);
+}
+
+#[test]
+fn verify_resource() {
+    assert_eq!(Foo::KIND, "Foo");
+    assert_eq!(Foo::GROUP, "clux.dev");
+    assert_eq!(Foo::VERSION, "v1");
+    assert_eq!(Foo::API_VERSION, "clux.dev/v1");
 }

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -4,12 +4,13 @@ use k8s_openapi::Resource;
 use kube::api::ObjectMeta;
 
 
-
 #[derive(CustomResource, Serialize, Deserialize, Default, Debug, Clone)]
 #[kube(group = "clux.dev", version = "v1", namespaced)]
-#[kube(subresource_status)]
-#[kube(subresource_scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
-#[kube(printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#)]
+#[kube(status)]
+#[kube(scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
+#[kube(
+    printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
+)]
 pub struct FooSpec {
     name: String,
     info: String,

--- a/kube/examples/crd_reflector.rs
+++ b/kube/examples/crd_reflector.rs
@@ -5,7 +5,7 @@ use futures_timer::Delay;
 use std::time::Duration;
 
 use kube::{
-    api::{ListParams, Resource, Meta},
+    api::{ListParams, Meta, Resource},
     client::APIClient,
     config,
     runtime::Reflector,

--- a/kube/src/api/crds.rs
+++ b/kube/src/api/crds.rs
@@ -154,20 +154,8 @@ mod test {
     #[ignore] // circle has no kube config
     async fn convenient_custom_resource() {
         use crate::{api::Api, client::APIClient, config};
-        #[derive(
-            Clone,
-            Debug,
-            PartialEq,
-            k8s_openapi_derive::CustomResourceDefinition,
-            serde_derive::Deserialize,
-            serde_derive::Serialize,
-        )]
-        #[custom_resource_definition(
-            group = "k8s-openapi-tests-custom-resource-definition.com",
-            version = "v1",
-            plural = "foobars",
-            namespaced
-        )]
+        #[derive(Clone, Debug, PartialEq, kube_derive::CustomResource, Deserialize, Serialize)]
+        #[kube(group = "clux.dev", version = "v1", plural = "foos", namespaced)]
         struct FooSpec {
             foo: String,
         };
@@ -179,5 +167,6 @@ mod test {
             .within("myns")
             .build()
             .into_api(client);
+        // ^ ensures that traits are implemented
     }
 }

--- a/kube/src/api/crds.rs
+++ b/kube/src/api/crds.rs
@@ -164,7 +164,7 @@ mod test {
         let client = APIClient::new(config);
         let r1: Api<Foo> = Api::namespaced(client.clone(), "myns");
 
-        let r2 : Api<Foo> = CustomResource::kind("Foo")
+        let r2: Api<Foo> = CustomResource::kind("Foo")
             .group("clux.dev")
             .version("v1")
             .within("myns")

--- a/kube/src/api/mod.rs
+++ b/kube/src/api/mod.rs
@@ -4,7 +4,7 @@
 ///
 /// Not using [`()`](https://doc.rust-lang.org/stable/std/primitive.unit.html), because serde's
 /// [`Deserialize`](https://docs.rs/serde/1.0.104/serde/trait.Deserialize.html) `impl` is too strict.
-#[derive(Clone, Deserialize, Serialize, Default)]
+#[derive(Clone, Deserialize, Serialize, Default, Debug)]
 pub struct NotUsed {}
 
 pub(crate) mod resource;

--- a/kube/src/config/kube_config.rs
+++ b/kube/src/config/kube_config.rs
@@ -104,7 +104,7 @@ impl KubeConfigLoader {
             .map_err(|e| Error::SslError(format!("{}", e)))?;
 
         if bundle.is_none() {
-            return Ok(None)
+            return Ok(None);
         }
         let bundle = bundle.unwrap();
 
@@ -125,7 +125,7 @@ impl KubeConfigLoader {
         let bundle = self.cluster.load_certificate_authority()?;
 
         if bundle.is_none() {
-            return Ok(None)
+            return Ok(None);
         }
         let bundle = bundle.unwrap();
 

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -59,6 +59,7 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 pub mod api;
+pub use api::{Api, Resource};
 pub mod client;
 pub mod config;
 mod oauth2;


### PR DESCRIPTION
For #159

This might not be the way to go, but at least it's a way to learn how to do proc-macros. It's daunting to try and fix stuff in the existing `k8s-openapi-derive` crate, but might still do that.

For now, this serves as failing tests. We've ripped out everything but arg parsing from the original crate. We don't need api integration with `k8s_openapi`, nor the swagger validation at the moment, but would like a more kubebuilder like setup (but typesafe).

Some open questions;

- should we enforce you generate the root type of a FooSpec?
- if FooSpec then howto FooStatus
- would be nice to not have the root type opaque..
- How to access the generated CRD (so we can install it)? trait CRD+ impl via derive on root obj?
- use inflector library to infer plural? seems to work well so far..

- how about openapi validation? the existing codegen for it was... intense. but it would be nice to have, at laest if the [crd](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/)  can derive the [latest structural schema types](https://kubernetes.io/blog/2019/06/20/crd-structural-schema/) - however might have better solns via 
#129

Then the two things we defo have to do:

- `impl k8s_openapi::Resource` for the root type
- `impl k8s_openapi::Metadata<Ty=ObjectMeta>` for the root type

NB: based on [k8s-openapi-derive](https://arnavion.github.io/k8s-openapi/v0.7.x/k8s_openapi_derive/derive.CustomResourceDefinition.html) ([src](https://github.com/Arnavion/k8s-openapi/tree/master/k8s-openapi-derive/src))