### PR TITLE
a simpler serialization interface for Api::create + Api::replace

### DIFF
--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -67,7 +67,7 @@ async fn main() -> anyhow::Result<()> {
     info!("Creating Foo CRD: {}", serde_json::to_string_pretty(&foocrd)?);
     let pp = PostParams::default();
     let patch_params = PatchParams::default();
-    match crds.create(&pp, serde_json::to_vec(&foocrd)?).await {
+    match crds.create(&pp, &foocrd).await {
         Ok(o) => {
             info!("Created {} ({:?})", Meta::name(&o), o.status.unwrap());
             debug!("Created CRD: {:?}", o.spec);
@@ -82,14 +82,13 @@ async fn main() -> anyhow::Result<()> {
 
     // Create Foo baz
     info!("Creating Foo instance baz");
-    let f1 = json!({
-        "apiVersion": "clux.dev/v1",
-        "kind": "Foo",
-        "metadata": { "name": "baz" },
-        "spec": { "name": "baz", "info": "old baz", "replicas": 1 },
+    let f1 = Foo::new("baz", FooSpec {
+        name: "baz".into(),
+        info: "old baz".into(),
+        replicas: 1,
     });
-    let o = foos.create(&pp, serde_json::to_vec(&f1)?).await?;
-    assert_eq!(f1["metadata"]["name"], Meta::name(&o));
+    let o = foos.create(&pp, &f1).await?;
+    assert_eq!(Meta::name(&f1), Meta::name(&o));
     info!("Created {}", Meta::name(&o));
 
     // Verify we can get it
@@ -99,7 +98,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Replace its spec
     info!("Replace Foo baz");
-    let foo_replace = json!({
+    let foo_replace: Foo = serde_json::from_value(json!({
         "apiVersion": "clux.dev/v1",
         "kind": "Foo",
         "metadata": {
@@ -108,10 +107,8 @@ async fn main() -> anyhow::Result<()> {
             "resourceVersion": Meta::resource_ver(&f1cpy),
         },
         "spec": { "name": "baz", "info": "new baz", "replicas": 1 },
-    });
-    let f1_replaced = foos
-        .replace("baz", &pp, serde_json::to_vec(&foo_replace)?)
-        .await?;
+    }))?;
+    let f1_replaced = foos.replace("baz", &pp, &foo_replace).await?;
     assert_eq!(f1_replaced.spec.name, "baz");
     assert_eq!(f1_replaced.spec.info, "new baz");
     assert!(f1_replaced.status.is_none());
@@ -124,14 +121,14 @@ async fn main() -> anyhow::Result<()> {
 
     // Create Foo qux with status
     info!("Create Foo instance qux");
-    let f2 = json!({
-        "apiVersion": "clux.dev/v1",
-        "kind": "Foo",
-        "metadata": { "name": "qux" },
-        "spec": FooSpec { name: "qux".into(), replicas: 0, info: "unpatched qux".into() },
-        "status": FooStatus::default(),
+    let mut f2 = Foo::new("qux", FooSpec {
+        name: "qux".into(),
+        replicas: 0,
+        info: "unpatched qux".into(),
     });
-    let o = foos.create(&pp, serde_json::to_vec(&f2)?).await?;
+    f2.status = Some(FooStatus::default());
+
+    let o = foos.create(&pp, &f2).await?;
     info!("Created {}", Meta::name(&o));
 
     // Update status on qux

--- a/kube/examples/job_api.rs
+++ b/kube/examples/job_api.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create a Job
     let job_name = "empty-job";
-    let my_job = json!({
+    let my_job = serde_json::from_value(json!({
         "apiVersion": "batch/v1",
         "kind": "Job",
         "metadata": {
@@ -39,13 +39,12 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         }
-    });
+    }))?;
 
     let jobs: Api<Job> = Api::namespaced(client, &namespace);
     let pp = PostParams::default();
 
-    let data = serde_json::to_vec(&my_job).expect("failed to serialize job");
-    jobs.create(&pp, data).await.expect("failed to create job");
+    jobs.create(&pp, &my_job).await?;
 
     // See if it ran to completion
     let lp = ListParams::default()

--- a/kube/examples/pod_api.rs
+++ b/kube/examples/pod_api.rs
@@ -21,7 +21,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create Pod blog
     info!("Creating Pod instance blog");
-    let p = json!({
+    let p: Pod = serde_json::from_value(json!({
         "apiVersion": "v1",
         "kind": "Pod",
         "metadata": { "name": "blog" },
@@ -31,13 +31,13 @@ async fn main() -> anyhow::Result<()> {
               "image": "clux/blog:0.1.0"
             }],
         }
-    });
+    }))?;
 
     let pp = PostParams::default();
-    match pods.create(&pp, serde_json::to_vec(&p)?).await {
+    match pods.create(&pp, &p).await {
         Ok(o) => {
             let name = Meta::name(&o);
-            assert_eq!(p["metadata"]["name"], name);
+            assert_eq!(Meta::name(&p), name);
             info!("Created {}", name);
             // wait for it..
             std::thread::sleep(std::time::Duration::from_millis(5_000));

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -58,14 +58,17 @@ where
 /// PUSH/PUT/POST/GET abstractions
 impl<K> Api<K>
 where
-    K: Clone + DeserializeOwned + Serialize + Meta,
+    K: Clone + DeserializeOwned + Meta,
 {
     pub async fn get(&self, name: &str) -> Result<K> {
         let req = self.api.get(name)?;
         self.client.request::<K>(req).await
     }
 
-    pub async fn create(&self, pp: &PostParams, data: &K) -> Result<K> {
+    pub async fn create(&self, pp: &PostParams, data: &K) -> Result<K>
+    where
+        K: Serialize,
+    {
         let bytes = serde_json::to_vec(&data)?;
         let req = self.api.create(&pp, bytes)?;
         self.client.request::<K>(req).await
@@ -91,7 +94,10 @@ where
         self.client.request::<K>(req).await
     }
 
-    pub async fn replace(&self, name: &str, pp: &PostParams, data: &K) -> Result<K> {
+    pub async fn replace(&self, name: &str, pp: &PostParams, data: &K) -> Result<K>
+    where
+        K: Serialize,
+    {
         let bytes = serde_json::to_vec(&data)?;
         let req = self.api.replace(name, &pp, bytes)?;
         self.client.request::<K>(req).await


### PR DESCRIPTION
a less offensive (perhaps) variant of #172 without the footgun.

not too much saved, but at least we enforce the input type of `create` and `replace` are what we expect.