### PR TITLE
feat(*): Adds automatic token refreshing

### DIFF
--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -32,7 +32,7 @@ openssl = { version = "0.10.29", optional = true }
 rustls = { version = "0.17.0", optional = true }
 bytes = "0.5.4"
 Inflector = "0.11.4"
-tokio = { version = "0.2.17", features = ["time", "signal"] }
+tokio = { version = "0.2.17", features = ["time", "signal", "sync"] }
 
 [dependencies.reqwest]
 version = "0.10.4"

--- a/kube/src/config/mod.rs
+++ b/kube/src/config/mod.rs
@@ -91,6 +91,9 @@ pub struct Config {
     /// This is stored in a raw buffer form so that Config can implement `Clone`
     /// (since [`reqwest::Identity`] does not currently implement `Clone`)
     pub(crate) identity: Option<(Vec<u8>, String)>,
+    /// The authentication header from the credentials available in the kubeconfig. This supports
+    /// exec plugins as well as specified in
+    /// https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
     pub(crate) auth_header: Authentication,
 }
 
@@ -245,6 +248,9 @@ impl Config {
     }
 }
 
+/// Loads the authentication header from the credentials available in the kubeconfig. This supports
+/// exec plugins as well as specified in
+/// https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
 fn load_auth_header(loader: &ConfigLoader) -> Result<Authentication> {
     let (raw_token, expiration) = match &loader.user.token {
         Some(token) => (Some(token.clone()), None),


### PR DESCRIPTION
This is by no means elegant, but seems to be functional. Setting the
authorization headers now occurs at request time instead of during
initial configuration. It will only try to refresh a token if the
configured expiration time has passed.

The second commit on this introduces what I think is probably a more easily readable version of the auth using an `enum`. If we don't like it, we can pop off that commit

Closes #72 
Closes #224 