### PR TITLE
self-driving reflector + signal handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
   * People parsing `~/.kube/config` must use the `KubeConfig` struct instead
   * `Reflector<K>` now only takes an `Api<K>` to construct (.params method)
   * `Informer<K>` now only takes an `Api<K>` to construct (.params method)
-  * `Reflector` is now self-polls #151
-  * `Reflector` now has basic signal handling #152
+  * `Informer::init_from` -> `Informer::set_version`
+  * `Reflector` now self-polls #151 + handles signals #152
+  * `Reflector::poll` made private in favour of `Reflector::run`
   * `Api::watch` no longer filters out error events (`next` -> `try_next`)
   * `Api::watch` returns `Result<WatchEvent>` rather than `WatchEvent`
   * `WatchEvent::Bookmark` added to enum

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
   * implement `TryFrom<Config> for Client`
   * `Client::try_default` or `Client::new` now recommended constructors
   * People parsing `~/.kube/config` must use the `KubeConfig` struct instead
-  * `Reflector<K>` now takes an `Api<K>` + `ListParams` to construct
-  * `Informer<K>` now takes an `Api<K>` + `ListParams` to construct
+  * `Reflector<K>` now only takes an `Api<K>` to construct (.params method)
+  * `Informer<K>` now only takes an `Api<K>` to construct (.params method)
+  * `Reflector` is now self-polls #151
+  * `Reflector` now has basic signal handling #152
   * `Api::watch` no longer filters out error events (`next` -> `try_next`)
   * `Api::watch` returns `Result<WatchEvent>` rather than `WatchEvent`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   * `Reflector` now has basic signal handling #152
   * `Api::watch` no longer filters out error events (`next` -> `try_next`)
   * `Api::watch` returns `Result<WatchEvent>` rather than `WatchEvent`
+  * `WatchEvent::Bookmark` added to enum
+  * `ListParams::allow_bookmarks` added
 
 0.31.0 / 2020-03-27
 ===================

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ An Informer updates the last received `resourceVersion` internally on every even
 
 ```rust
 let pods: Api<Pod> = Api::namespaced(client, "default");
-let inform = Informer::new(pods, pods);
+let inform = Informer::new(pods);
 ```
 
 The main feature of `Informer<K>` is being able to subscribe to events while having a streaming `.poll()` open:
@@ -120,7 +120,8 @@ async fn handle(event: WatchEvent<Pod>) -> anyhow::Result<()> {
         },
         WatchEvent::Error(e) => {
             println!("Error event: {:?}", e);
-        }
+        },
+        _ => {},
     }
     Ok(())
 }
@@ -136,7 +137,7 @@ A cache for `K` that keeps itself up to date. It does not expose events, but you
 let nodes: Api<Node> = Api::namespaced(client, &namespace);
 let lp = ListParams::default()
     .labels("beta.kubernetes.io/instance-type=m4.2xlarge");
-let rf = Reflector::new(nodes, lp);
+let rf = Reflector::new(nodes).params(lp);
 ```
 
 then you should `poll()` the reflector, and `state()` to get the current cached state:

--- a/kube/examples/configmap_informer.rs
+++ b/kube/examples/configmap_informer.rs
@@ -10,13 +10,13 @@ use kube::{
 /// Example way to read secrets
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    std::env::set_var("RUST_LOG", "info,kube=debug");
+    std::env::set_var("RUST_LOG", "info,kube=trace");
     env_logger::init();
     let client = Client::try_default().await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let cms: Api<ConfigMap> = Api::namespaced(client, &namespace);
-    let lp = ListParams::default().timeout(10); // short watch timeout in this example
+    let lp = ListParams::default().allow_bookmarks().timeout(10); // short watch timeout in this example
     let inf = Informer::new(cms).params(lp);
 
     loop {

--- a/kube/examples/configmap_informer.rs
+++ b/kube/examples/configmap_informer.rs
@@ -1,0 +1,28 @@
+#[macro_use] extern crate log;
+use futures::{StreamExt, TryStreamExt};
+use k8s_openapi::api::core::v1::ConfigMap;
+use kube::{
+    api::{Api, ListParams},
+    runtime::Informer,
+    Client,
+};
+
+/// Example way to read secrets
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    std::env::set_var("RUST_LOG", "info,kube=debug");
+    env_logger::init();
+    let client = Client::try_default().await?;
+    let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
+
+    let cms: Api<ConfigMap> = Api::namespaced(client, &namespace);
+    let lp = ListParams::default().timeout(10); // short watch timeout in this example
+    let inf = Informer::new(cms).params(lp);
+
+    loop {
+        let mut stream = inf.poll().await?.boxed();
+        while let Some(event) = stream.try_next().await? {
+            info!("Got: {:?}", event);
+        }
+    }
+}

--- a/kube/examples/configmap_reflector.rs
+++ b/kube/examples/configmap_reflector.rs
@@ -17,16 +17,17 @@ async fn main() -> anyhow::Result<()> {
     let cms: Api<ConfigMap> = Api::namespaced(client, &namespace);
     let lp = ListParams::default().timeout(10); // short watch timeout in this example
     let rf = Reflector::new(cms).params(lp);
-    let runner = rf.clone().run();
 
+    let rf2 = rf.clone(); // read from a clone in a task
     tokio::spawn(async move {
         loop {
             // Periodically read our state
             tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
-            let pods: Vec<_> = rf.state().await.unwrap().iter().map(Meta::name).collect();
+            let pods: Vec<_> = rf2.state().await.unwrap().iter().map(Meta::name).collect();
             info!("Current configmaps: {:?}", pods);
         }
     });
-    runner.await?;
+
+    rf.run().await?; // run reflector and listen for signals
     Ok(())
 }

--- a/kube/examples/crd_reflector.rs
+++ b/kube/examples/crd_reflector.rs
@@ -1,9 +1,6 @@
 #[macro_use] extern crate log;
-use std::time::Duration;
-
 use kube_derive::CustomResource;
 use serde::{Deserialize, Serialize};
-use tokio::time::delay_for;
 
 use kube::{
     api::{Api, ListParams, Meta},
@@ -28,21 +25,23 @@ async fn main() -> anyhow::Result<()> {
     // This example requires `kubectl apply -f examples/foo.yaml` run first
     let foos: Api<Foo> = Api::namespaced(client, &namespace);
     let lp = ListParams::default().timeout(20); // low timeout in this example
-    let rf = Reflector::new(foos, lp).init().await?;
+    let rf = Reflector::new(foos).params(lp);
+    let runner = rf.clone().run();
 
-    let cloned = rf.clone();
     tokio::spawn(async move {
         loop {
-            if let Err(e) = cloned.poll().await {
-                warn!("Poll error: {:?}", e);
-            }
+            // Periodically read our state
+            tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
+            let crds = rf
+                .state()
+                .await
+                .unwrap()
+                .iter()
+                .map(Meta::name)
+                .collect::<Vec<_>>();
+            info!("Current crds: {:?}", crds);
         }
     });
-
-    loop {
-        delay_for(Duration::from_secs(5)).await;
-        // Read updated internal state (instant):
-        let crds = rf.state().await?.iter().map(Meta::name).collect::<Vec<_>>();
-        info!("Current crds: {:?}", crds);
-    }
+    runner.await?;
+    Ok(())
 }

--- a/kube/examples/crd_reflector.rs
+++ b/kube/examples/crd_reflector.rs
@@ -26,13 +26,13 @@ async fn main() -> anyhow::Result<()> {
     let foos: Api<Foo> = Api::namespaced(client, &namespace);
     let lp = ListParams::default().timeout(20); // low timeout in this example
     let rf = Reflector::new(foos).params(lp);
-    let runner = rf.clone().run();
 
+    let rf2 = rf.clone(); // read from a clone in a task
     tokio::spawn(async move {
         loop {
             // Periodically read our state
             tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
-            let crds = rf
+            let crds = rf2
                 .state()
                 .await
                 .unwrap()
@@ -42,6 +42,6 @@ async fn main() -> anyhow::Result<()> {
             info!("Current crds: {:?}", crds);
         }
     });
-    runner.await?;
+    rf.run().await?; // run reflector and listen for signals
     Ok(())
 }

--- a/kube/examples/deployment_reflector.rs
+++ b/kube/examples/deployment_reflector.rs
@@ -16,33 +16,17 @@ async fn main() -> anyhow::Result<()> {
 
     let deploys: Api<Deployment> = Api::namespaced(client, &namespace);
     let lp = ListParams::default().timeout(10); // short watch timeout in this example
-    let rf = Reflector::new(deploys, lp).init().await?;
+    let rf = Reflector::new(deploys).params(lp);
+    let runner = rf.clone().run();
 
-    // rf is initialized with full state, which can be extracted on demand.
-    // Output is an owned Vec<Deployment>
-    rf.state().await?.into_iter().for_each(|d| {
-        info!(
-            "Found deployment for {} - {} replicas running {:?}",
-            Meta::name(&d),
-            d.status.unwrap().replicas.unwrap(),
-            d.spec
-                .unwrap()
-                .template
-                .spec
-                .unwrap()
-                .containers
-                .into_iter()
-                .map(|c| c.image.unwrap())
-                .collect::<Vec<_>>()
-        );
+    tokio::spawn(async move {
+        loop {
+            // Periodically read our state
+            tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
+            let deploys: Vec<_> = rf.state().await.unwrap().iter().map(Meta::name).collect();
+            info!("Current deploys: {:?}", deploys);
+        }
     });
-
-    loop {
-        // Update internal state by calling watch (waits the full timeout)
-        rf.poll().await?;
-
-        // Read the updated internal state (instant):
-        let deploys: Vec<_> = rf.state().await?.iter().map(Meta::name).collect();
-        info!("Current deploys: {:?}", deploys);
-    }
+    runner.await?;
+    Ok(())
 }

--- a/kube/examples/event_informer.rs
+++ b/kube/examples/event_informer.rs
@@ -16,7 +16,7 @@ async fn main() -> anyhow::Result<()> {
 
     let events: Api<Event> = Api::all(client);
     let lp = ListParams::default();
-    let ei = Informer::new(events, lp);
+    let ei = Informer::new(events).params(lp);
 
     loop {
         let mut events = ei.poll().await?.boxed();
@@ -47,6 +47,7 @@ fn handle_event(ev: WatchEvent<Event>) -> anyhow::Result<()> {
         WatchEvent::Error(e) => {
             warn!("Error event: {:?}", e);
         }
+        _ => {}
     }
     Ok(())
 }

--- a/kube/examples/job_api.rs
+++ b/kube/examples/job_api.rs
@@ -65,6 +65,7 @@ async fn main() -> anyhow::Result<()> {
             }
             WatchEvent::Deleted(s) => info!("Deleted {}", Meta::name(&s)),
             WatchEvent::Error(s) => error!("{}", s),
+            _ => {}
         }
     }
 

--- a/kube/examples/node_informer.rs
+++ b/kube/examples/node_informer.rs
@@ -16,7 +16,7 @@ async fn main() -> anyhow::Result<()> {
     let nodes: Api<Node> = Api::all(client.clone());
 
     let lp = ListParams::default().labels("beta.kubernetes.io/os=linux");
-    let ni = Informer::new(nodes, lp);
+    let ni = Informer::new(nodes).params(lp);
 
     loop {
         let mut nodes = ni.poll().await?.boxed();
@@ -77,6 +77,7 @@ async fn handle_nodes(events: &Api<Event>, ne: WatchEvent<Node>) -> anyhow::Resu
         WatchEvent::Error(e) => {
             warn!("Error event: {:?}", e);
         }
+        _ => {}
     }
     Ok(())
 }

--- a/kube/examples/node_reflector.rs
+++ b/kube/examples/node_reflector.rs
@@ -17,16 +17,16 @@ async fn main() -> anyhow::Result<()> {
         .labels("beta.kubernetes.io/instance-type=m4.2xlarge") // filter instances by label
         .timeout(10); // short watch timeout in this example
     let rf = Reflector::new(nodes).params(lp);
-    let runner = rf.clone().run();
 
+    let rf2 = rf.clone(); // read from a clone in a task
     tokio::spawn(async move {
         loop {
             // Periodically read our state
             tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
-            let deploys: Vec<_> = rf.state().await.unwrap().iter().map(Meta::name).collect();
+            let deploys: Vec<_> = rf2.state().await.unwrap().iter().map(Meta::name).collect();
             info!("Current {} nodes: {:?}", deploys.len(), deploys);
         }
     });
-    runner.await?;
+    rf.run().await?; // run reflector and listen for signals
     Ok(())
 }

--- a/kube/examples/pod_informer.rs
+++ b/kube/examples/pod_informer.rs
@@ -16,7 +16,7 @@ async fn main() -> anyhow::Result<()> {
     let namespace = env::var("NAMESPACE").unwrap_or("default".into());
 
     let pods: Api<Pod> = Api::namespaced(client, &namespace);
-    let inf = Informer::new(pods, ListParams::default());
+    let inf = Informer::new(pods).params(ListParams::default().timeout(10));
 
     loop {
         let mut pods = inf.poll().await?.boxed();

--- a/kube/examples/pod_informer.rs
+++ b/kube/examples/pod_informer.rs
@@ -50,6 +50,7 @@ fn handle_pod(ev: WatchEvent<Pod>) -> anyhow::Result<()> {
         WatchEvent::Deleted(o) => {
             info!("Deleted Pod: {}", Meta::name(&o));
         }
+        WatchEvent::Bookmark(_) => {}
         WatchEvent::Error(e) => {
             warn!("Error event: {:?}", e);
         }

--- a/kube/examples/pod_reflector.rs
+++ b/kube/examples/pod_reflector.rs
@@ -5,8 +5,6 @@ use kube::{
     runtime::Reflector,
     Client,
 };
-use std::time::Duration;
-use tokio::time::delay_for;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -17,34 +15,17 @@ async fn main() -> anyhow::Result<()> {
 
     let pods: Api<Pod> = Api::namespaced(client, &namespace);
     let lp = ListParams::default().timeout(10); // short watch timeout in this example
-    let rf = Reflector::new(pods, lp).init().await?;
+    let rf = Reflector::new(pods).params(lp);
+    let runner = rf.clone().run();
 
-    // Can read initial state now:
-    rf.state().await?.into_iter().for_each(|pod| {
-        let name = Meta::name(&pod);
-        let phase = pod.status.unwrap().phase.unwrap();
-        let containers = pod
-            .spec
-            .unwrap()
-            .containers
-            .into_iter()
-            .map(|c| c.name)
-            .collect::<Vec<_>>();
-        info!("Found initial pod {} ({}) with {:?}", name, phase, containers);
-    });
-
-    let cloned = rf.clone();
     tokio::spawn(async move {
         loop {
-            if let Err(e) = cloned.poll().await {
-                warn!("Poll error: {:?}", e);
-            }
+            // Periodically read our state
+            tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
+            let pods: Vec<_> = rf.state().await.unwrap().iter().map(Meta::name).collect();
+            info!("Current pods: {:?}", pods);
         }
     });
-
-    loop {
-        delay_for(Duration::from_secs(5)).await;
-        let pods: Vec<_> = rf.state().await?.iter().map(Meta::name).collect();
-        info!("Current pods: {:?}", pods);
-    }
+    runner.await?;
+    Ok(())
 }

--- a/kube/src/api/object.rs
+++ b/kube/src/api/object.rs
@@ -20,6 +20,11 @@ where
     Modified(K),
     /// Resource was deleted
     Deleted(K),
+    /// Resource bookmark
+    ///
+    /// From [Watch bookmarks](https://kubernetes.io/docs/reference/using-api/api-concepts/#watch-bookmarks)
+    /// NB: This became Beta first in Kubernetes 1.16
+    Bookmark(K),
     /// There was some kind of error
     Error(ErrorResponse),
 }
@@ -33,6 +38,7 @@ where
             WatchEvent::Added(_) => write!(f, "Added event"),
             WatchEvent::Modified(_) => write!(f, "Modified event"),
             WatchEvent::Deleted(_) => write!(f, "Deleted event"),
+            WatchEvent::Bookmark(_) => write!(f, "Bookmark event"),
             WatchEvent::Error(e) => write!(f, "Error event: {:?}", e),
         }
     }

--- a/kube/src/api/resource.rs
+++ b/kube/src/api/resource.rs
@@ -89,6 +89,7 @@ pub struct ListParams {
     pub include_uninitialized: bool,
     pub label_selector: Option<String>,
     pub timeout: Option<u32>,
+    pub allow_bookmarks: bool,
 }
 
 impl ListParams {
@@ -146,6 +147,12 @@ impl ListParams {
     /// If called, partially initialized resources are included in watch/list responses.
     pub fn include_uninitialized(mut self) -> Self {
         self.include_uninitialized = true;
+        self
+    }
+
+    /// Enables watch bookmarks from the api server if supported
+    pub fn allow_bookmarks(mut self) -> Self {
+        self.allow_bookmarks = true;
         self
     }
 }
@@ -317,6 +324,9 @@ impl Resource {
         }
         if let Some(labels) = &lp.label_selector {
             qp.append_pair("labelSelector", &labels);
+        }
+        if lp.allow_bookmarks {
+            qp.append_pair("allowWatchBookmarks", "true");
         }
 
         let urlstr = qp.finish();

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -280,6 +280,7 @@ where
     ///             WatchEvent::Added(s) => println!("Added {}", Meta::name(&s)),
     ///             WatchEvent::Modified(s) => println!("Modified: {}", Meta::name(&s)),
     ///             WatchEvent::Deleted(s) => println!("Deleted {}", Meta::name(&s)),
+    ///             WatchEvent::Bookmark(s) => {},
     ///             WatchEvent::Error(s) => println!("{}", s),
     ///         }
     ///     }

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -44,6 +44,10 @@ pub enum Error {
     #[error("Invalid API method {0}")]
     InvalidMethod(String),
 
+    /// Runtime reached an irrecoverable state
+    #[error("Runtime Error {0}")]
+    RuntimeError(String),
+
     /// A request validation failed
     #[error("Request validation failed with {0}")]
     RequestValidation(String),

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -47,7 +47,7 @@
 //!     let pod = pods.create(&PostParams::default(), &pod).await?;
 //!
 //!     // Create an informer for watching events about
-//!     let informer = Informer::new(pods,
+//!     let informer = Informer::new(pods).params(
 //!         ListParams::default()
 //!             .fields("metadata.name=my-container")
 //!             .timeout(10),

--- a/kube/src/runtime/informer.rs
+++ b/kube/src/runtime/informer.rs
@@ -126,7 +126,10 @@ where
             async move {
                 // Check if we need to update our version based on the incoming events
                 match &event {
-                    Ok(WatchEvent::Added(o)) | Ok(WatchEvent::Modified(o)) | Ok(WatchEvent::Deleted(o)) => {
+                    Ok(WatchEvent::Added(o))
+                    | Ok(WatchEvent::Modified(o))
+                    | Ok(WatchEvent::Deleted(o))
+                    | Ok(WatchEvent::Bookmark(o)) => {
                         // always store the last seen resourceVersion
                         if let Some(nv) = Meta::resource_ver(o) {
                             *version.lock().await = nv.clone();

--- a/kube/src/runtime/informer.rs
+++ b/kube/src/runtime/informer.rs
@@ -20,6 +20,9 @@ use std::{sync::Arc, time::Duration};
 /// but we have configured timeouts such that this should not happen frequently.
 ///
 /// On boot, the initial watch causes added events for every currently live object.
+///
+/// Because of https://github.com/clux/kube-rs/issues/219 we recommend you use this
+/// with kubernetes >= 1.16 and watch bookmarks enabled.
 #[derive(Clone)]
 pub struct Informer<K>
 where

--- a/kube/src/runtime/reflector.rs
+++ b/kube/src/runtime/reflector.rs
@@ -96,6 +96,9 @@ where
                     debug!("Removing {} from {}", Meta::name(&o), kind);
                     state.remove(&ObjectId::key_for(&o));
                 }
+                WatchEvent::Bookmark(o) => {
+                    debug!("Bookmarking {} from {}", Meta::name(&o), kind);
+                }
                 WatchEvent::Error(e) => {
                     warn!("Failed to watch {}: {:?}", kind, e);
                     return Err(Error::Api(e));

--- a/kube/src/runtime/reflector.rs
+++ b/kube/src/runtime/reflector.rs
@@ -23,7 +23,7 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 #[derive(Clone)]
 pub struct Reflector<K>
 where
-    K: Clone + DeserializeOwned + Send + Meta,
+    K: Clone + DeserializeOwned + Meta,
 {
     state: Arc<Mutex<State<K>>>,
     params: ListParams,
@@ -32,7 +32,7 @@ where
 
 impl<K> Reflector<K>
 where
-    K: Clone + DeserializeOwned + Meta + Send,
+    K: Clone + DeserializeOwned + Meta,
 {
     /// Create a reflector on an api resource
     pub fn new(api: Api<K>) -> Self {
@@ -82,8 +82,8 @@ where
         let resource_version = self.state.lock().await.version.clone();
         trace!("Polling {} from resourceVersion={}", kind, resource_version);
         let stream = self.api.watch(&self.params, &resource_version).await?;
-
         pin_mut!(stream);
+
         // For every event, modify our state
         while let Some(ev) = stream.try_next().await? {
             let mut state = self.state.lock().await;

--- a/kube/src/runtime/reflector.rs
+++ b/kube/src/runtime/reflector.rs
@@ -71,7 +71,6 @@ where
                     }
                 },
                 complete => continue, // another poll
-                //default => panic!(), // never runs - futures runs first, then complete
             }
         }
     }

--- a/kube/src/runtime/reflector.rs
+++ b/kube/src/runtime/reflector.rs
@@ -1,65 +1,107 @@
 use crate::{
-    api::{Api, ListParams, Meta, WatchEvent},
+    api::{Api, ListParams, Meta, Resource, WatchEvent},
+    runtime::Informer,
     Error, Result,
 };
 use futures::{lock::Mutex, StreamExt, TryStreamExt};
 use serde::de::DeserializeOwned;
-use tokio::time::delay_for;
 
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, sync::Arc};
 
 /// A reflection of state for a Kubernetes ['Api'] resource
 ///
-/// This watches and caches a `Resource<K>` by:
-/// - seeding the cache from a large initial list call
-/// - keeping track of initial, and subsequent resourceVersions
-/// - recovering when resourceVersions get desynced
+/// This builds on top of the ['Informer'] by tracking the events received,
+/// via ['Informer::poll']. This object will in fact use .poll() continuously,
+/// and use the results to maintain an up to date state map.
 ///
-/// It exposes it's internal state readably through a getter.
+/// It is prone to the same desync problems as an informer, but it will self-heal,
+/// as best as possible - though this means that you might occasionally see a full
+/// reset (boot equivalent) when network issues are encountered.
+/// During a reset, the state is cleared before it is rebuilt.
+///
+/// The internal state is exposed readably through a getter.
 #[derive(Clone)]
 pub struct Reflector<K>
 where
     K: Clone + DeserializeOwned + Send + Meta,
 {
     state: Arc<Mutex<State<K>>>,
-    api: Api<K>,
-    params: ListParams,
+    informer: Informer<K>,
+    resource: Resource,
 }
 
 impl<K> Reflector<K>
 where
-    K: Clone + DeserializeOwned + Meta + Send,
+    K: Clone + DeserializeOwned + Meta + Send + Sync,
 {
-    /// Create a reflector on an api resource with a set of parameters
-    pub fn new(api: Api<K>, lp: ListParams) -> Self {
+    /// Create a reflector on an api resource
+    pub fn new(api: Api<K>) -> Self {
         Reflector {
-            api,
-            params: lp,
+            resource: api.resource.clone(),
+            informer: Informer::new(api),
             state: Default::default(),
         }
     }
 
-    /// Initializes with a full list of data from a large initial LIST call
-    pub async fn init(self) -> Result<Self> {
-        info!("Starting Reflector for {}", self.api.resource.kind);
-        self.reset().await?;
-        Ok(self)
+    /// Modify the default watch parameters for the underlying watch
+    pub fn params(mut self, lp: ListParams) -> Self {
+        self.informer = self.informer.params(lp);
+        self
     }
 
-    /// Run a single watch poll
-    ///
-    /// If this returns an error, it tries a full refresh.
-    /// This is meant to be run continually in a thread/task. Spawn one.
-    pub async fn poll(&self) -> Result<()> {
-        trace!("Watching {}", self.api.resource.kind);
-        if let Err(e) = self.single_watch().await {
-            warn!("Poll error on {}: {}: {:?}", self.api.resource.kind, e, e);
-            // If desynched due to mismatching resourceVersion, retry in a bit
-            let dur = Duration::from_secs(10);
-            delay_for(dur).await;
-            self.reset().await?; // propagate error if this failed..
+    /// Start the reflectors self-driving polling
+    pub async fn run(self) -> Result<()> {
+        use futures::{future::FutureExt, pin_mut, select};
+        use tokio::signal;
+        loop {
+            let signal_fut = signal::ctrl_c().fuse(); // TODO: SIGTERM
+            let stream_fut = self.poll().fuse();
+            pin_mut!(signal_fut, stream_fut);
+            select! {
+                sig = signal_fut => {
+                    warn!("Intercepted ctrl_c signal");
+                    return Ok(());
+                },
+                stream = stream_fut => {
+                    if let Err(e) = stream {
+                        error!("Kube state failed to recover: {}", e);
+                        return Err(e);
+                    }
+                },
+                complete => continue, // another poll
+                //default => panic!(), // never runs - futures runs first, then complete
+            }
         }
+    }
 
+    /// A single poll call to modify the internal state
+    async fn poll(&self) -> Result<()> {
+        let kind = &self.resource.kind;
+        trace!("Polling {}", kind);
+        let mut stream = self.informer.poll().await?.boxed();
+
+        // For every event, modify our state
+        while let Some(ev) = stream.try_next().await? {
+            let mut state = self.state.lock().await;
+            match ev {
+                WatchEvent::Added(o) => {
+                    debug!("Adding {} to {}", Meta::name(&o), kind);
+                    state.entry(ObjectId::key_for(&o)).or_insert_with(|| o.clone());
+                }
+                WatchEvent::Modified(o) => {
+                    debug!("Modifying {} in {}", Meta::name(&o), kind);
+                    state.entry(ObjectId::key_for(&o)).and_modify(|e| *e = o.clone());
+                }
+                WatchEvent::Deleted(o) => {
+                    debug!("Removing {} from {}", Meta::name(&o), kind);
+                    state.remove(&ObjectId::key_for(&o));
+                }
+                WatchEvent::Error(e) => {
+                    warn!("Failed to watch {}: {:?}", kind, e);
+                    return Err(Error::Api(e));
+                }
+            }
+        }
         Ok(())
     }
 
@@ -68,7 +110,7 @@ where
     /// This is instant if you are reading and writing from the same context.
     pub async fn state(&self) -> Result<Vec<K>> {
         let state = self.state.lock().await;
-        Ok(state.data.values().cloned().collect::<Vec<K>>())
+        Ok(state.values().cloned().collect::<Vec<K>>())
     }
 
     /// Read a single entry by name
@@ -76,108 +118,38 @@ where
     /// Will read in the configured namsepace, or globally on non-namespaced reflectors.
     /// If you are using a non-namespaced resources with name clashes,
     /// Try [`Reflector::get_within`] instead.
-    pub fn get(&self, name: &str) -> Result<Option<K>> {
+    pub async fn get(&self, name: &str) -> Result<Option<K>> {
         let id = ObjectId {
             name: name.into(),
-            namespace: self.api.resource.namespace.clone(),
+            namespace: self.resource.namespace.clone(),
         };
 
-        futures::executor::block_on(async { Ok(self.state.lock().await.data.get(&id).map(Clone::clone)) })
+        Ok(self.state.lock().await.get(&id).map(Clone::clone))
     }
 
     /// Read a single entry by name within a specific namespace
     ///
     /// This is a more specific version of [`Reflector::get`].
     /// This is only useful if your reflector is configured to poll across namsepaces.
-    pub fn get_within(&self, name: &str, ns: &str) -> Result<Option<K>> {
+    pub async fn get_within(&self, name: &str, ns: &str) -> Result<Option<K>> {
         let id = ObjectId {
             name: name.into(),
             namespace: Some(ns.into()),
         };
-        futures::executor::block_on(async { Ok(self.state.lock().await.data.get(&id).map(Clone::clone)) })
+        Ok(self.state.lock().await.get(&id).map(Clone::clone))
     }
 
-    /// Reset the state with a full LIST call
-    pub async fn reset(&self) -> Result<()> {
-        trace!("Refreshing {}", self.api.resource.kind);
-        let (data, version) = self.get_full_resource_entries().await?;
-        *self.state.lock().await = State { data, version };
-        Ok(())
-    }
-
-    async fn get_full_resource_entries(&self) -> Result<(Cache<K>, String)> {
-        let res = self.api.list(&self.params).await?;
-        let version = res.metadata.resource_version.unwrap_or_default();
-        trace!(
-            "Got {} {} at resourceVersion={:?}",
-            res.items.len(),
-            self.api.resource.kind,
-            version
-        );
-        let mut data = BTreeMap::new();
-        for i in res.items {
-            // The non-generic parts we care about are spec + status
-            data.insert(ObjectId::key_for(&i), i);
-        }
-        let keys = data
-            .keys()
-            .map(ObjectId::to_string)
-            .collect::<Vec<_>>()
-            .join(", ");
-        debug!("Initialized with: [{}]", keys);
-        Ok((data, version))
-    }
-
-    // Watch helper
-    async fn single_watch(&self) -> Result<()> {
-        let rg = &self.api.resource;
-        let oldver = self.state.lock().await.version.clone();
-        let mut events = self.api.watch(&self.params, &oldver).await?.boxed();
-
-        // Follow docs conventions and store the last resourceVersion
-        // https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
-        while let Some(ev) = events.try_next().await? {
-            // Update in place:
-            let mut state = self.state.lock().await;
-            match ev {
-                WatchEvent::Added(o) => {
-                    debug!("Adding {} to {}", Meta::name(&o), rg.kind);
-                    state
-                        .data
-                        .entry(ObjectId::key_for(&o))
-                        .or_insert_with(|| o.clone());
-                    if let Some(v) = Meta::resource_ver(&o) {
-                        state.version = v.to_string();
-                    }
-                }
-                WatchEvent::Modified(o) => {
-                    debug!("Modifying {} in {}", Meta::name(&o), rg.kind);
-                    state
-                        .data
-                        .entry(ObjectId::key_for(&o))
-                        .and_modify(|e| *e = o.clone());
-                    if let Some(v) = Meta::resource_ver(&o) {
-                        state.version = v.to_string();
-                    }
-                }
-                WatchEvent::Deleted(o) => {
-                    debug!("Removing {} from {}", Meta::name(&o), rg.kind);
-                    state.data.remove(&ObjectId::key_for(&o));
-                    if let Some(v) = Meta::resource_ver(&o) {
-                        state.version = v.to_string();
-                    }
-                }
-                WatchEvent::Error(e) => {
-                    warn!("Failed to watch {}: {:?}", rg.kind, e);
-                    return Err(Error::Api(e));
-                }
-            }
-        }
-        Ok(())
+    /// Reset the state of the underlying informer and clear the cache
+    pub async fn reset(&self) {
+        trace!("Resetting {}", self.resource.kind);
+        *self.state.lock().await = Default::default();
+        self.informer.reset().await
     }
 }
 
 /// ObjectId represents an object by name and namespace (if any)
+///
+/// This is an internal subset of ['k8s_openapi::api::core::v1::ObjectReference']
 #[derive(Ord, PartialOrd, Hash, Eq, PartialEq, Clone)]
 struct ObjectId {
     name: String,
@@ -202,21 +174,5 @@ impl ObjectId {
     }
 }
 
-
 /// Internal representation for Reflector
-type Cache<K> = BTreeMap<ObjectId, K>;
-
-/// Internal shared state of Reflector
-struct State<K> {
-    data: Cache<K>,
-    version: String,
-}
-
-impl<K> Default for State<K> {
-    fn default() -> Self {
-        State {
-            data: Default::default(),
-            version: 0.to_string(),
-        }
-    }
-}
+type State<K> = BTreeMap<ObjectId, K>;


### PR DESCRIPTION
fixes #151 and fixes #152 with tokio::signal and a futures::select call.
~~drops a lot of Reflector logic to defer to Informer.~~

Also changes the api of Informer and Reflector to have clean constructors:
- Reflector::new(api).params(lp)
- Informer::new(api).params(lp)

~~Seems to work pretty well, but may need to deal with desyncs better.
Ran into the unordered resourceVersion issue on a really old namespace.
Need to double check if that can happen with old version.~~

The examples that are converted herein seem to work fine. Signal handler also works.