### PR TITLE
Fallback to ErrorResponse when WatchEvent parsing fails

### DIFF
--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -195,10 +195,19 @@ impl APIClient {
                                             // added in the current partial line to our buffer for
                                             // use in the next loop
                                             if !e.is_eof() {
-                                                warn!("Failed to parse: {}", String::from_utf8_lossy(line));
+                                                // Check if it's a general API error response
+                                                let e = match serde_json::from_slice(&new_buff) {
+                                                    Ok(e) => Error::Api(e),
+                                                    _ => {
+                                                        let line = String::from_utf8_lossy(line);
+                                                        warn!("Failed to parse: {}", line);
+                                                        Error::SerdeError(e)
+                                                    }
+                                                };
+
                                                 // Clear the buffer as this was a valid object
                                                 new_buff.clear();
-                                                items.push(Err(Error::SerdeError(e)));
+                                                items.push(Err(e));
                                             }
                                         }
                                     }


### PR DESCRIPTION
General errors, such as unauthorized responses, are not sent inside a
wrapping WatchEvent of type ERROR. If parsing of a WatchEvent failed, do
a second attempt by interpreting the response as an ErrorResponse
instead.