### PR TITLE
Fix 0.32.1 version number in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.33.1 / 2020-04-15
+0.32.1 / 2020-04-15
 ===================
   * add missing tokio `signal` feature as a dependency
   * upgrade all dependencies, including minor bumps to rustls and base64


### PR DESCRIPTION
Makes the version number in the changelog match the release tag.

![Screenshot from 2020-04-15 22-16-41](https://user-images.githubusercontent.com/1081140/79341537-eeeb2100-7f66-11ea-9195-9b75a855685a.png)

Ref: https://github.com/clux/kube-rs/commit/9a9449b03fd1be256b111aa3b878a8b434fb4d13