### PR TITLE
Rename references to kubeconfig to not include space.

### DIFF
--- a/kube/src/api/crds.rs
+++ b/kube/src/api/crds.rs
@@ -152,7 +152,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[ignore] // circle has no kube config
+    #[ignore] // circle has no kubeconfig
     async fn convenient_custom_resource() {
         use crate::{Api, Client};
         #[derive(Clone, Debug, kube_derive::CustomResource, Deserialize, Serialize)]

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -88,7 +88,7 @@ impl Client {
     /// configuration.
     ///
     /// Will use [`Config::infer`] to try in-cluster enironment
-    /// variables first, then fallback to the local kube config.
+    /// variables first, then fallback to the local kubeconfig.
     ///
     /// Will fail if neither configuration could be loaded.
     ///

--- a/kube/src/config/exec.rs
+++ b/kube/src/config/exec.rs
@@ -46,13 +46,13 @@ pub fn auth_exec(auth: &ExecConfig) -> Result<ExecCredential> {
     }
     let out = cmd
         .output()
-        .map_err(|e| Error::KubeConfig(format!("Unable to run auth exec: {}", e)))?;
+        .map_err(|e| Error::Kubeconfig(format!("Unable to run auth exec: {}", e)))?;
     if !out.status.success() {
         let err = format!("command `{:?}` failed: {:?}", cmd, out);
-        return Err(Error::KubeConfig(err));
+        return Err(Error::Kubeconfig(err));
     }
     let creds = serde_json::from_slice(&out.stdout)
-        .map_err(|e| Error::KubeConfig(format!("Unable to parse auth exec result: {}", e)))?;
+        .map_err(|e| Error::Kubeconfig(format!("Unable to parse auth exec result: {}", e)))?;
 
     Ok(creds)
 }

--- a/kube/src/config/file_config.rs
+++ b/kube/src/config/file_config.rs
@@ -2,14 +2,14 @@ use std::{collections::HashMap, fs::File, path::Path};
 
 use crate::{config::utils, oauth2, Error, Result};
 
-/// [`KubeConfig`] represents information on how to connect to a remote kubernetes cluster
+/// [`Kubeconfig`] represents information on how to connect to a remote kubernetes cluster
 /// that is normally stored in `~/.kube/config`
 ///
 /// This type (and its children) are exposed for convenience only.
 /// Please load a [`Config`] object for use with a `kube::Client`
-/// which will read and parse the kube config file
+/// which will read and parse the kubeconfig file
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct KubeConfig {
+pub struct Kubeconfig {
     pub kind: Option<String>,
     #[serde(rename = "apiVersion")]
     pub api_version: Option<String>,
@@ -129,16 +129,16 @@ pub struct Context {
 }
 
 /// Some helpers on the raw Config object are exposed for people needing to parse it
-impl KubeConfig {
+impl Kubeconfig {
     /// Read a Config from an arbitrary location
-    pub fn read_from<P: AsRef<Path>>(path: P) -> Result<KubeConfig> {
-        let f = File::open(path).map_err(|e| Error::KubeConfig(format!("{}", e)))?;
-        let config = serde_yaml::from_reader(f).map_err(|e| Error::KubeConfig(format!("{}", e)))?;
+    pub fn read_from<P: AsRef<Path>>(path: P) -> Result<Kubeconfig> {
+        let f = File::open(path).map_err(|e| Error::Kubeconfig(format!("{}", e)))?;
+        let config = serde_yaml::from_reader(f).map_err(|e| Error::Kubeconfig(format!("{}", e)))?;
         Ok(config)
     }
 
     /// Read a Config from the default location
-    pub fn read() -> Result<KubeConfig> {
+    pub fn read() -> Result<Kubeconfig> {
         let path = utils::find_kubeconfig()?;
         Self::read_from(path)
     }
@@ -151,7 +151,7 @@ impl Cluster {
         }
         let res =
             utils::data_or_file_with_base64(&self.certificate_authority_data, &self.certificate_authority)
-                .map_err(|e| Error::KubeConfig(format!("{}", e)))?;
+                .map_err(|e| Error::Kubeconfig(format!("{}", e)))?;
         Ok(Some(res))
     }
 }
@@ -181,11 +181,11 @@ impl AuthInfo {
 
     pub(crate) fn load_client_certificate(&self) -> Result<Vec<u8>> {
         utils::data_or_file_with_base64(&self.client_certificate_data, &self.client_certificate)
-            .map_err(|e| Error::KubeConfig(format!("{}", e)))
+            .map_err(|e| Error::Kubeconfig(format!("{}", e)))
     }
 
     pub(crate) fn load_client_key(&self) -> Result<Vec<u8>> {
         utils::data_or_file_with_base64(&self.client_key_data, &self.client_key)
-            .map_err(|e| Error::KubeConfig(format!("{}", e)))
+            .map_err(|e| Error::Kubeconfig(format!("{}", e)))
     }
 }

--- a/kube/src/config/incluster_config.rs
+++ b/kube/src/config/incluster_config.rs
@@ -34,7 +34,7 @@ pub fn load_token() -> Result<String> {
 /// Returns certification from specified path in cluster.
 pub fn load_cert() -> Result<Certificate> {
     let ca = utils::data_or_file_with_base64(&None, &Some(SERVICE_CERTFILE))?;
-    Certificate::from_pem(&ca).map_err(|e| Error::KubeConfig(format!("{}", e)))
+    Certificate::from_pem(&ca).map_err(|e| Error::Kubeconfig(format!("{}", e)))
 }
 
 /// Returns the default namespace from specified path in cluster.

--- a/kube/src/config/utils.rs
+++ b/kube/src/config/utils.rs
@@ -15,7 +15,7 @@ const KUBECONFIG: &str = "KUBECONFIG";
 pub fn find_kubeconfig() -> Result<PathBuf> {
     kubeconfig_path()
         .or_else(default_kube_path)
-        .ok_or_else(|| Error::KubeConfig("Failed to find path of kubeconfig".into()))
+        .ok_or_else(|| Error::Kubeconfig("Failed to find path of kubeconfig".into()))
 }
 
 /// Returns kubeconfig path from specified environment variable.
@@ -31,7 +31,7 @@ pub fn default_kube_path() -> Option<PathBuf> {
 pub fn data_or_file_with_base64<P: AsRef<Path>>(data: &Option<String>, file: &Option<P>) -> Result<Vec<u8>> {
     match (data, file) {
         (Some(d), _) => {
-            base64::decode(&d).map_err(|e| Error::KubeConfig(format!("Failed to decode base64: {}", e)))
+            base64::decode(&d).map_err(|e| Error::Kubeconfig(format!("Failed to decode base64: {}", e)))
         }
         (_, Some(f)) => {
             let f = (*f).as_ref();
@@ -40,18 +40,18 @@ pub fn data_or_file_with_base64<P: AsRef<Path>>(data: &Option<String>, file: &Op
             } else {
                 find_kubeconfig().and_then(|cfg| {
                     cfg.parent().map(|kubedir| kubedir.join(f)).ok_or_else(|| {
-                        Error::KubeConfig(format!("Failed to compute the absolute path of '{:?}'", f))
+                        Error::Kubeconfig(format!("Failed to compute the absolute path of '{:?}'", f))
                     })
                 })?
             };
             // dbg!(&abs_file);
-            let mut ff = File::open(&abs_file).map_err(|e| Error::KubeConfig(format!("{}", e)))?;
+            let mut ff = File::open(&abs_file).map_err(|e| Error::Kubeconfig(format!("{}", e)))?;
             let mut b = vec![];
             ff.read_to_end(&mut b)
-                .map_err(|e| Error::KubeConfig(format!("Failed to read file: {}", e)))?;
+                .map_err(|e| Error::Kubeconfig(format!("Failed to read file: {}", e)))?;
             Ok(b)
         }
-        _ => Err(Error::KubeConfig(
+        _ => Err(Error::Kubeconfig(
             "Failed to get data/file with base64 format".into(),
         )),
     }
@@ -63,12 +63,12 @@ pub fn data_or_file<P: AsRef<Path>>(data: &Option<String>, file: &Option<P>) -> 
         (_, Some(f)) => {
             let mut s = String::new();
             let mut ff =
-                File::open(f).map_err(|e| Error::KubeConfig(format!("Failed to open file: {}", e)))?;
+                File::open(f).map_err(|e| Error::Kubeconfig(format!("Failed to open file: {}", e)))?;
             ff.read_to_string(&mut s)
-                .map_err(|e| Error::KubeConfig(format!("Failed to read file: {}", e)))?;
+                .map_err(|e| Error::Kubeconfig(format!("Failed to read file: {}", e)))?;
             Ok(s)
         }
-        _ => Err(Error::KubeConfig("Failed to get data/file".into())),
+        _ => Err(Error::Kubeconfig("Failed to get data/file".into())),
     }
 }
 

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -1,7 +1,9 @@
 use thiserror::Error;
 
-#[macro_use] extern crate serde_derive;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate log;
 
 #[derive(Error, Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[error("{message}: {reason}")]
@@ -49,8 +51,8 @@ pub enum Error {
     RequestValidation(String),
 
     /// Configuration error
-    #[error("Error loading kube config: {0}")]
-    KubeConfig(String),
+    #[error("Error loading kubeconfig: {0}")]
+    Kubeconfig(String),
 
     #[error("SslError: {0}")]
     SslError(String),
@@ -61,8 +63,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub mod api;
 pub use api::{Api, Resource};
 pub mod client;
-#[doc(inline)] pub use client::Client;
+#[doc(inline)]
+pub use client::Client;
 pub mod config;
-#[doc(inline)] pub use config::Config;
+#[doc(inline)]
+pub use config::Config;
 mod oauth2;
 pub mod runtime;

--- a/kube/src/oauth2/mod.rs
+++ b/kube/src/oauth2/mod.rs
@@ -68,11 +68,11 @@ impl Credentials {
     pub fn load() -> Result<Credentials> {
         let path = env::var_os(GOOGLE_APPLICATION_CREDENTIALS)
             .map(PathBuf::from)
-            .ok_or_else(|| Error::KubeConfig("Missing GOOGLE_APPLICATION_CREDENTIALS env".into()))?;
+            .ok_or_else(|| Error::Kubeconfig("Missing GOOGLE_APPLICATION_CREDENTIALS env".into()))?;
         let f = File::open(path)
-            .map_err(|e| Error::KubeConfig(format!("Unable to load credentials file: {}", e)))?;
+            .map_err(|e| Error::Kubeconfig(format!("Unable to load credentials file: {}", e)))?;
         let config = serde_json::from_reader(f)
-            .map_err(|e| Error::KubeConfig(format!("Unable to parse credentials file: {}", e)))?;
+            .map_err(|e| Error::Kubeconfig(format!("Unable to parse credentials file: {}", e)))?;
         Ok(config)
     }
 }
@@ -142,10 +142,10 @@ impl CredentialsClient {
             .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
             .send()
             .await
-            .map_err(|e| Error::KubeConfig(format!("Unable to request token: {}", e)))
+            .map_err(|e| Error::Kubeconfig(format!("Unable to request token: {}", e)))
             .and_then(|response| {
                 if response.status() != reqwest::StatusCode::OK {
-                    Err(Error::KubeConfig(format!(
+                    Err(Error::Kubeconfig(format!(
                         "Fail to retrieve new credential {:#?}",
                         response
                     )))
@@ -155,7 +155,7 @@ impl CredentialsClient {
             })?
             .json::<TokenResponse>()
             .await
-            .map_err(|e| Error::KubeConfig(format!("Unable to parse request token: {}", e)))?;
+            .map_err(|e| Error::Kubeconfig(format!("Unable to parse request token: {}", e)))?;
         Ok(token_response.into_token())
     }
 }


### PR DESCRIPTION
I believe the proper name is kubeconfig not "kube config" or "KubeConfig" or "kube-config".

This makes the naming consistent 