### PR TITLE
Implement mutable metdata trait from Arnavion/k8s-openapi#67

### DIFF
--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -303,6 +303,12 @@ impl CustomDerive for CustomResource {
                 fn metadata(&self) -> Option<&Self::Ty> {
                     Some(&self.metadata)
                 }
+                fn metadata_mut(&mut self) -> Option<&mut Self::Ty> {
+                    Some(&mut self.metadata)
+                }
+                fn set_metadata(&mut self, metadata: Self::Ty) {
+                    self.metadata = metadata;
+                }
             }
         };
 


### PR DESCRIPTION
This implements the new mutable function from Arnavion/k8s-openapi#67.

It allows to set the metadata of a CRD, without needing the exact type, used to create a `create_or_update` function:

~~~rust
    async fn create_or_update<T, F>(
        &self,
        api: &Api<T>,
        namespace: String,
        name: String,
        mutator: F,
    ) -> Result<()>
    where
        T: Clone + Serialize + DeserializeOwned + Meta<Ty = ObjectMeta> + Default,
        F: FnOnce(T) -> Result<T>,
    {
        match api.get(&name).await {
            Err(Error::Api(ae)) if ae.code == 404 => {
                log::info!("CreateOrUpdate - Err(Api(404))");
                let mut object: T = Default::default();
                object.set_metadata(ObjectMeta {
                    namespace: Some(namespace),
                    name: Some(name),
                    ..Default::default()
                });
                let object = mutator(object)?;
                api.create(&PostParams::default(), &object).await?;
            }
            Err(e) => {
                log::info!("Error - {}", e);
                Err(e)?;
            }
            Ok(object) => {
                log::info!("CreateOrUpdate - Ok(...)");
                let object = mutator(object)?;
                api.replace(&name, &PostParams::default(), &object).await?;
            }
        };

        Ok(())
    }
~~~