### PR TITLE
[0.27.x] Rename all ObjectMeta fields to camelCase

### DIFF
--- a/src/api/metadata.rs
+++ b/src/api/metadata.rs
@@ -35,6 +35,7 @@ use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
 /// Generally maps and vecs are moved out of their Options to avoid unnecessary boxing
 /// because `xs.is_none()` is often functionally equivalent to `xs.is_empty()`.
 #[derive(Deserialize, Serialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct ObjectMeta {
     /// The unique name (within namespace) for a resource
     ///


### PR DESCRIPTION
Otherwise multi-word fields (like `deletion_timestamp`) get stuck as `None`.

This is moot after #157, but it might be nice for a 0.27.1 while waiting for #161 to stabilize.