### PR TITLE
better naming and user-friendly defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Add `Client::inferred` as a recommended constructor
   * `Client` now implements `From<Configuration>`
   * Added comprehensive documentation on `Api`
+  * Rename `config::KubeConfigLoader` -> `config::ConfigLoader`
 
 0.30.0 / 2020-03-17
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * `Client` now implements `From<Configuration>`
   * Added comprehensive documentation on `Api`
   * Rename `config::KubeConfigLoader` -> `config::ConfigLoader`
+  * removed `futures-timer` dependency for `tokio` (feature=timer)
 
 0.30.0 / 2020-03-17
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 0.31.0 / 2020-03-XX
 ===================
   * Expose `config::Configuration` at root level
-  * Add `Configuration::inferred` as a recommended constructor
+  * Add `Configuration::infer` as a recommended constructor
   * Rename `client::APIClient` to `client::Client`
   * Expose `client::Client` at root level
-  * Add `Client::inferred` as a recommended constructor
+  * Add `Client::infer` as a recommended constructor
   * `Client` now implements `From<Configuration>`
   * Added comprehensive documentation on `Api`
   * Rename `config::KubeConfigLoader` -> `config::ConfigLoader`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+0.31.0 / 2020-03-XX
+===================
+  * Expose `config::Configuration` at root level
+  * Add `Configuration::inferred` as a recommended constructor
+  * Rename `client::APIClient` to `client::Client`
+  * Expose `client::Client` at root level
+  * Add `Client::inferred` as a recommended constructor
+  * `Client` now implements `From<Configuration>`
+  * Added comprehensive documentation on `Api`
+
 0.30.0 / 2020-03-17
 ===================
   * Fix `#[kube(printcolumn)]` when `#[kube(apiextensions = "v1beta1")]`

--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ pub struct FooSpec {
 Then you can use a lot of generated code as:
 
 ```rust
-let config = config::load_kube_config().await?;
-let client = APIClient::new(config);
-
 println!("kind = {}", Foo::KIND); // impl k8s_openapi::Resource
 let foos: Api<Foo> = Api::namespaced(client, "default");
 let f = Foo::new("my-foo");

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -27,13 +27,13 @@ log = "0.4.8"
 time = "0.2.6"
 either = "1.5.3"
 thiserror = "1.0.10"
-futures-timer = "3.0.1"
 futures-util = "0.3.4"
 futures = "0.3.4"
 openssl = { version = "0.10.28", optional = true }
 rustls = { version = "0.16.0", optional = true }
 bytes = "0.5.4"
 Inflector = "0.11.4"
+tokio = { version = "0.2.13", features = ["time"] }
 
 [dependencies.reqwest]
 version = "0.10.2"
@@ -54,7 +54,7 @@ rustls-tls = ["rustls", "reqwest/rustls-tls"]
 kube-derive = { path = "../kube-derive" }
 tempfile = "3.1.0"
 env_logger = "0.7.1"
-tokio = { version = "0.2.11", features = ["full"] }
+tokio = { version = "0.2.13", features = ["full"] }
 anyhow = "1.0.26"
 
 [dev-dependencies.k8s-openapi]

--- a/kube/examples/configmap_reflector.rs
+++ b/kube/examples/configmap_reflector.rs
@@ -11,7 +11,7 @@ use kube::{
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::from(Configuration::inferred().await?);
+    let client = Client::from(Configuration::infer().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let resource = Resource::namespaced::<ConfigMap>(&namespace);

--- a/kube/examples/configmap_reflector.rs
+++ b/kube/examples/configmap_reflector.rs
@@ -2,9 +2,8 @@
 use k8s_openapi::api::core::v1::ConfigMap;
 use kube::{
     api::{ListParams, Meta, Resource},
-    client::APIClient,
-    config,
     runtime::Reflector,
+    Client, Configuration,
 };
 
 /// Example way to read secrets
@@ -12,8 +11,7 @@ use kube::{
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
+    let client = Client::from(Configuration::inferred().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let resource = Resource::namespaced::<ConfigMap>(&namespace);

--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -1,10 +1,10 @@
 #[macro_use] extern crate log;
 use either::Either::{Left, Right};
-use futures_timer::Delay;
 use kube_derive::CustomResource;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::json;
 use std::time::Duration;
+use tokio::time::delay_for;
 
 use apiexts::CustomResourceDefinition;
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as apiexts;
@@ -60,7 +60,7 @@ async fn main() -> anyhow::Result<()> {
         })
     });
     // Wait for the delete to take place (map-left case or delete from previous run)
-    Delay::new(Duration::from_secs(2)).await;
+    delay_for(Duration::from_secs(2)).await;
 
     // Create the CRD so we can create Foos in kube
     let foocrd = Foo::crd();
@@ -76,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
         Err(e) => return Err(e.into()),                        // any other case is probably bad
     }
     // Wait for the api to catch up
-    Delay::new(Duration::from_secs(1)).await;
+    delay_for(Duration::from_secs(1)).await;
 
 
     // Manage the Foo CR

--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -37,7 +37,7 @@ pub struct FooStatus {
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::from(Configuration::inferred().await?);
+    let client = Client::from(Configuration::infer().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // Manage CRDs first

--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -11,8 +11,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as a
 
 use kube::{
     api::{Api, DeleteParams, ListParams, Meta, PatchParams, PostParams},
-    client::APIClient,
-    config,
+    Client, Configuration,
 };
 
 // Own custom resource
@@ -38,8 +37,7 @@ pub struct FooStatus {
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
+    let client = Client::from(Configuration::inferred().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // Manage CRDs first

--- a/kube/examples/crd_apply.rs
+++ b/kube/examples/crd_apply.rs
@@ -37,7 +37,7 @@ pub struct FooStatus {
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=info");
     env_logger::init();
-    let client = Client::from(Configuration::inferred().await?);
+    let client = Client::from(Configuration::infer().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let ssapply = PatchParams {

--- a/kube/examples/crd_apply.rs
+++ b/kube/examples/crd_apply.rs
@@ -9,8 +9,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as a
 
 use kube::{
     api::{Api, ListParams, Meta, PatchParams, PatchStrategy, WatchEvent},
-    client::APIClient,
-    config,
+    Client, Configuration,
 };
 
 // NB: This example uses server side apply and beta1 customresources
@@ -38,8 +37,7 @@ pub struct FooStatus {
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=info");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
+    let client = Client::from(Configuration::inferred().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let ssapply = PatchParams {

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -6,12 +6,16 @@ use serde_derive::{Deserialize, Serialize};
 ///
 /// A struct with our chosen Kind will be created for us, using the following kube attrs
 #[derive(CustomResource, Serialize, Deserialize, Debug, Clone)]
-#[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
-#[kube(status = "FooStatus")]
-#[kube(scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]
 #[kube(
+    group = "clux.dev",
+    version = "v1",
+    kind = "Foo",
+    namespaced,
+    status = "FooStatus",
+    scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#,
     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
 )]
+#[kube(apiextensions = "v1beta1")] // kubernetes <= 1.16
 pub struct MyFoo {
     name: String,
     info: Option<String>,
@@ -41,7 +45,7 @@ fn verify_crd() {
     use serde_json::{self, json};
     let crd = Foo::crd();
     let output = json!({
-      "apiVersion": "apiextensions.k8s.io/v1",
+      "apiVersion": "apiextensions.k8s.io/v1beta1",
       "kind": "CustomResourceDefinition",
       "metadata": {
         "name": "foos.clux.dev"
@@ -54,22 +58,26 @@ fn verify_crd() {
           "shortNames": [],
           "singular": "foo"
         },
+        "additionalPrinterColumns": [
+          {
+            "description": "name of foo",
+            "JSONPath": ".spec.name",
+            "name": "Spec",
+            "type": "string"
+          }
+        ],
         "scope": "Namespaced",
         "versions": [
           {
-            "additionalPrinterColumns": [
-              {
-                "description": "name of foo",
-                "jsonPath": ".spec.name",
-                "name": "Spec",
-                "type": "string"
-              }
-            ],
             "name": "v1",
             "served": true,
             "storage": true
           }
-        ]
+        ],
+        "subresources": {
+          "scale": {"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"},
+          "status": {}
+        }
       }
     });
     let outputcrd = serde_json::from_value(output).expect("expected output is valid");

--- a/kube/examples/crd_reflector.rs
+++ b/kube/examples/crd_reflector.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 
 use kube::{
     api::{ListParams, Meta, Resource},
-    Client,
     runtime::Reflector,
+    Client,
 };
 
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
@@ -21,7 +21,7 @@ pub struct FooSpec {
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::new().await?;
+    let client = Client::inferred().await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // This example requires `kubectl apply -f examples/foo.yaml` run first

--- a/kube/examples/crd_reflector.rs
+++ b/kube/examples/crd_reflector.rs
@@ -21,7 +21,7 @@ pub struct FooSpec {
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::inferred().await?;
+    let client = Client::infer().await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // This example requires `kubectl apply -f examples/foo.yaml` run first

--- a/kube/examples/crd_reflector.rs
+++ b/kube/examples/crd_reflector.rs
@@ -1,8 +1,8 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate serde_derive;
 #[macro_use] extern crate kube_derive;
-use futures_timer::Delay;
 use std::time::Duration;
+use tokio::time::delay_for;
 
 use kube::{
     api::{ListParams, Meta, Resource},
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
     });
 
     loop {
-        Delay::new(Duration::from_secs(5)).await;
+        delay_for(Duration::from_secs(5)).await;
         // Read updated internal state (instant):
         let crds = rf.state().await?.iter().map(Meta::name).collect::<Vec<_>>();
         info!("Current crds: {:?}", crds);

--- a/kube/examples/crd_reflector.rs
+++ b/kube/examples/crd_reflector.rs
@@ -6,8 +6,7 @@ use std::time::Duration;
 
 use kube::{
     api::{ListParams, Meta, Resource},
-    client::APIClient,
-    config,
+    Client,
     runtime::Reflector,
 };
 
@@ -22,8 +21,7 @@ pub struct FooSpec {
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
+    let client = Client::new().await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // This example requires `kubectl apply -f examples/foo.yaml` run first

--- a/kube/examples/deployment_reflector.rs
+++ b/kube/examples/deployment_reflector.rs
@@ -10,7 +10,7 @@ use kube::{
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::from(Configuration::inferred().await?);
+    let client = Client::from(Configuration::infer().await?);
 
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 

--- a/kube/examples/deployment_reflector.rs
+++ b/kube/examples/deployment_reflector.rs
@@ -2,17 +2,16 @@
 use k8s_openapi::api::apps::v1::Deployment;
 use kube::{
     api::{ListParams, Meta, Resource},
-    client::APIClient,
-    config,
     runtime::Reflector,
+    Client, Configuration,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
+    let client = Client::from(Configuration::inferred().await?);
+
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let resource = Resource::namespaced::<Deployment>(&namespace);

--- a/kube/examples/event_informer.rs
+++ b/kube/examples/event_informer.rs
@@ -12,7 +12,7 @@ use futures::{StreamExt, TryStreamExt};
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::from(Configuration::inferred().await?);
+    let client = Client::from(Configuration::infer().await?);
 
     let events = Resource::all::<Event>();
     let lp = ListParams::default();

--- a/kube/examples/event_informer.rs
+++ b/kube/examples/event_informer.rs
@@ -2,9 +2,8 @@
 use k8s_openapi::api::core::v1::Event;
 use kube::{
     api::{ListParams, Resource, WatchEvent},
-    client::APIClient,
-    config,
     runtime::Informer,
+    Client, Configuration,
 };
 
 use futures::{StreamExt, TryStreamExt};
@@ -13,8 +12,7 @@ use futures::{StreamExt, TryStreamExt};
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
+    let client = Client::from(Configuration::inferred().await?);
 
     let events = Resource::all::<Event>();
     let lp = ListParams::default();

--- a/kube/examples/job_api.rs
+++ b/kube/examples/job_api.rs
@@ -5,16 +5,14 @@ use serde_json::json;
 
 use kube::{
     api::{Api, DeleteParams, ListParams, Meta, PostParams, WatchEvent},
-    client::APIClient,
-    config,
+    Client, Configuration,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
+    let client = Client::from(Configuration::inferred().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // Create a Job

--- a/kube/examples/job_api.rs
+++ b/kube/examples/job_api.rs
@@ -12,7 +12,7 @@ use kube::{
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::from(Configuration::inferred().await?);
+    let client = Client::from(Configuration::infer().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // Create a Job

--- a/kube/examples/log_stream.rs
+++ b/kube/examples/log_stream.rs
@@ -12,7 +12,7 @@ use std::env;
 async fn main() -> Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::from(Configuration::inferred().await?);
+    let client = Client::from(Configuration::infer().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let mypod = env::args()

--- a/kube/examples/log_stream.rs
+++ b/kube/examples/log_stream.rs
@@ -4,8 +4,7 @@ use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{Api, LogParams},
-    client::APIClient,
-    config,
+    Client, Configuration,
 };
 use std::env;
 
@@ -13,8 +12,7 @@ use std::env;
 async fn main() -> Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
+    let client = Client::from(Configuration::inferred().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let mypod = env::args()

--- a/kube/examples/node_informer.rs
+++ b/kube/examples/node_informer.rs
@@ -3,18 +3,15 @@ use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::{Event, Node};
 use kube::{
     api::{Api, ListParams, Meta, Resource, WatchEvent},
-    client::APIClient,
-    config,
     runtime::Informer,
+    Client, Configuration,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,node_informer=debug,kube=debug");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
-
+    let client = Client::from(Configuration::inferred().await?);
     let nodes = Resource::all::<Node>();
     let events: Api<Event> = Api::all(client.clone());
 

--- a/kube/examples/node_informer.rs
+++ b/kube/examples/node_informer.rs
@@ -11,7 +11,7 @@ use kube::{
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,node_informer=debug,kube=debug");
     env_logger::init();
-    let client = Client::from(Configuration::inferred().await?);
+    let client = Client::from(Configuration::infer().await?);
     let nodes = Resource::all::<Node>();
     let events: Api<Event> = Api::all(client.clone());
 

--- a/kube/examples/node_reflector.rs
+++ b/kube/examples/node_reflector.rs
@@ -10,7 +10,7 @@ use kube::{
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::from(Configuration::inferred().await?);
+    let client = Client::from(Configuration::infer().await?);
 
     let resource = Resource::all::<Node>();
     let lp = ListParams::default()

--- a/kube/examples/node_reflector.rs
+++ b/kube/examples/node_reflector.rs
@@ -2,17 +2,15 @@
 use k8s_openapi::api::core::v1::Node;
 use kube::{
     api::{ListParams, Meta, Resource},
-    client::APIClient,
-    config,
     runtime::Reflector,
+    Client, Configuration,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
+    let client = Client::from(Configuration::inferred().await?);
 
     let resource = Resource::all::<Node>();
     let lp = ListParams::default()

--- a/kube/examples/pod_api.rs
+++ b/kube/examples/pod_api.rs
@@ -4,16 +4,14 @@ use serde_json::json;
 
 use kube::{
     api::{Api, DeleteParams, ListParams, Meta, PatchParams, PostParams},
-    client::APIClient,
-    config,
+    Client, Configuration,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
+    let client = Client::from(Configuration::inferred().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // Manage pods

--- a/kube/examples/pod_api.rs
+++ b/kube/examples/pod_api.rs
@@ -11,7 +11,7 @@ use kube::{
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::from(Configuration::inferred().await?);
+    let client = Client::from(Configuration::infer().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // Manage pods

--- a/kube/examples/pod_informer.rs
+++ b/kube/examples/pod_informer.rs
@@ -12,7 +12,7 @@ use std::env;
 async fn main() -> anyhow::Result<()> {
     env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::from(Configuration::inferred().await?);
+    let client = Client::from(Configuration::infer().await?);
     let namespace = env::var("NAMESPACE").unwrap_or("default".into());
 
     let resource = Resource::namespaced::<Pod>(&namespace);

--- a/kube/examples/pod_informer.rs
+++ b/kube/examples/pod_informer.rs
@@ -3,9 +3,8 @@ use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{ListParams, Meta, Resource, WatchEvent},
-    client::APIClient,
-    config,
     runtime::Informer,
+    Client, Configuration,
 };
 use std::env;
 
@@ -13,8 +12,7 @@ use std::env;
 async fn main() -> anyhow::Result<()> {
     env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
+    let client = Client::from(Configuration::inferred().await?);
     let namespace = env::var("NAMESPACE").unwrap_or("default".into());
 
     let resource = Resource::namespaced::<Pod>(&namespace);

--- a/kube/examples/pod_reflector.rs
+++ b/kube/examples/pod_reflector.rs
@@ -12,7 +12,7 @@ use tokio::time::delay_for;
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::from(Configuration::inferred().await?);
+    let client = Client::from(Configuration::infer().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let resource = Resource::namespaced::<Pod>(&namespace);

--- a/kube/examples/pod_reflector.rs
+++ b/kube/examples/pod_reflector.rs
@@ -1,5 +1,4 @@
 #[macro_use] extern crate log;
-use futures_timer::Delay;
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{ListParams, Meta, Resource},
@@ -7,6 +6,7 @@ use kube::{
     Client, Configuration,
 };
 use std::time::Duration;
+use tokio::time::delay_for;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -43,7 +43,7 @@ async fn main() -> anyhow::Result<()> {
     });
 
     loop {
-        Delay::new(Duration::from_secs(5)).await;
+        delay_for(Duration::from_secs(5)).await;
         let pods: Vec<_> = rf.state().await?.iter().map(Meta::name).collect();
         info!("Current pods: {:?}", pods);
     }

--- a/kube/examples/pod_reflector.rs
+++ b/kube/examples/pod_reflector.rs
@@ -3,9 +3,8 @@ use futures_timer::Delay;
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{ListParams, Meta, Resource},
-    client::APIClient,
-    config,
     runtime::Reflector,
+    Client, Configuration,
 };
 use std::time::Duration;
 
@@ -13,8 +12,7 @@ use std::time::Duration;
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
+    let client = Client::from(Configuration::inferred().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let resource = Resource::namespaced::<Pod>(&namespace);

--- a/kube/examples/secret_reflector.rs
+++ b/kube/examples/secret_reflector.rs
@@ -34,7 +34,7 @@ fn decode(secret: &Secret) -> BTreeMap<String, Decoded> {
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::from(Configuration::inferred().await?);
+    let client = Client::from(Configuration::infer().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let resource = Resource::namespaced::<Secret>(&namespace);

--- a/kube/examples/secret_reflector.rs
+++ b/kube/examples/secret_reflector.rs
@@ -4,9 +4,8 @@ use std::collections::BTreeMap;
 use k8s_openapi::api::core::v1::Secret;
 use kube::{
     api::{ListParams, Meta, Resource},
-    client::APIClient,
-    config,
     runtime::Reflector,
+    Client, Configuration,
 };
 
 /// Example way to read secrets
@@ -35,8 +34,7 @@ fn decode(secret: &Secret) -> BTreeMap<String, Decoded> {
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let config = config::load_kube_config().await?;
-    let client = APIClient::new(config);
+    let client = Client::from(Configuration::inferred().await?);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let resource = Resource::namespaced::<Secret>(&namespace);

--- a/kube/src/api/crds.rs
+++ b/kube/src/api/crds.rs
@@ -160,7 +160,7 @@ mod test {
         struct FooSpec {
             foo: String,
         };
-        let client = Client::from(Configuration::inferred().await.unwrap());
+        let client = Client::from(Configuration::infer().await.unwrap());
         let r1: Api<Foo> = Api::namespaced(client.clone(), "myns");
 
         let r2: Api<Foo> = CustomResource::kind("Foo")

--- a/kube/src/api/crds.rs
+++ b/kube/src/api/crds.rs
@@ -154,13 +154,13 @@ mod test {
     #[tokio::test]
     #[ignore] // circle has no kube config
     async fn convenient_custom_resource() {
-        use crate::{Api, Client};
+        use crate::{Api, Client, Configuration};
         #[derive(Clone, Debug, kube_derive::CustomResource, Deserialize, Serialize)]
         #[kube(group = "clux.dev", version = "v1", namespaced)]
         struct FooSpec {
             foo: String,
         };
-        let client = Client::new().await.unwrap();
+        let client = Client::from(Configuration::inferred().await.unwrap());
         let r1: Api<Foo> = Api::namespaced(client.clone(), "myns");
 
         let r2: Api<Foo> = CustomResource::kind("Foo")

--- a/kube/src/api/crds.rs
+++ b/kube/src/api/crds.rs
@@ -1,6 +1,6 @@
 use crate::{
     api::{typed::Api, Resource},
-    client::APIClient,
+    Client,
 };
 use inflector::{cases::pascalcase::is_pascal_case, string::pluralize::to_plural};
 use std::marker::PhantomData;
@@ -91,7 +91,7 @@ impl CrBuilder {
     }
 
     // Consume the CrBuilder and convert to an Api object
-    pub fn into_api<K>(self, client: APIClient) -> Api<K> {
+    pub fn into_api<K>(self, client: Client) -> Api<K> {
         let crd = self.build();
         Api {
             client,
@@ -122,7 +122,7 @@ impl From<CustomResource> for Resource {
 
 /// Make Api useable on CRDs without k8s_openapi
 impl CustomResource {
-    pub fn into_api<K>(self, client: APIClient) -> Api<K> {
+    pub fn into_api<K>(self, client: Client) -> Api<K> {
         Api {
             client,
             api: self.into(),
@@ -154,14 +154,13 @@ mod test {
     #[tokio::test]
     #[ignore] // circle has no kube config
     async fn convenient_custom_resource() {
-        use crate::{api::Api, client::APIClient, config};
+        use crate::{Api, Client};
         #[derive(Clone, Debug, kube_derive::CustomResource, Deserialize, Serialize)]
         #[kube(group = "clux.dev", version = "v1", namespaced)]
         struct FooSpec {
             foo: String,
         };
-        let config = config::load_kube_config().await.unwrap();
-        let client = APIClient::new(config);
+        let client = Client::new().await.unwrap();
         let r1: Api<Foo> = Api::namespaced(client.clone(), "myns");
 
         let r2: Api<Foo> = CustomResource::kind("Foo")

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -60,11 +60,11 @@ where
     /// NB: Requires that the resource has a status subresource.
     ///
     /// ```no_run
-    /// use kube::{api::{Api, PatchParams}, config, client::APIClient};
+    /// use kube::{api::{Api, PatchParams}, Client};
     /// use k8s_openapi::api::batch::v1::Job;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = APIClient::new(config::load_kube_config().await?);
+    ///     let client = Client::new().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let mut j = jobs.get("baz").await?;
     ///     let pp = PatchParams::default(); // json merge patch
@@ -89,11 +89,11 @@ where
     /// You can leave out the .spec entirely from the serialized output.
     ///
     /// ```no_run
-    /// use kube::{api::{Api, PostParams}, config, client::APIClient};
+    /// use kube::{api::{Api, PostParams}, Client};
     /// use k8s_openapi::api::batch::v1::{Job, JobStatus};
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = APIClient::new(config::load_kube_config().await?);
+    ///     let client = Client::new().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let mut o = jobs.get_status("baz").await?; // retrieve partial object
     ///     o.status = Some(JobStatus::default()); // update the job part

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -64,7 +64,7 @@ where
     /// use k8s_openapi::api::batch::v1::Job;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::inferred().await?;
+    ///     let client = Client::infer().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let mut j = jobs.get("baz").await?;
     ///     let pp = PatchParams::default(); // json merge patch
@@ -93,7 +93,7 @@ where
     /// use k8s_openapi::api::batch::v1::{Job, JobStatus};
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::inferred().await?;
+    ///     let client = Client::infer().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let mut o = jobs.get_status("baz").await?; // retrieve partial object
     ///     o.status = Some(JobStatus::default()); // update the job part

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -64,7 +64,7 @@ where
     /// use k8s_openapi::api::batch::v1::Job;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::new().await?;
+    ///     let client = Client::inferred().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let mut j = jobs.get("baz").await?;
     ///     let pp = PatchParams::default(); // json merge patch
@@ -93,7 +93,7 @@ where
     /// use k8s_openapi::api::batch::v1::{Job, JobStatus};
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::new().await?;
+    ///     let client = Client::inferred().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let mut o = jobs.get_status("baz").await?; // retrieve partial object
     ///     o.status = Some(JobStatus::default()); // update the job part

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -67,7 +67,7 @@ where
     /// use k8s_openapi::api::core::v1::Pod;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::new().await?;
+    ///     let client = Client::inferred().await?;
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
     ///     let p: Pod = pods.get("blog").await?;
     ///     Ok(())
@@ -87,7 +87,7 @@ where
     /// use k8s_openapi::api::core::v1::Pod;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::new().await?;
+    ///     let client = Client::inferred().await?;
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
     ///     let lp = ListParams::default().labels("app=blog"); // for this app only
     ///     for p in pods.list(&lp).await? {
@@ -140,7 +140,7 @@ where
     /// use apiexts::CustomResourceDefinition;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::new().await?;
+    ///     let client = Client::inferred().await?;
     ///     let crds: Api<CustomResourceDefinition> = Api::all(client);
     ///     crds.delete("foos.clux.dev", &DeleteParams::default()).await?
     ///         .map_left(|o| println!("Deleting CRD: {:?}", o.status))
@@ -166,7 +166,7 @@ where
     /// use k8s_openapi::api::core::v1::Pod;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::new().await?;
+    ///     let client = Client::inferred().await?;
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
     ///     match pods.delete_collection(&ListParams::default()).await? {
     ///         either::Left(list) => {
@@ -213,7 +213,7 @@ where
     /// use k8s_openapi::api::batch::v1::Job;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::new().await?;
+    ///     let client = Client::inferred().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let mut j = jobs.get("baz").await?;
     ///     let j_new: Job = serde_json::from_value(serde_json::json!({
@@ -264,7 +264,7 @@ where
     /// use futures::StreamExt;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::new().await?;
+    ///     let client = Client::inferred().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let lp = ListParams::default()
     ///         .fields("metadata.name=my_job")

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -67,7 +67,7 @@ where
     /// use k8s_openapi::api::core::v1::Pod;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::inferred().await?;
+    ///     let client = Client::infer().await?;
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
     ///     let p: Pod = pods.get("blog").await?;
     ///     Ok(())
@@ -87,7 +87,7 @@ where
     /// use k8s_openapi::api::core::v1::Pod;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::inferred().await?;
+    ///     let client = Client::infer().await?;
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
     ///     let lp = ListParams::default().labels("app=blog"); // for this app only
     ///     for p in pods.list(&lp).await? {
@@ -140,7 +140,7 @@ where
     /// use apiexts::CustomResourceDefinition;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::inferred().await?;
+    ///     let client = Client::infer().await?;
     ///     let crds: Api<CustomResourceDefinition> = Api::all(client);
     ///     crds.delete("foos.clux.dev", &DeleteParams::default()).await?
     ///         .map_left(|o| println!("Deleting CRD: {:?}", o.status))
@@ -166,7 +166,7 @@ where
     /// use k8s_openapi::api::core::v1::Pod;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::inferred().await?;
+    ///     let client = Client::infer().await?;
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
     ///     match pods.delete_collection(&ListParams::default()).await? {
     ///         either::Left(list) => {
@@ -213,7 +213,7 @@ where
     /// use k8s_openapi::api::batch::v1::Job;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::inferred().await?;
+    ///     let client = Client::infer().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let mut j = jobs.get("baz").await?;
     ///     let j_new: Job = serde_json::from_value(serde_json::json!({
@@ -264,7 +264,7 @@ where
     /// use futures::StreamExt;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
-    ///     let client = Client::inferred().await?;
+    ///     let client = Client::infer().await?;
     ///     let jobs: Api<Job> = Api::namespaced(client, "apps");
     ///     let lp = ListParams::default()
     ///         .fields("metadata.name=my_job")

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -69,19 +69,12 @@ impl From<Configuration> for Client {
 impl Client {
     /// Create and initialize a Client with the appropriate kube config
     ///
-    /// By default this tries the in-cluster config first,
-    /// and falls back to the local kube config otherwise.
-    pub async fn new() -> Result<Self> {
-        use crate::config;
-        // TODO: lift this match into config module
-        let configuration = match config::incluster_config() {
-            Err(e) => {
-                debug!("No in-cluster config found: {}", e);
-                debug!("Falling back to local kube config");
-                config::load_kube_config().await?
-            }
-            Ok(o) => o,
-        };
+    /// Will use `Configuration::inferred` to try in-cluster evars first,
+    /// then fallback to the local kube config.
+    ///
+    /// Will fail if neither configuration could be loaded.
+    pub async fn inferred() -> Result<Self> {
+        let configuration = crate::config::Configuration::inferred().await?;
         Ok(Self { configuration })
     }
 

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -76,9 +76,10 @@ impl Client {
         // TODO: lift this match into config module
         let configuration = match config::incluster_config() {
             Err(e) => {
-                debug!("No in-cluster configuration found ({})- falling back to local kube config", e);
+                debug!("No in-cluster config found: {}", e);
+                debug!("Falling back to local kube config");
                 config::load_kube_config().await?
-            },
+            }
             Ok(o) => o,
         };
         Ok(Self { configuration })

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -69,12 +69,12 @@ impl From<Configuration> for Client {
 impl Client {
     /// Create and initialize a Client with the appropriate kube config
     ///
-    /// Will use `Configuration::inferred` to try in-cluster evars first,
+    /// Will use `Configuration::infer` to try in-cluster evars first,
     /// then fallback to the local kube config.
     ///
     /// Will fail if neither configuration could be loaded.
-    pub async fn inferred() -> Result<Self> {
-        let configuration = crate::config::Configuration::inferred().await?;
+    pub async fn infer() -> Result<Self> {
+        let configuration = crate::config::Configuration::infer().await?;
         Ok(Self { configuration })
     }
 

--- a/kube/src/config/kube_config.rs
+++ b/kube/src/config/kube_config.rs
@@ -22,21 +22,21 @@ impl TryFrom<Der> for Certificate {
     }
 }
 
-/// KubeConfigLoader loads current context, cluster, and authentication information.
+/// ConfigLoader loads current context, cluster, and authentication information.
 #[derive(Clone, Debug)]
-pub struct KubeConfigLoader {
+pub struct ConfigLoader {
     pub current_context: Context,
     pub cluster: Cluster,
     pub user: AuthInfo,
 }
 
-impl KubeConfigLoader {
+impl ConfigLoader {
     pub async fn load<P: AsRef<Path>>(
         path: P,
         context: Option<String>,
         cluster: Option<String>,
         user: Option<String>,
-    ) -> Result<KubeConfigLoader> {
+    ) -> Result<ConfigLoader> {
         let config = Config::read_from(path)?;
         let context_name = context.as_ref().unwrap_or(&config.current_context);
         let current_context = config
@@ -63,7 +63,7 @@ impl KubeConfigLoader {
             }
         }
         let user = user_opt.ok_or_else(|| Error::KubeConfig("Unable to find named user".into()))?;
-        Ok(KubeConfigLoader {
+        Ok(ConfigLoader {
             current_context: current_context.clone(),
             cluster: cluster.clone(),
             user,

--- a/kube/src/config/mod.rs
+++ b/kube/src/config/mod.rs
@@ -40,6 +40,19 @@ impl Configuration {
             default_ns,
         }
     }
+
+    /// Construct configuration by attempting to load in-cluster first, then local
+    pub async fn inferred() -> Result<Self> {
+        let cfg = match incluster_config() {
+            Err(e) => {
+                trace!("No in-cluster config found: {}", e);
+                trace!("Falling back to local kube config");
+                load_kube_config().await?
+            }
+            Ok(o) => o,
+        };
+        Ok(cfg)
+    }
 }
 
 /// Returns a config includes authentication and cluster infomation from kubeconfig file.

--- a/kube/src/config/mod.rs
+++ b/kube/src/config/mod.rs
@@ -15,7 +15,7 @@ use crate::{config::kube_config::Der, Error, Result};
 use reqwest::{header, Client, ClientBuilder};
 use std::convert::TryInto;
 
-use self::kube_config::KubeConfigLoader;
+use self::kube_config::ConfigLoader;
 
 /// Configuration stores kubernetes path and client for requests.
 #[derive(Clone)]
@@ -105,11 +105,11 @@ fn hacky_cert_lifetime_for_macos(client_builder: ClientBuilder, _: &Der) -> Clie
 /// Returns a client builder and config loader, based on the cluster information from the kubeconfig file.
 ///
 /// This allows to create your custom reqwest client for using with the cluster API.
-pub async fn create_client_builder(options: ConfigOptions) -> Result<(ClientBuilder, KubeConfigLoader)> {
+pub async fn create_client_builder(options: ConfigOptions) -> Result<(ClientBuilder, ConfigLoader)> {
     let kubeconfig =
         utils::find_kubeconfig().map_err(|e| Error::KubeConfig(format!("Unable to load file: {}", e)))?;
 
-    let loader = KubeConfigLoader::load(kubeconfig, options.context, options.cluster, options.user).await?;
+    let loader = ConfigLoader::load(kubeconfig, options.context, options.cluster, options.user).await?;
 
     let token = match &loader.user.token {
         Some(token) => Some(token.clone()),

--- a/kube/src/config/mod.rs
+++ b/kube/src/config/mod.rs
@@ -41,8 +41,11 @@ impl Configuration {
         }
     }
 
-    /// Construct configuration by attempting to load in-cluster first, then local
-    pub async fn inferred() -> Result<Self> {
+    /// Infer the config type and return it
+    ///
+    /// Done by attempting to load in-cluster evars first,
+    /// then if that fails, try the full local kube config.
+    pub async fn infer() -> Result<Self> {
         let cfg = match incluster_config() {
             Err(e) => {
                 trace!("No in-cluster config found: {}", e);

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -63,5 +63,6 @@ pub use api::{Api, Resource};
 pub mod client;
 pub use client::Client;
 pub mod config;
+pub use config::Configuration;
 mod oauth2;
 pub mod runtime;

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -61,6 +61,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub mod api;
 pub use api::{Api, Resource};
 pub mod client;
+pub use client::Client;
 pub mod config;
 mod oauth2;
 pub mod runtime;

--- a/kube/src/runtime/informer.rs
+++ b/kube/src/runtime/informer.rs
@@ -1,6 +1,6 @@
 use crate::{
     api::{ListParams, Meta, Resource, WatchEvent},
-    Client,Result,
+    Client, Result,
 };
 
 use futures::{lock::Mutex, Stream, StreamExt};

--- a/kube/src/runtime/informer.rs
+++ b/kube/src/runtime/informer.rs
@@ -4,9 +4,9 @@ use crate::{
 };
 
 use futures::{lock::Mutex, Stream, StreamExt};
-use futures_timer::Delay;
 use serde::de::DeserializeOwned;
 use std::{sync::Arc, time::Duration};
+use tokio::time::delay_for;
 
 /// An event informer for a `Resource`
 ///
@@ -79,7 +79,7 @@ where
             if *needs_resync || *needs_retry {
                 // Try again in a bit
                 let dur = Duration::from_secs(10);
-                Delay::new(dur).await;
+                delay_for(dur).await;
                 // If we are outside history, start over from latest
                 if *needs_resync {
                     self.reset().await;

--- a/kube/src/runtime/informer.rs
+++ b/kube/src/runtime/informer.rs
@@ -1,7 +1,6 @@
 use crate::{
     api::{ListParams, Meta, Resource, WatchEvent},
-    client::APIClient,
-    Result,
+    Client,Result,
 };
 
 use futures::{lock::Mutex, Stream, StreamExt};
@@ -21,7 +20,7 @@ where
     K: Clone + DeserializeOwned + Meta,
 {
     version: Arc<Mutex<String>>,
-    client: APIClient,
+    client: Client,
     resource: Resource,
     params: ListParams,
     needs_resync: Arc<Mutex<bool>>,
@@ -34,7 +33,7 @@ where
     K: Clone + DeserializeOwned + Meta,
 {
     /// Create a reflector with a kube client on a kube resource
-    pub fn new(client: APIClient, lp: ListParams, r: Resource) -> Self {
+    pub fn new(client: Client, lp: ListParams, r: Resource) -> Self {
         Informer {
             client,
             resource: r,

--- a/kube/src/runtime/reflector.rs
+++ b/kube/src/runtime/reflector.rs
@@ -1,7 +1,6 @@
 use crate::{
     api::{ListParams, Meta, ObjectList, Resource, WatchEvent},
-    client::APIClient,
-    Error, Result,
+    Client, Error, Result,
 };
 use futures::{lock::Mutex, StreamExt, TryStreamExt};
 use futures_timer::Delay;
@@ -41,7 +40,7 @@ where
     K: Clone + DeserializeOwned + Send + Meta,
 {
     state: Arc<Mutex<State<K>>>,
-    client: APIClient,
+    client: Client,
     resource: Resource,
     params: ListParams,
 }
@@ -51,7 +50,7 @@ where
     K: Clone + DeserializeOwned + Meta + Send,
 {
     /// Create a reflector with a kube client on a resource
-    pub fn new(client: APIClient, lp: ListParams, r: Resource) -> Self {
+    pub fn new(client: Client, lp: ListParams, r: Resource) -> Self {
         Reflector {
             client,
             resource: r,

--- a/kube/src/runtime/reflector.rs
+++ b/kube/src/runtime/reflector.rs
@@ -3,8 +3,8 @@ use crate::{
     Client, Error, Result,
 };
 use futures::{lock::Mutex, StreamExt, TryStreamExt};
-use futures_timer::Delay;
 use serde::de::DeserializeOwned;
+use tokio::time::delay_for;
 
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
@@ -76,7 +76,7 @@ where
             warn!("Poll error on {}: {}: {:?}", self.resource.kind, e, e);
             // If desynched due to mismatching resourceVersion, retry in a bit
             let dur = Duration::from_secs(10);
-            Delay::new(dur).await;
+            delay_for(dur).await;
             self.reset().await?; // propagate error if this failed..
         }
 


### PR DESCRIPTION
rename `APIClient` to `Client` and expose it straight on `kube`.

Added a `Client::inferred` that will try the most sensible config for you.
Added a `Config::inferred` that the above ultimately defers to.
move old `Client::new` to a `From<Configuration>` impl.

swap futures_timer for tokio (feature time only)