### PR TITLE
Allow type-asserting Resources into Api<K>s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-0.34.0 / 2020-05-XX
+0.35.0 / 2020-XX-XX
+===================
+  * Added `Api::from_dynamic_resource` for constructing `Api`s whose Group-Version-Kind is not known at compile time
+  * `k8s_openapi::Metadata` is no longer a supertrait of `Meta`
+    * If you need this, add an extra type bound for `k8s_openapi::Metadata` or switch from 
+      `k8s_openapi::Metadata::metadata()` to `Meta::meta()`
+
+0.34.0 / 2020-05-08
 ===================
   * Bump `k8s-openapi` to `0.8.0`
   * `Config::from_cluster_env` <- renamed from `Config::new_from_cluster_env`

--- a/kube/src/api/metadata.rs
+++ b/kube/src/api/metadata.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 /// - .metadata.resource_version
 ///
 /// This avoids a bunch of the unnecessary unwrap mechanics for apps
-pub trait Meta: Metadata {
+pub trait Meta {
     /// Metadata that all persisted resources must have
     fn meta(&self) -> &ObjectMeta;
     /// The name of the resource


### PR DESCRIPTION
Useful if the Group-Version-Kind is only known at runtime. See https://discordapp.com/channels/500028886025895936/685161813675212899/709314505590j440048.