### PR TITLE
cleanup crd definition in example

### DIFF
--- a/kube/examples/crd_api.rs
+++ b/kube/examples/crd_api.rs
@@ -209,5 +209,20 @@ async fn main() -> anyhow::Result<()> {
             info!("Deleted collection of crds: status={:?}", status);
         }
     }
+
+    // Cleanup the CRD definition
+    match crds.delete("foos.clux.dev", &dp).await? {
+        Left(o) => {
+            info!(
+                "Deleting {} CRD definition: {:?}",
+                Meta::name(&o),
+                o.status.unwrap().conditions.unwrap().last()
+            );
+        }
+        Right(status) => {
+            info!("Deleted foos CRD definition: status={:?}", status);
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
minor nit, I was playing around with the examples and noticed this one deletes all instances of the CRD, but doesn't cleanup the CRD itself.

Thanks for your work!