### PR TITLE
lift Api into Reflector + Informer, and fix Api::watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   * implement `TryFrom<Config> for Client`
   * `Client::try_default` or `Client::new` now recommended constructors
   * People parsing `~/.kube/config` must use the `KubeConfig` struct instead
+  * `Reflector<K>` now takes an `Api<K>` + `ListParams` to construct
+  * `Informer<K>` now takes an `Api<K>` + `ListParams` to construct
+  * `Api::watch` no longer filters out error events (`next` -> `try_next`)
+  * `Api::watch` returns `Result<WatchEvent>` rather than `WatchEvent`
 
 0.31.0 / 2020-03-27
 ===================

--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ A basic event watcher that presents a stream of api events on a resource with a 
 An Informer updates the last received `resourceVersion` internally on every event, before shipping the event to the app. If your controller restarts, you will receive one event for every active object at startup, before entering a normal watch.
 
 ```rust
-let r = Resource::all::<Pod>();
-let inf = Informer::new(client, r);
+let pods: Api<Pod> = Api::namespaced(client, "default");
+let inform = Informer::new(pods, pods);
 ```
 
 The main feature of `Informer<K>` is being able to subscribe to events while having a streaming `.poll()` open:
 
 ```rust
-let pods = inf.poll().await?.boxed(); // starts a watch and returns a stream
+let pods = inform.poll().await?.boxed(); // starts a watch and returns a stream
 
 while let Some(event) = pods.try_next().await? { // await next event
     handle(event).await?; // pass the WatchEvent to a handler
@@ -133,10 +133,10 @@ A cache for `K` that keeps itself up to date. It does not expose events, but you
 
 
 ```rust
-let r = Resource::namespaced::<Node>(&namespace);
+let nodes: Api<Node> = Api::namespaced(client, &namespace);
 let lp = ListParams::default()
     .labels("beta.kubernetes.io/instance-type=m4.2xlarge");
-let rf = Reflector::new(client, lp, r);
+let rf = Reflector::new(nodes, lp);
 ```
 
 then you should `poll()` the reflector, and `state()` to get the current cached state:

--- a/kube/examples/configmap_reflector.rs
+++ b/kube/examples/configmap_reflector.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate log;
 use k8s_openapi::api::core::v1::ConfigMap;
 use kube::{
-    api::{ListParams, Meta, Resource},
+    api::{Api, ListParams, Meta},
     runtime::Reflector,
     Client,
 };
@@ -14,9 +14,9 @@ async fn main() -> anyhow::Result<()> {
     let client = Client::try_default().await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
-    let resource = Resource::namespaced::<ConfigMap>(&namespace);
+    let cms: Api<ConfigMap> = Api::namespaced(client, &namespace);
     let lp = ListParams::default().timeout(10); // short watch timeout in this example
-    let rf: Reflector<ConfigMap> = Reflector::new(client, lp, resource).init().await?;
+    let rf = Reflector::new(cms, lp).init().await?;
 
     // Can read initial state now:
     rf.state().await?.into_iter().for_each(|cm| {

--- a/kube/examples/crd_apply.rs
+++ b/kube/examples/crd_apply.rs
@@ -1,5 +1,5 @@
 #[macro_use] extern crate log;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use kube_derive::CustomResource;
 use serde::{Deserialize, Serialize};
 
@@ -108,7 +108,7 @@ async fn wait_for_crd_ready(crds: &Api<CustomResourceDefinition>) -> anyhow::Res
         .timeout(5); // should not take long
     let mut stream = crds.watch(&lp, "0").await?.boxed();
 
-    while let Some(status) = stream.next().await {
+    while let Some(status) = stream.try_next().await? {
         if let WatchEvent::Modified(s) = status {
             info!("Modify event for {}", Meta::name(&s));
             if let Some(s) = s.status {

--- a/kube/examples/crd_reflector.rs
+++ b/kube/examples/crd_reflector.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use tokio::time::delay_for;
 
 use kube::{
-    api::{ListParams, Meta, Resource},
+    api::{Api, ListParams, Meta},
     runtime::Reflector,
     Client,
 };
@@ -26,9 +26,9 @@ async fn main() -> anyhow::Result<()> {
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // This example requires `kubectl apply -f examples/foo.yaml` run first
-    let resource = Resource::namespaced::<Foo>(&namespace);
+    let foos: Api<Foo> = Api::namespaced(client, &namespace);
     let lp = ListParams::default().timeout(20); // low timeout in this example
-    let rf: Reflector<Foo> = Reflector::new(client, lp, resource).init().await?;
+    let rf = Reflector::new(foos, lp).init().await?;
 
     let cloned = rf.clone();
     tokio::spawn(async move {

--- a/kube/examples/deployment_reflector.rs
+++ b/kube/examples/deployment_reflector.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate log;
 use k8s_openapi::api::apps::v1::Deployment;
 use kube::{
-    api::{ListParams, Meta, Resource},
+    api::{Api, ListParams, Meta},
     runtime::Reflector,
     Client,
 };
@@ -14,9 +14,9 @@ async fn main() -> anyhow::Result<()> {
 
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
-    let resource = Resource::namespaced::<Deployment>(&namespace);
+    let deploys: Api<Deployment> = Api::namespaced(client, &namespace);
     let lp = ListParams::default().timeout(10); // short watch timeout in this example
-    let rf: Reflector<Deployment> = Reflector::new(client, lp, resource).init().await?;
+    let rf = Reflector::new(deploys, lp).init().await?;
 
     // rf is initialized with full state, which can be extracted on demand.
     // Output is an owned Vec<Deployment>

--- a/kube/examples/event_informer.rs
+++ b/kube/examples/event_informer.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate log;
 use k8s_openapi::api::core::v1::Event;
 use kube::{
-    api::{ListParams, Resource, WatchEvent},
+    api::{Api, ListParams, WatchEvent},
     runtime::Informer,
     Client,
 };
@@ -14,9 +14,9 @@ async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let client = Client::try_default().await?;
 
-    let events = Resource::all::<Event>();
+    let events: Api<Event> = Api::all(client);
     let lp = ListParams::default();
-    let ei = Informer::new(client, lp, events);
+    let ei = Informer::new(events, lp);
 
     loop {
         let mut events = ei.poll().await?.boxed();

--- a/kube/examples/job_api.rs
+++ b/kube/examples/job_api.rs
@@ -1,5 +1,5 @@
 #[macro_use] extern crate log;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::batch::v1::Job;
 use serde_json::json;
 
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
         .timeout(20); // should be done by then
     let mut stream = jobs.watch(&lp, "").await?.boxed();
 
-    while let Some(status) = stream.next().await {
+    while let Some(status) = stream.try_next().await? {
         match status {
             WatchEvent::Added(s) => info!("Added {}", Meta::name(&s)),
             WatchEvent::Modified(s) => {

--- a/kube/examples/node_informer.rs
+++ b/kube/examples/node_informer.rs
@@ -21,7 +21,7 @@ async fn main() -> anyhow::Result<()> {
     loop {
         let mut nodes = ni.poll().await?.boxed();
 
-        while let Some(ne) = nodes.next().await {
+        while let Some(ne) = nodes.try_next().await? {
             handle_nodes(&events, ne).await?;
         }
     }

--- a/kube/examples/node_reflector.rs
+++ b/kube/examples/node_reflector.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate log;
 use k8s_openapi::api::core::v1::Node;
 use kube::{
-    api::{ListParams, Meta, Resource},
+    api::{Api, ListParams, Meta},
     runtime::Reflector,
     Client,
 };
@@ -12,11 +12,11 @@ async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let client = Client::try_default().await?;
 
-    let resource = Resource::all::<Node>();
+    let nodes: Api<Node> = Api::all(client.clone());
     let lp = ListParams::default()
         .labels("beta.kubernetes.io/instance-type=m4.2xlarge") // filter instances by label
         .timeout(10); // short watch timeout in this example
-    let rf: Reflector<Node> = Reflector::new(client, lp, resource).init().await?;
+    let rf = Reflector::new(nodes, lp).init().await?;
 
     // rf is initialized with full state, which can be extracted on demand.
     // Output is an owned Vec<Node>

--- a/kube/examples/pod_informer.rs
+++ b/kube/examples/pod_informer.rs
@@ -2,7 +2,7 @@
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
-    api::{ListParams, Meta, Resource, WatchEvent},
+    api::{Api, ListParams, Meta, WatchEvent},
     runtime::Informer,
     Client,
 };
@@ -15,8 +15,8 @@ async fn main() -> anyhow::Result<()> {
     let client = Client::try_default().await?;
     let namespace = env::var("NAMESPACE").unwrap_or("default".into());
 
-    let resource = Resource::namespaced::<Pod>(&namespace);
-    let inf = Informer::new(client, ListParams::default(), resource);
+    let pods: Api<Pod> = Api::namespaced(client, &namespace);
+    let inf = Informer::new(pods, ListParams::default());
 
     loop {
         let mut pods = inf.poll().await?.boxed();

--- a/kube/examples/pod_reflector.rs
+++ b/kube/examples/pod_reflector.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate log;
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
-    api::{ListParams, Meta, Resource},
+    api::{Api, ListParams, Meta},
     runtime::Reflector,
     Client,
 };
@@ -15,9 +15,9 @@ async fn main() -> anyhow::Result<()> {
     let client = Client::try_default().await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
-    let resource = Resource::namespaced::<Pod>(&namespace);
+    let pods: Api<Pod> = Api::namespaced(client, &namespace);
     let lp = ListParams::default().timeout(10); // short watch timeout in this example
-    let rf: Reflector<Pod> = Reflector::new(client, lp, resource).init().await?;
+    let rf = Reflector::new(pods, lp).init().await?;
 
     // Can read initial state now:
     rf.state().await?.into_iter().for_each(|pod| {

--- a/kube/examples/secret_reflector.rs
+++ b/kube/examples/secret_reflector.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 
 use k8s_openapi::api::core::v1::Secret;
 use kube::{
-    api::{ListParams, Meta, Resource},
+    api::{Api, ListParams, Meta},
     runtime::Reflector,
     Client,
 };
@@ -36,9 +36,9 @@ async fn main() -> anyhow::Result<()> {
     let client = Client::try_default().await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
-    let resource = Resource::namespaced::<Secret>(&namespace);
+    let secrets: Api<Secret> = Api::namespaced(client, &namespace);
     let lp = ListParams::default().timeout(10); // short watch timeout in this example
-    let rf: Reflector<Secret> = Reflector::new(client, lp, resource).init().await?;
+    let rf = Reflector::new(secrets, lp).init().await?;
 
     // Can read initial state now:
     rf.state().await?.into_iter().for_each(|secret| {

--- a/kube/src/api/crds.rs
+++ b/kube/src/api/crds.rs
@@ -100,7 +100,7 @@ impl CrBuilder {
         let crd = self.build();
         Api {
             client,
-            api: crd.into(),
+            resource: crd.into(),
             phantom: PhantomData,
         }
     }
@@ -131,7 +131,7 @@ impl CustomResource {
     pub fn into_api<K>(self, client: Client) -> Api<K> {
         Api {
             client,
-            api: self.into(),
+            resource: self.into(),
             phantom: PhantomData,
         }
     }
@@ -168,15 +168,15 @@ mod test {
             foo: String,
         };
         let client = Client::try_default().await.unwrap();
-        let r1: Api<Foo> = Api::namespaced(client.clone(), "myns");
+        let a1: Api<Foo> = Api::namespaced(client.clone(), "myns");
 
-        let r2: Api<Foo> = CustomResource::kind("Foo")
+        let a2: Api<Foo> = CustomResource::kind("Foo")
             .group("clux.dev")
             .version("v1")
             .within("myns")
             .build()
             .into_api(client);
-        assert_eq!(r1.api.api_version, r2.api.api_version);
+        assert_eq!(a1.resource.api_version, a2.resource.api_version);
         // ^ ensures that traits are implemented
     }
 }

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -18,19 +18,19 @@ where
 {
     /// Fetch the scale subresource
     pub async fn get_scale(&self, name: &str) -> Result<Scale> {
-        let req = self.api.get_scale(name)?;
+        let req = self.resource.get_scale(name)?;
         self.client.request::<Scale>(req).await
     }
 
     /// Update the scale subresource
     pub async fn patch_scale(&self, name: &str, pp: &PatchParams, patch: Vec<u8>) -> Result<Scale> {
-        let req = self.api.patch_scale(name, &pp, patch)?;
+        let req = self.resource.patch_scale(name, &pp, patch)?;
         self.client.request::<Scale>(req).await
     }
 
     /// Replace the scale subresource
     pub async fn replace_scale(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<Scale> {
-        let req = self.api.replace_scale(name, &pp, data)?;
+        let req = self.resource.replace_scale(name, &pp, data)?;
         self.client.request::<Scale>(req).await
     }
 }
@@ -50,7 +50,7 @@ where
     ///
     /// This actually returns the whole K, with metadata, and spec.
     pub async fn get_status(&self, name: &str) -> Result<K> {
-        let req = self.api.get_status(name)?;
+        let req = self.resource.get_status(name)?;
         self.client.request::<K>(req).await
     }
 
@@ -78,7 +78,7 @@ where
     /// }
     /// ```
     pub async fn patch_status(&self, name: &str, pp: &PatchParams, patch: Vec<u8>) -> Result<K> {
-        let req = self.api.patch_status(name, &pp, patch)?;
+        let req = self.resource.patch_status(name, &pp, patch)?;
         self.client.request::<K>(req).await
     }
 
@@ -102,7 +102,7 @@ where
     /// }
     /// ```
     pub async fn replace_status(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<K> {
-        let req = self.api.replace_status(name, &pp, data)?;
+        let req = self.resource.replace_status(name, &pp, data)?;
         self.client.request::<K>(req).await
     }
 }
@@ -202,13 +202,13 @@ where
 {
     /// Fetch logs as a string
     pub async fn logs(&self, name: &str, lp: &LogParams) -> Result<String> {
-        let req = self.api.logs(name, lp)?;
+        let req = self.resource.logs(name, lp)?;
         Ok(self.client.request_text(req).await?)
     }
 
     /// Fetch logs as a stream of bytes
     pub async fn log_stream(&self, name: &str, lp: &LogParams) -> Result<impl Stream<Item = Result<Bytes>>> {
-        let req = self.api.logs(name, lp)?;
+        let req = self.resource.logs(name, lp)?;
         Ok(self.client.request_text_stream(req).await?)
     }
 }

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -266,7 +266,7 @@ where
     /// ```no_run
     /// use kube::{api::{Api, ListParams, Meta, WatchEvent}, Client};
     /// use k8s_openapi::api::batch::v1::Job;
-    /// use futures::StreamExt;
+    /// use futures::{StreamExt, TryStreamExt};
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
     ///     let client = Client::try_default().await?;
@@ -275,7 +275,7 @@ where
     ///         .fields("metadata.name=my_job")
     ///         .timeout(20); // upper bound of how long we watch for
     ///     let mut stream = jobs.watch(&lp, "0").await?.boxed();
-    ///     while let Some(status) = stream.next().await {
+    ///     while let Some(status) = stream.try_next().await? {
     ///         match status {
     ///             WatchEvent::Added(s) => println!("Added {}", Meta::name(&s)),
     ///             WatchEvent::Modified(s) => println!("Modified: {}", Meta::name(&s)),

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -167,6 +167,7 @@ impl Client {
         // We first construct a Stream of Vec<Result<T>> as we potentially might need to
         // yield multiple objects per loop, then we flatten it to the Stream<Result<T>> as expected.
         // Any reqwest errors will terminate this stream early.
+
         let stream = futures::stream::try_unfold((res, Vec::new()), |(mut resp, _buff)| {
             async {
                 let mut buff = _buff; // can be avoided, see #145
@@ -177,6 +178,10 @@ impl Client {
                             trace!("Some chunk of len {}", chunk.len());
                             //trace!("Chunk contents: {}", String::from_utf8_lossy(&chunk));
                             buff.extend_from_slice(&chunk);
+
+                            //if buff.len() > 32000 { // TEST CASE
+                            //    return Err(Error::InvalidMethod(format!("{}", buff.len())));
+                            //}
 
                             // If we've encountered a newline, see if we have any items to yield
                             if chunk.contains(&b'\n') {

--- a/kube/src/runtime/informer.rs
+++ b/kube/src/runtime/informer.rs
@@ -98,7 +98,6 @@ where
         let resource_version = self.version.lock().await.clone();
         let stream = self.api.watch(&self.params, &resource_version).await?;
 
-        info!("got here");
         // Intercept stream elements to update internal resourceVersion
         let newstream = stream.then(move |event| {
             // Clone our Arcs for each event

--- a/kube/src/runtime/informer.rs
+++ b/kube/src/runtime/informer.rs
@@ -7,7 +7,7 @@ use futures::{lock::Mutex, Stream, StreamExt};
 use serde::de::DeserializeOwned;
 use std::{sync::Arc, time::Duration};
 
-/// An event informer for a [`Resource`]
+/// An event informer for a Kubernetes ['Api'] resource
 ///
 /// This observes events on an `Api<K>` and tracks last seen versions.
 /// As per the kubernetes documentation, this is an abstraction that can


### PR DESCRIPTION
Lifts `Reflector` and `Informer` to use `Api` rather than the lower level `Resource` directly.
This simplifies the signature of the two a bit, but it required one change to `Api::watch`:

New return type is now:
- `Result<impl Stream<Item = Result<WatchEvent<K>>>> `

compared to the old:
- `Result<impl Stream<Item = WatchEvent<K>>>`

The old signature was there because `watch` was actually filtering out errors. I don't remember why we did this, it doesn't feel like a good pattern. Why would we want the app to just discard all these errors? Maybe this came from the initial async impl where we got EOF errors all over the place. :thinking: 

A couple of smaller changes herein:
- renames an internal field on `Api` (Api::api -> Api::resource)
- doc cleanups
- less error handling in informer (a lot of dead code in there that fell away from using Api)