### PR TITLE
K8s openapi 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+==========
+  * Bump `k8s-openapi` to `0.9.0`
+
 0.36.0 / 2020-06-19
 ===================
   * https://gitlab.com/teozkr/kube-rt/ merged in for a new `kube-runtime` crate #258

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Select a version of `kube` along with the [generated k8s api types](https://gith
 kube = "0.36.0"
 kube-derive = "0.36.0"
 kube-runtime = "0.36.0"
-k8s-openapi = { version = "0.8.0", default-features = false, features = ["v1_17"] }
+k8s-openapi = { version = "0.9.0", default-features = false, features = ["v1_17"] }
 ```
 
 Note that turning off `default-features` for `k8s-openapi` is recommended to speed up your compilation (and we provide an api anyway).
@@ -191,7 +191,7 @@ or in `Cargo.toml`:
 [dependencies]
 kube = { version = "0.36.0", default-features = false, features = ["rustls-tls"] }
 kube-runtime = { version = "0.36.0", default-features = false, features = ["rustls-tls"] }
-k8s-openapi = { version = "0.8.0", default-features = false, features = ["v1_17"] }
+k8s-openapi = { version = "0.9.0", default-features = false, features = ["v1_17"] }
 ```
 
 This will pull in the variant of `reqwest` that also uses its `rustls-tls` feature.

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -300,8 +300,11 @@ impl CustomDerive for CustomResource {
         let impl_metadata = quote! {
             impl k8s_openapi::Metadata for #rootident {
                 type Ty = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-                fn metadata(&self) -> Option<&Self::Ty> {
-                    Some(&self.metadata)
+                fn metadata(&self) -> &Self::Ty {
+                    &self.metadata
+                }
+                fn metadata_mut(&mut self) -> &mut Self::Ty {
+                    &mut self.metadata
                 }
             }
         };

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 futures = "0.3.5"
 kube = { path = "../kube", default-features = false }
 #kube = { version = "0.36.0", default-features = false }
-k8s-openapi = "0.8.0"
+k8s-openapi = "0.9.0"
 derivative = "2.1.1"
 serde = "1.0.110"
 smallvec = "1.4.0"
@@ -30,6 +30,6 @@ native-tls = ["kube/native-tls"]
 rustls-tls = ["kube/rustls-tls"]
 
 [dev-dependencies.k8s-openapi]
-version = "0.8.0"
+version = "0.9.0"
 default-features = false
 features = ["v1_18"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -31,7 +31,7 @@ futures-util = "0.3.5"
 futures = "0.3.5"
 pem = "0.8.1"
 openssl = { version = "0.10.29", optional = true }
-rustls = { version = "0.17.0", optional = true }
+rustls = { version = "0.18.0", optional = true }
 bytes = "0.5.4"
 Inflector = "0.11.4"
 tokio = { version = "0.2.21", features = ["time", "signal", "sync"] }

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -43,7 +43,7 @@ default-features = false
 features = ["json", "gzip", "stream"]
 
 [dependencies.k8s-openapi]
-version = "0.8.0"
+version = "0.9.0"
 default-features = false
 features = []
 
@@ -63,6 +63,6 @@ color-eyre = "0.5.0"
 snafu = { version = "0.6.8", features = ["futures"] }
 
 [dev-dependencies.k8s-openapi]
-version = "0.8.0"
+version = "0.9.0"
 default-features = false
 features = ["v1_18"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 [dependencies]
 base64 = "0.12.1"
 chrono = "0.4.11"
-dirs = "2.0.2"
+dirs = "3.0.1"
 serde = { version = "1.0.111", features = ["derive"] }
 serde_json = "1.0.53"
 serde_yaml = "0.8.12"

--- a/kube/examples/configmapgen_controller.rs
+++ b/kube/examples/configmapgen_controller.rs
@@ -61,14 +61,14 @@ async fn reconcile(generator: ConfigMapGenerator, ctx: Context<Data>) -> Result<
     let mut contents = BTreeMap::new();
     contents.insert("content".to_string(), generator.spec.content);
     let cm = ConfigMap {
-        metadata: Some(ObjectMeta {
+        metadata: ObjectMeta {
             name: generator.metadata.name.clone(),
             owner_references: Some(vec![OwnerReference {
                 controller: Some(true),
                 ..object_to_owner_reference::<ConfigMapGenerator>(generator.metadata.clone())?
             }]),
             ..ObjectMeta::default()
-        }),
+        },
         data: Some(contents),
         ..Default::default()
     };
@@ -81,8 +81,8 @@ async fn reconcile(generator: ConfigMapGenerator, ctx: Context<Data>) -> Result<
     cm_api
         .patch(
             cm.metadata
+                .name
                 .as_ref()
-                .and_then(|x| x.name.as_ref())
                 .context(MissingObjectKey {
                     name: ".metadata.name",
                 })?,

--- a/kube/src/api/metadata.rs
+++ b/kube/src/api/metadata.rs
@@ -30,7 +30,7 @@ where
     K: Metadata<Ty = ObjectMeta>,
 {
     fn meta(&self) -> &ObjectMeta {
-        self.metadata().expect("kind has metadata")
+        self.metadata()
     }
 
     fn name(&self) -> String {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0.31"
 env_logger = "0.7.1"
 futures = "0.3.5"
 kube = { path = "../kube" }
-k8s-openapi = { version = "0.8.0", features = ["v1_18"], default-features = false }
+k8s-openapi = { version = "0.9.0", features = ["v1_18"], default-features = false }
 log = "0.4.8"
 serde_json = "1.0.55"
 tokio = { version = "0.2.21", features = ["full"] }


### PR DESCRIPTION
Taking the latest version of k8s-openapi, which had some API changes - notably that metadata is no longer optional.

Arguably `fn meta()` on the `Meta` trait isn't useful any more since it doesn't now have anything to do other than call `metadata()`, but I left it alone so as not to be more breaking than necessary.  (Though I'd have no objection to it being removed.)

I also took the opportunity to bump `dirs` and `rustls` while I was here.