### PR TITLE
Make much of the controller runtime Send

### DIFF
--- a/kube-runtime/src/controller.rs
+++ b/kube-runtime/src/controller.rs
@@ -17,7 +17,8 @@ use futures::{
 use kube::api::{Api, ListParams, Meta};
 use serde::de::DeserializeOwned;
 use snafu::{futures::TryStreamExt as SnafuTryStreamExt, Backtrace, OptionExt, ResultExt, Snafu};
-use std::{pin::Pin, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
+use stream::BoxStream;
 use tokio::time::Instant;
 
 #[derive(Snafu, Debug)]
@@ -202,13 +203,13 @@ where
 {
     // NB: Need to Unpin for stream::select_all
     // TODO: get an arbitrary std::error::Error in here?
-    selector: SelectAll<Pin<Box<dyn Stream<Item = Result<ObjectRef<K>, watcher::Error>>>>>,
+    selector: SelectAll<BoxStream<'static, Result<ObjectRef<K>, watcher::Error>>>,
     reader: Store<K>,
 }
 
 impl<K> Controller<K>
 where
-    K: Clone + Meta + DeserializeOwned + Send + 'static,
+    K: Clone + Meta + DeserializeOwned + Send + Sync + 'static,
 {
     /// Create a Controller on a type `K`
     ///
@@ -219,7 +220,7 @@ where
         let reader = writer.as_reader();
         let mut selector = stream::SelectAll::new();
         let self_watcher =
-            trigger_self(try_flatten_applied(reflector(writer, watcher(owned_api, lp)))).boxed_local();
+            trigger_self(try_flatten_applied(reflector(writer, watcher(owned_api, lp)))).boxed();
         selector.push(self_watcher);
         Self { selector, reader }
     }
@@ -241,7 +242,7 @@ where
         lp: ListParams,
     ) -> Self {
         let child_watcher = trigger_owners(try_flatten_touched(watcher(api, lp)));
-        self.selector.push(Box::pin(child_watcher));
+        self.selector.push(child_watcher.boxed());
         self
     }
 
@@ -255,10 +256,13 @@ where
         mut self,
         api: Api<Other>,
         lp: ListParams,
-        mapper: impl Fn(Other) -> I + 'static,
-    ) -> Self {
+        mapper: impl Fn(Other) -> I + Send + 'static,
+    ) -> Self
+    where
+        I::IntoIter: Send,
+    {
         let other_watcher = trigger_with(try_flatten_touched(watcher(api, lp)), mapper);
-        self.selector.push(Box::pin(other_watcher));
+        self.selector.push(other_watcher.boxed());
         self
     }
 
@@ -279,5 +283,35 @@ where
         ReconcilerFut::Error: std::error::Error + 'static,
     {
         applier(reconciler, error_policy, context, self.reader, self.selector)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Context, ReconcilerAction};
+    use crate::Controller;
+    use k8s_openapi::api::core::v1::ConfigMap;
+    use kube::Api;
+
+    fn assert_send<T: Send>(x: T) -> T {
+        x
+    }
+
+    fn mock_type<T>() -> T {
+        unimplemented!(
+            "mock_type is not supposed to be called, only used for filling holes in type assertions"
+        )
+    }
+
+    // not #[test] because we don't want to actually run it, we just want to assert that it typechecks
+    #[allow(dead_code, unused_must_use)]
+    fn test_controller_should_be_send() {
+        assert_send(
+            Controller::new(mock_type::<Api<ConfigMap>>(), Default::default()).run(
+                |_, _| async { Ok(mock_type::<ReconcilerAction>()) },
+                |_: &std::io::Error, _| mock_type::<ReconcilerAction>(),
+                Context::new(()),
+            ),
+        );
     }
 }

--- a/kube-runtime/src/controller.rs
+++ b/kube-runtime/src/controller.rs
@@ -208,7 +208,7 @@ where
 
 impl<K> Controller<K>
 where
-    K: Clone + Meta + DeserializeOwned + 'static,
+    K: Clone + Meta + DeserializeOwned + Send + 'static,
 {
     /// Create a Controller on a type `K`
     ///
@@ -235,7 +235,7 @@ where
     /// You can customize the parameters used by the underlying watcher if
     /// only a subset of `Child` entries are required.
     /// The `api` must have the correct scope (cluster/all namespaces, or namespaced)
-    pub fn owns<Child: Clone + Meta + DeserializeOwned + 'static>(
+    pub fn owns<Child: Clone + Meta + DeserializeOwned + Send + 'static>(
         mut self,
         api: Api<Child>,
         lp: ListParams,
@@ -249,7 +249,7 @@ where
     ///
     /// This mapper should return something like Option<ObjectRef<K>>
     pub fn watches<
-        Other: Clone + Meta + DeserializeOwned + 'static,
+        Other: Clone + Meta + DeserializeOwned + Send + 'static,
         I: 'static + IntoIterator<Item = ObjectRef<K>>,
     >(
         mut self,

--- a/kube/src/api/dynamic.rs
+++ b/kube/src/api/dynamic.rs
@@ -6,7 +6,7 @@ use std::convert::TryFrom;
 
 use inflector::{cases::pascalcase::is_pascal_case, string::pluralize::to_plural};
 
-use std::marker::PhantomData;
+use std::iter;
 
 /// A dynamic builder for Resource
 ///
@@ -79,7 +79,7 @@ impl DynamicResource {
         Api {
             client,
             resource,
-            phantom: PhantomData,
+            phantom: iter::empty(),
         }
     }
 
@@ -96,7 +96,7 @@ impl DynamicResource {
         Ok(Api {
             client,
             resource,
-            phantom: PhantomData,
+            phantom: iter::empty(),
         })
     }
 }
@@ -144,7 +144,6 @@ impl TryFrom<DynamicResource> for Resource {
         })
     }
 }
-
 
 #[cfg(test)]
 mod test {

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -1,7 +1,7 @@
 use either::Either;
 use futures::Stream;
 use serde::{de::DeserializeOwned, Serialize};
-use std::marker::PhantomData;
+use std::iter;
 
 use crate::{
     api::{DeleteParams, ListParams, Meta, ObjectList, PatchParams, PostParams, Resource, WatchEvent},
@@ -26,7 +26,11 @@ pub struct Api<K> {
     /// The client to use (from this library)
     pub(crate) client: Client,
     /// Underlying Object unstored
-    pub(crate) phantom: PhantomData<K>,
+    ///
+    /// Note: Using `iter::Empty` over `PhantomData`, because we never actually keep any
+    /// `K` objects, so `Empty` better models our constraints (in particular, `Empty<K>`
+    /// is `Send`, even if `K` may not be).
+    pub(crate) phantom: iter::Empty<K>,
 }
 
 /// Expose same interface as Api for controlling scope/group/versions/ns
@@ -40,7 +44,7 @@ where
         Self {
             resource,
             client,
-            phantom: PhantomData,
+            phantom: iter::empty(),
         }
     }
 
@@ -50,7 +54,7 @@ where
         Self {
             resource,
             client,
-            phantom: PhantomData,
+            phantom: iter::empty(),
         }
     }
 


### PR DESCRIPTION
This, sadly, breaks compatibility by adding a constraint on `K: Send` for `watcher()` (and by extension, `Controller`).