### PR TITLE
error type for ssl errors - fixes #206

### DIFF
--- a/kube/src/config/file_loader.rs
+++ b/kube/src/config/file_loader.rs
@@ -106,8 +106,7 @@ impl ConfigLoader {
         let x509 = X509::from_pem(&client_cert)?;
         let pkey = PKey::private_key_from_pem(&client_key)?;
 
-        let p12 = Pkcs12::builder()
-            .build(password, "kubeconfig", &pkey, &x509)?;
+        let p12 = Pkcs12::builder().build(password, "kubeconfig", &pkey, &x509)?;
 
         let der = p12.to_der()?;
         // Make sure the buffer can be parsed properly but throw away the result
@@ -129,9 +128,7 @@ impl ConfigLoader {
 
     #[cfg(feature = "native-tls")]
     pub fn ca_bundle(&self) -> Result<Option<Vec<Der>>> {
-        let bundle = self
-            .cluster
-            .load_certificate_authority()?;
+        let bundle = self.cluster.load_certificate_authority()?;
 
         if let Some(bundle) = bundle {
             let bundle = X509::stack_from_pem(&bundle)?;

--- a/kube/src/config/file_loader.rs
+++ b/kube/src/config/file_loader.rs
@@ -103,14 +103,13 @@ impl ConfigLoader {
         let client_cert = &self.user.load_client_certificate()?;
         let client_key = &self.user.load_client_key()?;
 
-        let x509 = X509::from_pem(&client_cert).map_err(|e| Error::SslError(format!("{}", e)))?;
-        let pkey = PKey::private_key_from_pem(&client_key).map_err(|e| Error::SslError(format!("{}", e)))?;
+        let x509 = X509::from_pem(&client_cert)?;
+        let pkey = PKey::private_key_from_pem(&client_key)?;
 
         let p12 = Pkcs12::builder()
-            .build(password, "kubeconfig", &pkey, &x509)
-            .map_err(|e| Error::SslError(format!("{}", e)))?;
+            .build(password, "kubeconfig", &pkey, &x509)?;
 
-        let der = p12.to_der().map_err(|e| Error::SslError(format!("{}", e)))?;
+        let der = p12.to_der()?;
         // Make sure the buffer can be parsed properly but throw away the result
         let _identity = Identity::from_pkcs12_der(&der, password)?;
         Ok(der)
@@ -124,7 +123,7 @@ impl ConfigLoader {
         let mut buffer = client_key.clone();
         buffer.extend_from_slice(client_cert);
         // Make sure the buffer can be parsed properly but throw away the result
-        let _identity = Identity::from_pem(&buffer.as_slice()).map_err(|e| Error::SslError(format!("{}", e)));
+        let _identity = Identity::from_pem(&buffer.as_slice())?;
         Ok(buffer)
     }
 
@@ -132,15 +131,14 @@ impl ConfigLoader {
     pub fn ca_bundle(&self) -> Result<Option<Vec<Der>>> {
         let bundle = self
             .cluster
-            .load_certificate_authority()
-            .map_err(|e| Error::SslError(format!("{}", e)))?;
+            .load_certificate_authority()?;
 
         if let Some(bundle) = bundle {
-            let bundle = X509::stack_from_pem(&bundle).map_err(|e| Error::SslError(format!("{}", e)))?;
+            let bundle = X509::stack_from_pem(&bundle)?;
 
             let mut stack = vec![];
             for ca in bundle {
-                let der = ca.to_der().map_err(|e| Error::SslError(format!("{}", e)))?;
+                let der = ca.to_der()?;
                 stack.push(Der(der))
             }
             return Ok(Some(stack));

--- a/kube/src/config/utils.rs
+++ b/kube/src/config/utils.rs
@@ -1,7 +1,5 @@
 use std::{
-    env,
-    fs::File,
-    io::Read,
+    env, fs,
     path::{Path, PathBuf},
 };
 
@@ -45,11 +43,8 @@ pub fn data_or_file_with_base64<P: AsRef<Path>>(data: &Option<String>, file: &Op
                 })?
             };
             // dbg!(&abs_file);
-            let mut ff = File::open(&abs_file).map_err(|e| Error::Kubeconfig(format!("{}", e)))?;
-            let mut b = vec![];
-            ff.read_to_end(&mut b)
-                .map_err(|e| Error::Kubeconfig(format!("Failed to read file: {}", e)))?;
-            Ok(b)
+            fs::read(&abs_file)
+                .map_err(|e| Error::Kubeconfig(format!("Failed to read {:?}: {}", abs_file, e)))
         }
         _ => Err(Error::Kubeconfig(
             "Failed to get data/file with base64 format".into(),
@@ -61,12 +56,7 @@ pub fn data_or_file<P: AsRef<Path>>(data: &Option<String>, file: &Option<P>) -> 
     match (data, file) {
         (Some(d), _) => Ok(d.to_string()),
         (_, Some(f)) => {
-            let mut s = String::new();
-            let mut ff =
-                File::open(f).map_err(|e| Error::Kubeconfig(format!("Failed to open file: {}", e)))?;
-            ff.read_to_string(&mut s)
-                .map_err(|e| Error::Kubeconfig(format!("Failed to read file: {}", e)))?;
-            Ok(s)
+            fs::read_to_string(f).map_err(|e| Error::Kubeconfig(format!("Failed to read file: {}", e)))
         }
         _ => Err(Error::Kubeconfig("Failed to get data/file".into())),
     }

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -59,7 +59,7 @@ pub enum Error {
     /// An error from openssl when handling configuration
     #[cfg(feature = "native-tls")]
     #[error("TlsError: {0}")]
-    SslError2(#[from] openssl::error::ErrorStack)
+    SslError2(#[from] openssl::error::ErrorStack),
 }
 
 /// An Error response from the API

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -58,8 +58,8 @@ pub enum Error {
 
     /// An error from openssl when handling configuration
     #[cfg(feature = "native-tls")]
-    #[error("TlsError: {0}")]
-    SslError2(#[from] openssl::error::ErrorStack),
+    #[error("OpensslError: {0}")]
+    OpensslError(#[from] openssl::error::ErrorStack),
 }
 
 /// An Error response from the API

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -44,7 +44,7 @@ pub enum Error {
     #[error("Invalid API method {0}")]
     InvalidMethod(String),
 
-    /// A request validation failed  
+    /// A request validation failed
     #[error("Request validation failed with {0}")]
     RequestValidation(String),
 
@@ -55,6 +55,11 @@ pub enum Error {
     /// An error with configuring SSL occured
     #[error("SslError: {0}")]
     SslError(String),
+
+    /// An error from openssl when handling configuration
+    #[cfg(feature = "native-tls")]
+    #[error("TlsError: {0}")]
+    SslError2(#[from] openssl::error::ErrorStack)
 }
 
 /// An Error response from the API

--- a/kube/src/oauth2/mod.rs
+++ b/kube/src/oauth2/mod.rs
@@ -173,19 +173,11 @@ fn jws_encode(claim: &Claim, header: &Header, private_key: &str) -> Result<Strin
 #[cfg(feature = "native-tls")]
 fn sign(signature_base: &str, private_key: &str) -> Result<Vec<u8>> {
     use openssl::{hash::MessageDigest, pkey::PKey, rsa::Padding, sign::Signer};
-    let key =
-        PKey::private_key_from_pem(private_key.as_bytes()).map_err(|e| Error::SslError(format!("{}", e)))?;
-    let mut signer =
-        Signer::new(MessageDigest::sha256(), &key).map_err(|e| Error::SslError(format!("{}", e)))?;
-    signer
-        .set_rsa_padding(Padding::PKCS1)
-        .map_err(|e| Error::SslError(format!("{}", e)))?;
-    signer
-        .update(signature_base.as_bytes())
-        .map_err(|e| Error::SslError(format!("{}", e)))?;
-    signer
-        .sign_to_vec()
-        .map_err(|e| Error::SslError(format!("{}", e)))
+    let key = PKey::private_key_from_pem(private_key.as_bytes())?;
+    let mut signer = Signer::new(MessageDigest::sha256(), &key)?;
+    signer.set_rsa_padding(Padding::PKCS1)?;
+    signer.update(signature_base.as_bytes())?;
+    Ok(signer.sign_to_vec()?)
 }
 
 #[cfg(feature = "rustls-tls")]


### PR DESCRIPTION
An experiment to make the openssl interaction a little more DRY.
It was not particularly smart before, and it's not a whole lot more now, but at least it's easier to read.

Hoped there was a similar type for rustls, but rustls error type are frequently just `()` ([1](https://docs.rs/rustls/0.17.0/rustls/internal/pemfile/fn.pkcs8_private_keys.html), [2](https://docs.rs/rustls/0.17.0/rustls/internal/pemfile/fn.certs.html)..) so that makes this whole endeavour a little less attractive.

Not sure if worth it.