### PR TITLE
RT2: Drop pin-cell dependency

### DIFF
--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -12,7 +12,6 @@ derivative = "2.1.1"
 serde = "1.0.110"
 smallvec = "1.4.0"
 pin-project = "0.4.16"
-pin-cell = { git = "https://github.com/withoutboats/pin-cell" }
 tokio = { version = "0.2.21", features = ["time"] }
 snafu = { version = "0.6.8", features = ["futures"] }
 dashmap = "4.0.0-rc6"

--- a/kube-runtime/src/controller.rs
+++ b/kube-runtime/src/controller.rs
@@ -95,7 +95,7 @@ where
     K: Clone + Meta + 'static,
     ReconcilerFut: TryFuture<Ok = ReconcilerAction>,
     ReconcilerFut::Error: std::error::Error + 'static,
-    QueueStream: TryStream<Ok = ObjectRef<K>>,
+    QueueStream: TryStream<Ok = ObjectRef<K>> + Unpin,
     QueueStream::Error: std::error::Error + 'static,
 {
     let (scheduler_tx, scheduler_rx) = channel::mpsc::channel::<ScheduleRequest<ObjectRef<K>>>(100);

--- a/kube/examples/configmapgen_controller.rs
+++ b/kube/examples/configmapgen_controller.rs
@@ -126,7 +126,8 @@ async fn main() -> Result<()> {
                 Api::<ConfigMap>::all(client.clone()),
                 ListParams::default(),
             ))),
-        ),
+        )
+        .boxed_local(),
     )
     .for_each(|res| async move { println!("I did a thing! {:?}", res.map_err(Report::from)) })
     .await;

--- a/kube/examples/configmapgen_controller.rs
+++ b/kube/examples/configmapgen_controller.rs
@@ -126,8 +126,7 @@ async fn main() -> Result<()> {
                 Api::<ConfigMap>::all(client.clone()),
                 ListParams::default(),
             ))),
-        )
-        .boxed_local(),
+        ),
     )
     .for_each(|res| async move { println!("I did a thing! {:?}", res.map_err(Report::from)) })
     .await;


### PR DESCRIPTION
This is required for publishability, since there isn't a release of pin-cell
that works on stable rustc, and cargo doesn't allow publishing crates with git
dependencies.

The downside is that you might need to box the queue stream when building the
controller.