### PR TITLE
add typemeta for kube-derived CustomResource objects - fixes #170

### DIFF
--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -233,10 +233,27 @@ impl CustomDerive for CustomResource {
 
         let root_obj = quote! {
             #[derive(Serialize, Deserialize, Clone)]
+            #[serde(rename_all = "camelCase")]
             pub struct #rootident {
+                #visibility api_version: String,
+                #visibility kind: String,
                 #visibility metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
                 #visibility spec: #ident,
                 #statusq
+            }
+            impl #rootident {
+                pub fn new(name: &str, spec: #ident) -> Self {
+                    Self {
+                        api_version: #rootident::API_VERSION.to_string(),
+                        kind: #rootident::KIND.to_string(),
+                        metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                            name: Some(name.to_string()),
+                            ..Default::default()
+                        },
+                        spec: spec,
+                        status: None,
+                    }
+                }
             }
         };
 

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -223,18 +223,22 @@ impl CustomDerive for CustomResource {
         let rootident = Ident::new(&kind, Span::call_site());
 
         // if status set, also add that
-        let statusq = if let Some(status_name) = &status {
+        let (statusq, statusdef) = if let Some(status_name) = &status {
             let ident = format_ident!("{}", status_name);
-            quote! { #visibility status: Option<#ident>, }
+            let fst = quote! { #visibility status: Option<#ident>, };
+            let snd = quote! { status: None, };
+            (fst, snd)
         } else {
-            quote! {}
+            let fst = quote! {};
+            let snd = quote! {};
+            (fst, snd)
         };
         let has_status = status.is_some();
 
         let root_obj = quote! {
             #[derive(Serialize, Deserialize, Clone)]
             #[serde(rename_all = "camelCase")]
-            pub struct #rootident {
+            #visibility struct #rootident {
                 #visibility api_version: String,
                 #visibility kind: String,
                 #visibility metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
@@ -244,14 +248,14 @@ impl CustomDerive for CustomResource {
             impl #rootident {
                 pub fn new(name: &str, spec: #ident) -> Self {
                     Self {
-                        api_version: #rootident::API_VERSION.to_string(),
-                        kind: #rootident::KIND.to_string(),
+                        api_version: <#rootident as k8s_openapi::Resource>::API_VERSION.to_string(),
+                        kind: <#rootident as k8s_openapi::Resource>::KIND.to_string(),
                         metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
                             name: Some(name.to_string()),
                             ..Default::default()
                         },
                         spec: spec,
-                        status: None,
+                        #statusdef
                     }
                 }
             }

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -1,5 +1,4 @@
 use k8s_openapi::Resource;
-use kube::api::ObjectMeta;
 use kube_derive::CustomResource;
 use serde_derive::{Deserialize, Serialize};
 
@@ -25,14 +24,11 @@ pub struct FooStatus {
 
 fn main() {
     println!("Kind {}", Foo::KIND);
-    let foo = Foo {
-        metadata: ObjectMeta::default(),
-        spec: MyFoo {
-            name: "hi".into(),
-            info: None,
-        },
-        status: Some(FooStatus { is_bad: true }),
-    };
+    let mut foo = Foo::new("hi", MyFoo {
+        name: "hi".into(),
+        info: None,
+    });
+    foo.status = Some(FooStatus { is_bad: true });
     println!("Spec: {:?}", foo.spec);
     println!("Foo CRD: {:?}", Foo::crd());
 }

--- a/kube/src/api/metadata.rs
+++ b/kube/src/api/metadata.rs
@@ -1,23 +1,6 @@
 pub use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ListMeta, ObjectMeta};
 use k8s_openapi::Metadata;
 
-
-#[derive(Deserialize, Serialize, Clone, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct TypeMeta {
-    /// The version of the API
-    ///
-    /// Marked optional because it's not always present for items in a `ResourceList`
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub api_version: Option<String>,
-
-    /// The name of the API
-    ///
-    /// Marked optional because it's not always present for items in a `ResourceList`
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub kind: Option<String>,
-}
-
 /// An accessor trait for Metadata
 ///
 /// This for a subset of kubernetes type that do not end in List

--- a/kube/src/api/mod.rs
+++ b/kube/src/api/mod.rs
@@ -1,6 +1,6 @@
 //! API helpers
 
-/// Empty struct for when no Spec is required
+/// Empty struct for when data should be discarded
 ///
 /// Not using [`()`](https://doc.rust-lang.org/stable/std/primitive.unit.html), because serde's
 /// [`Deserialize`](https://docs.rs/serde/1.0.104/serde/trait.Deserialize.html) `impl` is too strict.
@@ -25,4 +25,4 @@ pub(crate) mod object;
 pub use self::object::{ObjectList, WatchEvent};
 
 mod metadata;
-pub use self::metadata::{ListMeta, Meta, ObjectMeta, TypeMeta};
+pub use self::metadata::{ListMeta, Meta, ObjectMeta};


### PR DESCRIPTION
did it in a way that still does not depend on kube.

also adds a Foo::new method on the created object - for #167