### PR TITLE
generalize derive attrs for kube-derive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ workflows:
   all_jobs:
     jobs:
       - cargo_test
-      - windows_test
+      # windows executor costs money :/
+      #- windows_test
 
 jobs:
   cargo_test:

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro2 = "1.0.18"
 quote = "1.0.6"
 syn = { version = "1.0.30", features = ["extra-traits"] }
 Inflector = "0.11.4"
+serde_json = "1.0.53"
 
 [lib]
 proc-macro = true

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -133,7 +133,7 @@ impl CustomDerive for CustomResource {
                                 derives.push(lit.value());
                                 continue;
                             } else {
-                                return Err(r#"#[kube(printcolumn = "...")] expects a string literal value"#)
+                                return Err(r#"#[kube(derive = "...")] expects a string literal value"#)
                                     .spanning(meta);
                             }
                         } else if meta.path.is_ident("finalizer") {

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -262,9 +262,9 @@ impl CustomDerive for CustomResource {
             derives.push("PartialEq");
         }
         let derives: Vec<Ident> = derives.iter().map(|s| format_ident!("{}", s)).collect();
-
+        let docstring = format!(" Auto-generated type that wraps {} for the derived `CustomResource` trait", ident);
         let root_obj = quote! {
-            /// Auto-generated type the CustomResource around #ident
+            #[doc = #docstring]
             #[derive(#(#derives),*)]
             #[serde(rename_all = "camelCase")]
             #visibility struct #rootident {

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
     kind = "Foo",
     namespaced,
     status = "FooStatus",
-    finalizer = "mygc.foo.clux.dev",
+    finalizer = "mygc.foos.clux.dev",
     scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#,
     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
 )]
@@ -36,7 +36,7 @@ fn main() {
     foo.status = Some(FooStatus { is_bad: true });
     println!("Spec: {:?}", foo.spec);
     println!("finalizers: {:?}", foo.metadata.finalizers);
-    println!("Foo CRD: {:?}", Foo::crd());
+    println!("Foo CRD: \n{}", serde_json::to_string_pretty(&Foo::crd()).unwrap());
 }
 
 // some tests

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
     kind = "Foo",
     namespaced,
     status = "FooStatus",
+    shortname = "f",
     finalizer = "mygc.foos.clux.dev",
     scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#,
     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
@@ -36,7 +37,8 @@ fn main() {
     foo.status = Some(FooStatus { is_bad: true });
     println!("Spec: {:?}", foo.spec);
     println!("finalizers: {:?}", foo.metadata.finalizers);
-    println!("Foo CRD: \n{}", serde_json::to_string_pretty(&Foo::crd()).unwrap());
+    let crd = serde_json::to_string_pretty(&Foo::crd()).unwrap();
+    println!("Foo CRD: \n{}", crd);
 }
 
 // some tests

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
     kind = "Foo",
     namespaced,
     status = "FooStatus",
+    finalizer = "mygc.foo.clux.dev",
     scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#,
     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
 )]
@@ -34,6 +35,7 @@ fn main() {
     });
     foo.status = Some(FooStatus { is_bad: true });
     println!("Spec: {:?}", foo.spec);
+    println!("finalizers: {:?}", foo.metadata.finalizers);
     println!("Foo CRD: {:?}", Foo::crd());
 }
 

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -5,13 +5,14 @@ use serde::{Deserialize, Serialize};
 /// Our spec for Foo
 ///
 /// A struct with our chosen Kind will be created for us, using the following kube attrs
-#[derive(CustomResource, Serialize, Deserialize, Debug, Clone)]
+#[derive(CustomResource, Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[kube(
     group = "clux.dev",
     version = "v1",
     kind = "Foo",
     namespaced,
     status = "FooStatus",
+    derive = "PartialEq",
     shortname = "f",
     finalizer = "mygc.foos.clux.dev",
     scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#,
@@ -23,7 +24,7 @@ pub struct MyFoo {
     info: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FooStatus {
     is_bad: bool,
 }

--- a/kube/examples/crd_derive.rs
+++ b/kube/examples/crd_derive.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
     status = "FooStatus",
     derive = "PartialEq",
     shortname = "f",
-    finalizer = "mygc.foos.clux.dev",
     scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#,
     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
 )]
@@ -37,7 +36,6 @@ fn main() {
     });
     foo.status = Some(FooStatus { is_bad: true });
     println!("Spec: {:?}", foo.spec);
-    println!("finalizers: {:?}", foo.metadata.finalizers);
     let crd = serde_json::to_string_pretty(&Foo::crd()).unwrap();
     println!("Foo CRD: \n{}", crd);
 }

--- a/kube/src/config/mod.rs
+++ b/kube/src/config/mod.rs
@@ -268,13 +268,14 @@ impl Config {
     /// Configure a proxy for this kube config
     ///
     /// ```rust
-    /// # fn main() {
-    /// # async fn run() -> Result<(), Box< dyn std::error::Error>> {
-    /// let mut config = kube::Config::from_kubeconfig(&kube::config::KubeConfigOptions::default()).await?;
-    /// let proxy = reqwest::Proxy::http("https://localhost:8080")?;
-    /// let config = config.proxy(proxy);
-    /// # Ok(())
-    /// # }}
+    /// use kube::{Config, config};
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), kube::Error> {
+    ///     let mut config = Config::from_kubeconfig(&config::KubeConfigOptions::default()).await?;
+    ///     let proxy = reqwest::Proxy::http("https://localhost:8080")?;
+    ///     let config = config.proxy(proxy);
+    ///     Ok(())
+    /// }
     /// ```
     pub fn proxy(mut self, proxy: reqwest::Proxy) -> Self {
         self.proxy = Some(proxy);

--- a/kube/src/config/mod.rs
+++ b/kube/src/config/mod.rs
@@ -267,7 +267,7 @@ impl Config {
 
     /// Configure a proxy for this kube config
     ///
-    /// ```rust
+    /// ```no_run
     /// use kube::{Config, config};
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {


### PR DESCRIPTION
- ~~adds `#[kube(finalizer = "magic.finalizer.string")]` attr to kube-derive which is hooked into Foo::new~~
- adds serde_json to kube-derive so we use less hacky json serialization within the crate
- fixes #243 by allowing customizing additional derives for the generated struct