### PR TITLE
separate seralization type from the api resource type - #142

### DIFF
--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -40,34 +40,40 @@ async fn main() -> anyhow::Result<()> {
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // Manage CRDs first
-    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    let crds = Api::all::<CustomResourceDefinition>(client.clone());
 
     // Delete any old versions of it first:
     let dp = DeleteParams::default();
     // but ignore delete err if not exists
-    let _ = crds.delete("foos.clux.dev", &dp).await.map(|res| {
-        res.map_left(|o| {
-            info!(
-                "Deleted {}: ({:?})",
-                Meta::name(&o),
-                o.status.unwrap().conditions.unwrap().last()
-            );
-            // NB: PropagationPolicy::Foreground doesn't cause us to block here
-            // we have to watch for it explicitly.. but this is a demo:
-            std::thread::sleep(std::time::Duration::from_millis(1000));
-        })
-        .map_right(|s| {
-            // it's gone.
-            info!("Deleted foos.clux.dev: ({:?})", s);
-        })
-    });
+    let _ = crds
+        .delete::<CustomResourceDefinition>("foos.clux.dev", &dp)
+        .await
+        .map(|res| {
+            res.map_left(|o| {
+                info!(
+                    "Deleted {}: ({:?})",
+                    Meta::name(&o),
+                    o.status.unwrap().conditions.unwrap().last()
+                );
+                // NB: PropagationPolicy::Foreground doesn't cause us to block here
+                // we have to watch for it explicitly.. but this is a demo:
+                std::thread::sleep(std::time::Duration::from_millis(1000));
+            })
+            .map_right(|s| {
+                // it's gone.
+                info!("Deleted foos.clux.dev: ({:?})", s);
+            })
+        });
 
     // Create the CRD so we can create Foos in kube
     let foocrd = Foo::crd();
     info!("Creating Foo CRD: {}", serde_json::to_string_pretty(&foocrd)?);
     let pp = PostParams::default();
     let patch_params = PatchParams::default();
-    match crds.create(&pp, serde_json::to_vec(&foocrd)?).await {
+    match crds
+        .create::<CustomResourceDefinition>(&pp, serde_json::to_vec(&foocrd)?)
+        .await
+    {
         Ok(o) => {
             info!("Created {} ({:?})", Meta::name(&o), o.status.unwrap());
             debug!("Created CRD: {:?}", o.spec);
@@ -78,7 +84,7 @@ async fn main() -> anyhow::Result<()> {
 
 
     // Manage the Foo CR
-    let foos: Api<Foo> = Api::namespaced(client.clone(), &namespace);
+    let foos = Api::namespaced::<Foo>(client.clone(), &namespace);
 
     // Create Foo baz
     info!("Creating Foo instance baz");
@@ -88,13 +94,13 @@ async fn main() -> anyhow::Result<()> {
         "metadata": { "name": "baz" },
         "spec": { "name": "baz", "info": "old baz", "replicas": 1 },
     });
-    let o = foos.create(&pp, serde_json::to_vec(&f1)?).await?;
+    let o = foos.create::<Foo>(&pp, serde_json::to_vec(&f1)?).await?;
     assert_eq!(f1["metadata"]["name"], Meta::name(&o));
     info!("Created {}", Meta::name(&o));
 
     // Verify we can get it
     info!("Get Foo baz");
-    let f1cpy = foos.get("baz").await?;
+    let f1cpy = foos.get::<Foo>("baz").await?;
     assert_eq!(f1cpy.spec.info, "old baz");
 
     // Replace its spec
@@ -110,14 +116,14 @@ async fn main() -> anyhow::Result<()> {
         "spec": { "name": "baz", "info": "new baz", "replicas": 1 },
     });
     let f1_replaced = foos
-        .replace("baz", &pp, serde_json::to_vec(&foo_replace)?)
+        .replace::<Foo>("baz", &pp, serde_json::to_vec(&foo_replace)?)
         .await?;
     assert_eq!(f1_replaced.spec.name, "baz");
     assert_eq!(f1_replaced.spec.info, "new baz");
     assert!(f1_replaced.status.is_none());
 
     // Delete it
-    foos.delete("baz", &dp).await?.map_left(|f1del| {
+    foos.delete::<Foo>("baz", &dp).await?.map_left(|f1del| {
         assert_eq!(f1del.spec.info, "old baz");
     });
 
@@ -131,7 +137,7 @@ async fn main() -> anyhow::Result<()> {
         "spec": FooSpec { name: "qux".into(), replicas: 0, info: "unpatched qux".into() },
         "status": FooStatus::default(),
     });
-    let o = foos.create(&pp, serde_json::to_vec(&f2)?).await?;
+    let o = foos.create::<Foo>(&pp, serde_json::to_vec(&f2)?).await?;
     info!("Created {}", Meta::name(&o));
 
     // Update status on qux
@@ -146,7 +152,9 @@ async fn main() -> anyhow::Result<()> {
         },
         "status": FooStatus { is_bad: true, replicas: 0 }
     });
-    let o = foos.replace_status("qux", &pp, serde_json::to_vec(&fs)?).await?;
+    let o = foos
+        .replace_status::<Foo>("qux", &pp, serde_json::to_vec(&fs)?)
+        .await?;
     info!("Replaced status {:?} for {}", o.status, Meta::name(&o));
     assert!(o.status.unwrap().is_bad);
 
@@ -155,19 +163,19 @@ async fn main() -> anyhow::Result<()> {
         "status": FooStatus { is_bad: false, replicas: 1 }
     });
     let o = foos
-        .patch_status("qux", &patch_params, serde_json::to_vec(&fs)?)
+        .patch_status::<Foo>("qux", &patch_params, serde_json::to_vec(&fs)?)
         .await?;
     info!("Patched status {:?} for {}", o.status, Meta::name(&o));
     assert!(!o.status.unwrap().is_bad);
 
     info!("Get Status on Foo instance qux");
-    let o = foos.get_status("qux").await?;
+    let o = foos.get_status::<Foo>("qux").await?;
     info!("Got status {:?} for {}", o.status, Meta::name(&o));
     assert!(!o.status.unwrap().is_bad);
 
     // Check scale subresource:
     info!("Get Scale on Foo instance qux");
-    let scale = foos.get_scale("qux").await?;
+    let scale = foos.get_scale::<Foo>("qux").await?;
     info!("Got scale {:?} - {:?}", scale.spec, scale.status);
     assert_eq!(scale.status.unwrap().replicas, 1);
 
@@ -176,7 +184,7 @@ async fn main() -> anyhow::Result<()> {
         "spec": { "replicas": 2 }
     });
     let o = foos
-        .patch_scale("qux", &patch_params, serde_json::to_vec(&fs)?)
+        .patch_scale::<Foo>("qux", &patch_params, serde_json::to_vec(&fs)?)
         .await?;
     info!("Patched scale {:?} for {}", o.spec, Meta::name(&o));
     assert_eq!(o.status.unwrap().replicas, 1);
@@ -189,7 +197,7 @@ async fn main() -> anyhow::Result<()> {
         "spec": { "info": "patched qux" }
     });
     let o = foos
-        .patch("qux", &patch_params, serde_json::to_vec(&patch)?)
+        .patch::<Foo>("qux", &patch_params, serde_json::to_vec(&patch)?)
         .await?;
     info!("Patched {} with new name: {}", Meta::name(&o), o.spec.name);
     assert_eq!(o.spec.info, "patched qux");
@@ -197,14 +205,14 @@ async fn main() -> anyhow::Result<()> {
 
     // Check we have 1 remaining instance
     let lp = ListParams::default();
-    let res = foos.list(&lp).await?;
+    let res = foos.list::<Foo>(&lp).await?;
     assert_eq!(res.items.len(), 1);
 
     // Delete the last - expect a status back (instant delete)
-    assert!(foos.delete("qux", &dp).await?.is_right());
+    assert!(foos.delete::<Foo>("qux", &dp).await?.is_right());
 
     // Cleanup the full collection - expect a wait
-    match foos.delete_collection(&lp).await? {
+    match foos.delete_collection::<Foo>(&lp).await? {
         Left(list) => {
             let deleted: Vec<_> = list.iter().map(Meta::name).collect();
             info!("Deleted collection of foos: {:?}", deleted);

--- a/kube/examples/job_api.rs
+++ b/kube/examples/job_api.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create a Job
     let job_name = "empty-job";
-    let my_job = json!({
+    let my_job: Job = serde_json::from_value(json!({
         "apiVersion": "batch/v1",
         "kind": "Job",
         "metadata": {
@@ -39,13 +39,12 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         }
-    });
+    }))?;
 
     let jobs = Api::namespaced::<Job>(client, &namespace);
     let pp = PostParams::default();
 
-    let data = serde_json::to_vec(&my_job)?;
-    jobs.create::<Job>(&pp, data).await?;
+    jobs.create::<Job>(&pp, &my_job).await?;
 
     // See if it ran to completion
     let lp = ListParams::default()

--- a/kube/examples/log_stream.rs
+++ b/kube/examples/log_stream.rs
@@ -22,11 +22,11 @@ async fn main() -> Result<()> {
         .ok_or_else(|| anyhow!("Usage: log_follow <pod>"))?;
     info!("Fetching logs for {:?} in {}", mypod, namespace);
 
-    let pods: Api<Pod> = Api::namespaced(client, &namespace);
+    let pods = Api::namespaced::<Pod>(client, &namespace);
     let mut lp = LogParams::default();
     lp.follow = true;
     lp.tail_lines = Some(1);
-    let mut logs = pods.log_stream(&mypod, &lp).await?.boxed();
+    let mut logs = pods.log_stream::<Pod>(&mypod, &lp).await?.boxed();
 
     while let Some(line) = logs.try_next().await? {
         println!("{:?}", String::from_utf8_lossy(&line));

--- a/kube/examples/node_informer.rs
+++ b/kube/examples/node_informer.rs
@@ -16,7 +16,7 @@ async fn main() -> anyhow::Result<()> {
     let client = APIClient::new(config);
 
     let nodes = Resource::all::<Node>();
-    let events: Api<Event> = Api::all(client.clone());
+    let events = Api::all::<Event>(client.clone());
 
     let lp = ListParams::default().labels("beta.kubernetes.io/os=linux");
     let ni = Informer::new(client.clone(), lp, nodes);
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 // This function lets the app handle an event from kube
-async fn handle_nodes(events: &Api<Event>, ne: WatchEvent<Node>) -> anyhow::Result<()> {
+async fn handle_nodes(events: &Api, ne: WatchEvent<Node>) -> anyhow::Result<()> {
     match ne {
         WatchEvent::Added(o) => {
             info!("New Node: {}", o.spec.unwrap().provider_id.unwrap());
@@ -58,7 +58,7 @@ async fn handle_nodes(events: &Api<Event>, ne: WatchEvent<Node>) -> anyhow::Resu
                 // Find events related to this node
                 let opts = ListParams::default()
                     .fields(&format!("involvedObject.kind=Node,involvedObject.name={}", name));
-                let evlist = events.list(&opts).await?;
+                let evlist = events.list::<Event>(&opts).await?;
                 for e in evlist {
                     warn!("Node event: {:?}", serde_json::to_string_pretty(&e)?);
                 }

--- a/kube/examples/pod_api.rs
+++ b/kube/examples/pod_api.rs
@@ -21,7 +21,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create Pod blog
     info!("Creating Pod instance blog");
-    let p = json!({
+    let p: Pod = serde_json::from_value(json!({
         "apiVersion": "v1",
         "kind": "Pod",
         "metadata": { "name": "blog" },
@@ -31,13 +31,13 @@ async fn main() -> anyhow::Result<()> {
               "image": "clux/blog:0.1.0"
             }],
         }
-    });
+    }))?;
 
     let pp = PostParams::default();
-    match pods.create::<Pod>(&pp, serde_json::to_vec(&p)?).await {
+    match pods.create::<Pod>(&pp, &p).await {
         Ok(o) => {
             let name = Meta::name(&o);
-            assert_eq!(p["metadata"]["name"], name);
+            assert_eq!(Meta::name(&p), name);
             info!("Created {}", name);
             // wait for it..
             std::thread::sleep(std::time::Duration::from_millis(5_000));

--- a/kube/src/api/crds.rs
+++ b/kube/src/api/crds.rs
@@ -3,7 +3,6 @@ use crate::{
     client::APIClient,
 };
 use inflector::{cases::pascalcase::is_pascal_case, string::pluralize::to_plural};
-use std::marker::PhantomData;
 
 /// A data equivalent of the Resource trait for for Custom Resources
 ///
@@ -91,12 +90,11 @@ impl CrBuilder {
     }
 
     // Consume the CrBuilder and convert to an Api object
-    pub fn into_api<K>(self, client: APIClient) -> Api<K> {
+    pub fn into_api(self, client: APIClient) -> Api {
         let crd = self.build();
         Api {
             client,
             api: crd.into(),
-            phantom: PhantomData,
         }
     }
 
@@ -122,11 +120,10 @@ impl From<CustomResource> for Resource {
 
 /// Make Api useable on CRDs without k8s_openapi
 impl CustomResource {
-    pub fn into_api<K>(self, client: APIClient) -> Api<K> {
+    pub fn into_api(self, client: APIClient) -> Api {
         Api {
             client,
             api: self.into(),
-            phantom: PhantomData,
         }
     }
 }
@@ -162,9 +159,9 @@ mod test {
         };
         let config = config::load_kube_config().await.unwrap();
         let client = APIClient::new(config);
-        let r1: Api<Foo> = Api::namespaced(client.clone(), "myns");
+        let r1 = Api::namespaced::<Foo>(client.clone(), "myns");
 
-        let r2: Api<Foo> = CustomResource::kind("Foo")
+        let r2 = CustomResource::kind("Foo")
             .group("clux.dev")
             .version("v1")
             .within("myns")

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -15,21 +15,27 @@ pub use k8s_openapi::api::autoscaling::v1::{Scale, ScaleSpec, ScaleStatus};
 /// Scale subresource
 ///
 /// https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#scale-subresource
-impl<K> Api<K>
-where
-    K: Clone + DeserializeOwned,
-{
-    pub async fn get_scale(&self, name: &str) -> Result<Scale> {
+impl Api {
+    pub async fn get_scale<K>(&self, name: &str) -> Result<Scale>
+    where
+        K: Clone + DeserializeOwned,
+    {
         let req = self.api.get_scale(name)?;
         self.client.request::<Scale>(req).await
     }
 
-    pub async fn patch_scale(&self, name: &str, pp: &PatchParams, patch: Vec<u8>) -> Result<Scale> {
+    pub async fn patch_scale<K>(&self, name: &str, pp: &PatchParams, patch: Vec<u8>) -> Result<Scale>
+    where
+        K: Clone + DeserializeOwned,
+    {
         let req = self.api.patch_scale(name, &pp, patch)?;
         self.client.request::<Scale>(req).await
     }
 
-    pub async fn replace_scale(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<Scale> {
+    pub async fn replace_scale<K>(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<Scale>
+    where
+        K: Clone + DeserializeOwned,
+    {
         let req = self.api.replace_scale(name, &pp, data)?;
         self.client.request::<Scale>(req).await
     }
@@ -41,21 +47,27 @@ where
 /// Status subresource
 ///
 /// https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#status-subresource
-impl<K> Api<K>
-where
-    K: Clone + DeserializeOwned,
-{
-    pub async fn get_status(&self, name: &str) -> Result<K> {
+impl Api {
+    pub async fn get_status<K>(&self, name: &str) -> Result<K>
+    where
+        K: Clone + DeserializeOwned,
+    {
         let req = self.api.get_status(name)?;
         self.client.request::<K>(req).await
     }
 
-    pub async fn patch_status(&self, name: &str, pp: &PatchParams, patch: Vec<u8>) -> Result<K> {
+    pub async fn patch_status<K>(&self, name: &str, pp: &PatchParams, patch: Vec<u8>) -> Result<K>
+    where
+        K: Clone + DeserializeOwned,
+    {
         let req = self.api.patch_status(name, &pp, patch)?;
         self.client.request::<K>(req).await
     }
 
-    pub async fn replace_status(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<K> {
+    pub async fn replace_status<K>(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<K>
+    where
+        K: Clone + DeserializeOwned,
+    {
         let req = self.api.replace_status(name, &pp, data)?;
         self.client.request::<K>(req).await
     }
@@ -150,16 +162,19 @@ pub trait LoggingObject {}
 
 impl LoggingObject for k8s_openapi::api::core::v1::Pod {}
 
-impl<K> Api<K>
-where
-    K: Clone + DeserializeOwned + LoggingObject,
-{
-    pub async fn log(&self, name: &str, lp: &LogParams) -> Result<String> {
+impl Api {
+    pub async fn log<K>(&self, name: &str, lp: &LogParams) -> Result<String>
+    where
+        K: Clone + DeserializeOwned + LoggingObject,
+    {
         let req = self.api.logs(name, lp)?;
         Ok(self.client.request_text(req).await?)
     }
 
-    pub async fn log_stream(&self, name: &str, lp: &LogParams) -> Result<impl Stream<Item = Result<Bytes>>> {
+    pub async fn log_stream<K>(&self, name: &str, lp: &LogParams) -> Result<impl Stream<Item = Result<Bytes>>>
+    where
+        K: Clone + DeserializeOwned + LoggingObject,
+    {
         let req = self.api.logs(name, lp)?;
         Ok(self.client.request_text_stream(req).await?)
     }

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -1,7 +1,6 @@
 use either::Either;
 use futures::{Stream, StreamExt};
 use serde::de::DeserializeOwned;
-use std::marker::PhantomData;
 
 use crate::{
     api::{DeleteParams, ListParams, Meta, ObjectList, PatchParams, PostParams, Resource, WatchEvent},
@@ -20,82 +19,96 @@ use crate::{
 /// - openapi types can be annoying to wrangle with their heavy Option use
 /// - no control over requests (opinionated)
 #[derive(Clone)]
-pub struct Api<K> {
+pub struct Api {
     /// The request creator object
     pub(crate) api: Resource,
     /// The client to use (from this library)
     pub(crate) client: APIClient,
-    /// Underlying Object unstored
-    pub(crate) phantom: PhantomData<K>,
 }
 
 /// Expose same interface as Api for controlling scope/group/versions/ns
-impl<K> Api<K>
-where
-    K: k8s_openapi::Resource,
-{
+impl Api {
     /// Cluster level resources, or resources viewed across all namespaces
-    pub fn all(client: APIClient) -> Self {
+    pub fn all<K>(client: APIClient) -> Self
+    where
+        K: k8s_openapi::Resource,
+    {
         let api = Resource::all::<K>();
-        Self {
-            api,
-            client,
-            phantom: PhantomData,
-        }
+        Self { api, client }
     }
 
     /// Namespaced resource within a given namespace
-    pub fn namespaced(client: APIClient, ns: &str) -> Self {
+    pub fn namespaced<K>(client: APIClient, ns: &str) -> Self
+    where
+        K: k8s_openapi::Resource,
+    {
         let api = Resource::namespaced::<K>(ns);
-        Self {
-            api,
-            client,
-            phantom: PhantomData,
-        }
+        Self { api, client }
     }
 }
 
 /// PUSH/PUT/POST/GET abstractions
-impl<K> Api<K>
-where
-    K: Clone + DeserializeOwned + Meta,
-{
-    pub async fn get(&self, name: &str) -> Result<K> {
+impl Api {
+    pub async fn get<K>(&self, name: &str) -> Result<K>
+    where
+        K: Clone + DeserializeOwned + Meta,
+    {
         let req = self.api.get(name)?;
         self.client.request::<K>(req).await
     }
 
-    pub async fn create(&self, pp: &PostParams, data: Vec<u8>) -> Result<K> {
+    pub async fn create<K>(&self, pp: &PostParams, data: Vec<u8>) -> Result<K>
+    where
+        K: Clone + DeserializeOwned + Meta,
+    {
         let req = self.api.create(&pp, data)?;
         self.client.request::<K>(req).await
     }
 
-    pub async fn delete(&self, name: &str, dp: &DeleteParams) -> Result<Either<K, Status>> {
+    pub async fn delete<K>(&self, name: &str, dp: &DeleteParams) -> Result<Either<K, Status>>
+    where
+        K: Clone + DeserializeOwned + Meta,
+    {
         let req = self.api.delete(name, &dp)?;
         self.client.request_status::<K>(req).await
     }
 
-    pub async fn list(&self, lp: &ListParams) -> Result<ObjectList<K>> {
+    pub async fn list<K>(&self, lp: &ListParams) -> Result<ObjectList<K>>
+    where
+        K: Clone + DeserializeOwned + Meta,
+    {
         let req = self.api.list(&lp)?;
         self.client.request::<ObjectList<K>>(req).await
     }
 
-    pub async fn delete_collection(&self, lp: &ListParams) -> Result<Either<ObjectList<K>, Status>> {
+    pub async fn delete_collection<K>(&self, lp: &ListParams) -> Result<Either<ObjectList<K>, Status>>
+    where
+        K: Clone + DeserializeOwned + Meta,
+    {
         let req = self.api.delete_collection(&lp)?;
         self.client.request_status::<ObjectList<K>>(req).await
     }
 
-    pub async fn patch(&self, name: &str, pp: &PatchParams, patch: Vec<u8>) -> Result<K> {
+    pub async fn patch<K>(&self, name: &str, pp: &PatchParams, patch: Vec<u8>) -> Result<K>
+    where
+        K: Clone + DeserializeOwned + Meta,
+    {
         let req = self.api.patch(name, &pp, patch)?;
         self.client.request::<K>(req).await
     }
 
-    pub async fn replace(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<K> {
+    pub async fn replace<K>(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<K>
+    where
+        K: Clone + DeserializeOwned + Meta,
+    {
         let req = self.api.replace(name, &pp, data)?;
         self.client.request::<K>(req).await
     }
 
-    pub async fn watch(&self, lp: &ListParams, version: &str) -> Result<impl Stream<Item = WatchEvent<K>>> {
+    pub async fn watch<K>(&self, lp: &ListParams, version: &str) -> Result<impl Stream<Item = WatchEvent<K>>>
+    where
+        K: Clone + DeserializeOwned + Meta,
+    {
         let req = self.api.watch(&lp, &version)?;
         self.client
             .request_events::<WatchEvent<K>>(req)

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -1,12 +1,11 @@
-use either::Either;
-use futures::{Stream, StreamExt};
-use serde::de::DeserializeOwned;
-
 use crate::{
     api::{DeleteParams, ListParams, Meta, ObjectList, PatchParams, PostParams, Resource, WatchEvent},
     client::{APIClient, Status},
     Result,
 };
+use either::Either;
+use futures::{Stream, StreamExt};
+use serde::{de::DeserializeOwned, Serialize};
 
 /// An easy Api interaction helper
 ///
@@ -57,11 +56,12 @@ impl Api {
         self.client.request::<K>(req).await
     }
 
-    pub async fn create<K>(&self, pp: &PostParams, data: Vec<u8>) -> Result<K>
+    pub async fn create<K>(&self, pp: &PostParams, data: &K) -> Result<K>
     where
-        K: Clone + DeserializeOwned + Meta,
+        K: Clone + DeserializeOwned + Meta + Serialize,
     {
-        let req = self.api.create(&pp, data)?;
+        let bytes = serde_json::to_vec(data)?;
+        let req = self.api.create(&pp, bytes)?;
         self.client.request::<K>(req).await
     }
 
@@ -97,11 +97,12 @@ impl Api {
         self.client.request::<K>(req).await
     }
 
-    pub async fn replace<K>(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<K>
+    pub async fn replace<K>(&self, name: &str, pp: &PostParams, data: &K) -> Result<K>
     where
-        K: Clone + DeserializeOwned + Meta,
+        K: Clone + DeserializeOwned + Meta + Serialize,
     {
-        let req = self.api.replace(name, &pp, data)?;
+        let bytes = serde_json::to_vec(data)?;
+        let req = self.api.replace(name, &pp, bytes)?;
         self.client.request::<K>(req).await
     }
 


### PR DESCRIPTION
lets you use Api without the generic type parameter, but all the methods
have the generic type param.

this lets you re-use a `Api::namespaced::<Pod>(...)` (say) by doing:
- api.get::<Pod>(...)
- api.get::<LimitedPod>)(...)

which can be useful sometimes.

Not entirely sure about this, but it lets you use a smaller deserialization type if needed (like in api fallbacks), and it can possibly let you control the types you use in patch calls in a different way.

The example changes are honestly not too bad. A little duplication of the type, which perhaps is undesirable.

Might be able to make the type signatures nicer here. Perhaps rather than taking ar bitrary bytes in many of the calls, we can now make the serialization done implicitly with `Into<json::Value>`.