### PR TITLE
Pass on HTTP errors when watching

### DIFF
--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -218,7 +218,10 @@ impl Client {
                                                     _ => {
                                                         let line = String::from_utf8_lossy(line);
                                                         warn!("Failed to parse: {}", line);
-                                                        Error::SerdeError(e)
+                                                        match resp.error_for_status_ref() {
+                                                            Ok(_) => Error::SerdeError(e),
+                                                            Err(e) => Error::ReqwestError(e),
+                                                        }
                                                     }
                                                 };
 


### PR DESCRIPTION
When trying to watch a non-existing CRD, the API server just returns 404 without a proper API error response. When the response payload is neither a valid WatchEvent nor a valid API Error response, try to pass on the plain HTTP status code instead of a Serde error.

Before the change, the error looked like this:

```
WARN  kube::client] Failed to parse: 404 page not found
Error deserializing response: invalid type: integer `404`, expected adjacently tagged enum WatchEvent at line 1 column 3
```

After the change, it looks like this:

```
WARN  kube::client] Failed to parse: 404 page not found
ReqwestError: HTTP status client error (404 Not Found) for url (https://192.168.39.228:8443/apis/example.com/v1alpha1/namespaces/kube-system/examples?&watch=true&resourceVersion=0&
timeoutSeconds=290)
```

That way, library users can check for the 404 code in the error to determine that a CRD is probably not installed at all.