### PR TITLE
Structured kubeconfig errors

### DIFF
--- a/kube/src/config/exec.rs
+++ b/kube/src/config/exec.rs
@@ -49,7 +49,7 @@ pub fn auth_exec(auth: &ExecConfig) -> Result<ExecCredential> {
     let out = cmd.output().map_err(ConfigError::AuthExecStart)?;
     if !out.status.success() {
         return Err(ConfigError::AuthExecRun {
-            cmd: Box::new(cmd),
+            cmd: format!("{:?}", cmd),
             status: out.status,
             out,
         }

--- a/kube/src/config/incluster_config.rs
+++ b/kube/src/config/incluster_config.rs
@@ -3,7 +3,7 @@ use std::env;
 use crate::{Error, Result};
 use reqwest::Certificate;
 
-use crate::config::utils;
+use crate::{error::ConfigError, config::utils};
 
 pub const SERVICE_HOSTENV: &str = "KUBERNETES_SERVICE_HOST";
 pub const SERVICE_PORTENV: &str = "KUBERNETES_SERVICE_PORT";
@@ -34,7 +34,7 @@ pub fn load_token() -> Result<String> {
 /// Returns certification from specified path in cluster.
 pub fn load_cert() -> Result<Certificate> {
     let ca = utils::data_or_file_with_base64(&None, &Some(SERVICE_CERTFILE))?;
-    Certificate::from_pem(&ca).map_err(|e| Error::Kubeconfig(format!("{}", e)))
+    Certificate::from_pem(&ca).map_err(ConfigError::LoadCert).map_err(Error::from)
 }
 
 /// Returns the default namespace from specified path in cluster.

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -1,6 +1,8 @@
 //! Error handling in [`kube`][crate]
 
+use http::header::InvalidHeaderValue;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use thiserror::Error;
 
 /// Possible errors when working with [`kube`][crate]
@@ -15,7 +17,7 @@ pub enum Error {
     ///
     /// It's quite common to get a `410 Gone` when the resourceVersion is too old.
     #[error("ApiError: {0} ({0:?})")]
-    Api(ErrorResponse),
+    Api(#[source] ErrorResponse),
 
     /// Reqwest error
     #[error("ReqwestError: {0}")]
@@ -54,7 +56,7 @@ pub enum Error {
 
     /// Configuration error
     #[error("Error loading kubeconfig: {0}")]
-    Kubeconfig(String),
+    Kubeconfig(#[from] ConfigError),
 
     /// An error with configuring SSL occured
     #[error("SslError: {0}")]
@@ -64,6 +66,111 @@ pub enum Error {
     #[cfg(feature = "native-tls")]
     #[error("OpensslError: {0}")]
     OpensslError(#[from] openssl::error::ErrorStack),
+}
+
+#[derive(Error, Debug)]
+// Redundant with the error messages and machine names
+#[allow(missing_docs)]
+/// Possible errors when loading config
+pub enum ConfigError {
+    #[error("Invalid basic auth: {0}")]
+    InvalidBasicAuth(#[source] InvalidHeaderValue),
+
+    #[error("Invalid bearer token: {0}")]
+    InvalidBearerToken(#[source] InvalidHeaderValue),
+
+    #[error("Tried to refresh a token and got a non-refreshable token response")]
+    /// Tried to refresh a token and got a non-refreshable token response
+    UnrefreshableTokenResponse,
+
+    #[error("Failed to infer config.. cluster env: ({cluster_env}), kubeconfig: ({kubeconfig})")]
+    ConfigInferenceExhausted {
+        cluster_env: Box<Error>,
+        // We can only pick one source, but the kubeconfig failure is more likely to be a user error
+        #[source]
+        kubeconfig: Box<Error>,
+    },
+
+    #[error("Unable to load in cluster config, {hostenv} and {portenv} must be defined")]
+    /// One or more required in-cluster config options are missing
+    MissingInClusterVariables {
+        hostenv: &'static str,
+        portenv: &'static str,
+    },
+
+    #[error("Unable to load incluster default namespace: {0}")]
+    InvalidInClusterNamespace(#[source] Box<Error>),
+
+    #[error("Unable to load in cluster token: {0}")]
+    InvalidInClusterToken(#[source] Box<Error>),
+
+    #[error("Malformed url: {0}")]
+    MalformedUrl(#[from] url::ParseError),
+
+    #[error("exec-plugin response did not contain a status")]
+    ExecPluginFailed,
+
+    #[error("Malformed token expiration date: {0}")]
+    MalformedTokenExpirationDate(#[source] chrono::ParseError),
+
+    #[error("Missing GOOGLE_APPLICATION_CREDENTIALS env")]
+    /// Missing GOOGLE_APPLICATION_CREDENTIALS env
+    MissingGoogleCredentials,
+
+    #[error("Unable to load OAuth2 credentials file: {0}")]
+    OAuth2LoadCredentials(#[source] std::io::Error),
+    #[error("Unable to parse OAuth2 credentials file: {0}")]
+    OAuth2ParseCredentials(#[source] serde_json::Error),
+    #[error("Unable to request token: {0}")]
+    OAuth2RequestToken(#[source] reqwest::Error),
+    #[error("Fail to retrieve new credential {0:?}")]
+    OAuth2RetrieveCredentials(Box<reqwest::Response>),
+    #[error("Unable to parse token: {0}")]
+    OAuth2ParseToken(#[source] reqwest::Error),
+
+    #[error("Unable to load config file: {0}")]
+    LoadConfigFile(#[source] Box<Error>),
+    #[error("Unable to load current context: {context_name}")]
+    LoadContext { context_name: String },
+    #[error("Unable to load cluster of context: {cluster_name}")]
+    LoadClusterOfContext { cluster_name: String },
+    #[error("Unable to find named user: {user_name}")]
+    FindUser { user_name: String },
+
+    #[error("Unable to find path of kubeconfig")]
+    NoKubeconfigPath,
+
+    #[error("Failed to decode base64: {0}")]
+    Base64Decode(#[source] base64::DecodeError),
+    #[error("Failed to compute the absolute path of '{path:?}'")]
+    NoAbsolutePath { path: PathBuf },
+    #[error("Failed to read '{path:?}': {source}")]
+    ReadFile {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to get data/file with base64 format")]
+    NoBase64FileOrData,
+    #[error("Failed to get data/file")]
+    NoFileOrData,
+
+    #[error("Failed to load certificate: {0}")]
+    LoadCert(#[source] reqwest::Error),
+
+    #[error("Failed to parse Kubeconfig YAML: {0}")]
+    ParseYaml(#[source] serde_yaml::Error),
+
+    #[error("Unable to run auth exec: {0}")]
+    AuthExecStart(#[source] std::io::Error),
+    #[error("Auth exec command '{cmd:?}' failed with status {status}: {out:?}")]
+    AuthExecRun {
+        cmd: Box<std::process::Command>,
+        status: std::process::ExitStatus,
+        out: std::process::Output,
+    },
+    #[error("Failed to parse auth exec output: {0}")]
+    AuthExecParse(#[source] serde_json::Error),
 }
 
 /// An Error response from the API

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -163,9 +163,9 @@ pub enum ConfigError {
 
     #[error("Unable to run auth exec: {0}")]
     AuthExecStart(#[source] std::io::Error),
-    #[error("Auth exec command '{cmd:?}' failed with status {status}: {out:?}")]
+    #[error("Auth exec command '{cmd}' failed with status {status}: {out:?}")]
     AuthExecRun {
-        cmd: Box<std::process::Command>,
+        cmd: String,
         status: std::process::ExitStatus,
         out: std::process::Output,
     },

--- a/kube/src/oauth2/mod.rs
+++ b/kube/src/oauth2/mod.rs
@@ -5,7 +5,10 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use crate::{error::ConfigError, Result};
+use crate::{
+    error::{ConfigError, Error},
+    Result,
+};
 
 use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Serialize};

--- a/kube/src/oauth2/mod.rs
+++ b/kube/src/oauth2/mod.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use crate::{Error, Result};
+use crate::{error::ConfigError, Result};
 
 use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Serialize};
@@ -69,11 +69,9 @@ impl Credentials {
     pub fn load() -> Result<Credentials> {
         let path = env::var_os(GOOGLE_APPLICATION_CREDENTIALS)
             .map(PathBuf::from)
-            .ok_or_else(|| Error::Kubeconfig("Missing GOOGLE_APPLICATION_CREDENTIALS env".into()))?;
-        let f = File::open(path)
-            .map_err(|e| Error::Kubeconfig(format!("Unable to load credentials file: {}", e)))?;
-        let config = serde_json::from_reader(f)
-            .map_err(|e| Error::Kubeconfig(format!("Unable to parse credentials file: {}", e)))?;
+            .ok_or_else(|| ConfigError::MissingGoogleCredentials)?;
+        let f = File::open(path).map_err(ConfigError::OAuth2LoadCredentials)?;
+        let config = serde_json::from_reader(f).map_err(ConfigError::OAuth2ParseCredentials)?;
         Ok(config)
     }
 }
@@ -143,20 +141,17 @@ impl CredentialsClient {
             .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
             .send()
             .await
-            .map_err(|e| Error::Kubeconfig(format!("Unable to request token: {}", e)))
+            .map_err(ConfigError::OAuth2RequestToken)
             .and_then(|response| {
                 if response.status() != reqwest::StatusCode::OK {
-                    Err(Error::Kubeconfig(format!(
-                        "Fail to retrieve new credential {:#?}",
-                        response
-                    )))
+                    Err(ConfigError::OAuth2RetrieveCredentials(Box::new(response)))
                 } else {
                     Ok(response)
                 }
             })?
             .json::<TokenResponse>()
             .await
-            .map_err(|e| Error::Kubeconfig(format!("Unable to parse request token: {}", e)))?;
+            .map_err(ConfigError::OAuth2ParseToken)?;
         Ok(token_response.into_token())
     }
 }


### PR DESCRIPTION
This makes the errors introspectable, which makes things like https://github.com/yaahc/color-eyre/ much nicer. It also allows you to inspect the error contents (though this API probably shouldn't be considered very stable..).