### PR TITLE
Drop reflector/path.rs

### DIFF
--- a/kube-runtime/src/reflector/path.rs
+++ b/kube-runtime/src/reflector/path.rs
@@ -1,1 +1,0 @@
-where K: Meta Kwhere K: Meta K


### PR DESCRIPTION
This only exists by accident anyway, isn't imported anywhere, and isn't legal Rust anyway.