### PR TITLE
Informer::poll() should return a Stream, not a TryStream

### DIFF
--- a/kube/src/runtime/informer.rs
+++ b/kube/src/runtime/informer.rs
@@ -4,7 +4,7 @@ use crate::{
     Result,
 };
 
-use futures::{lock::Mutex, StreamExt, TryStream};
+use futures::{lock::Mutex, Stream, StreamExt};
 use futures_timer::Delay;
 use serde::de::DeserializeOwned;
 use std::{sync::Arc, time::Duration};
@@ -70,7 +70,7 @@ where
     /// In the retry/reset cases we wait 10s between each attempt.
     ///
     /// If you need to track the `resourceVersion` you can use `Informer::version()`.
-    pub async fn poll(&self) -> Result<impl TryStream<Item = Result<WatchEvent<K>>>> {
+    pub async fn poll(&self) -> Result<impl Stream<Item = Result<WatchEvent<K>>>> {
         trace!("Watching {}", self.resource.kind);
 
         // First check if we need to backoff or reset our resourceVersion from last time


### PR DESCRIPTION
`X: TryStream<Item = Result<A, B>>` doesn't imply that `X::Ok = A` or `X::Error = B`, which breaks any utility methods that depend on `X::Ok` or `X::Error`. It also doesn't help anyway, since `TryStream` has a blanket impl for `Stream<Item = Result<..>>` that does constrain these correctly.