### PR TITLE
Downgrade Dashmap to 3.11.7 to fix store duplicates

### DIFF
--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -39,3 +39,4 @@ kube-derive = { path = "../kube-derive" }
 #kube-derive = "0.37.0"
 serde_json = "1.0.53"
 tokio = { version = "0.2.21", features = ["full", "test-util"] }
+rand = "0.7.3"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -22,7 +22,7 @@ smallvec = "1.4.0"
 pin-project = "0.4.16"
 tokio = { version = "0.2.21", features = ["time"] }
 snafu = { version = "0.6.8", features = ["futures"] }
-dashmap = "4.0.0-rc6"
+dashmap = "3.11.7"
 
 [features]
 default = ["native-tls"]

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -83,14 +83,4 @@ impl<K: 'static + Clone + Resource> Store<K> {
     pub fn state(&self) -> Vec<K> {
         self.store.iter().map(|eg| eg.value().clone()).collect()
     }
-
-    /// Return a guarded dashmap iterator of our state
-    ///
-    /// This creates an iterator over all entries in the map.
-    /// This does not take a snapshot of the map and thus changes during the lifetime
-    /// of the iterator may or may not become visible in the iterator.
-    #[must_use]
-    pub fn iter(&self) -> dashmap::Iter<ObjectRef<K>, K> {
-        self.store.iter()
-    }
 }

--- a/kube/examples/configmap_reflector.rs
+++ b/kube/examples/configmap_reflector.rs
@@ -1,4 +1,5 @@
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::ConfigMap;
 use kube::{
@@ -12,7 +13,7 @@ fn spawn_periodic_reader(reader: Store<ConfigMap>) {
         loop {
             // Periodically read our state
             tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
-            let cms: Vec<_> = reader.iter().map(|eg| Meta::name(eg.value()).clone()).collect();
+            let cms: Vec<_> = reader.state().iter().map(|obj| Meta::name(obj).clone()).collect();
             info!("Current configmaps: {:?}", cms);
         }
     });

--- a/kube/examples/pod_reflector_live.rs
+++ b/kube/examples/pod_reflector_live.rs
@@ -1,0 +1,25 @@
+use color_eyre::Result;
+use futures::prelude::*;
+use k8s_openapi::api::core::v1::Pod;
+use kube::{api::ListParams, Api, Client, Config};
+use kube_runtime::{reflector, watcher};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let config = Config::infer().await?;
+    let client = Client::new(config);
+    let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
+
+    let api: Api<Pod> = Api::namespaced(client, &namespace);
+    let store_w = reflector::store::Writer::default();
+    let store = store_w.as_reader();
+    let reflector = reflector(store_w, watcher(api, ListParams::default()));
+    // Use try_for_each to fail on first error, use for_each to keep retrying
+    reflector
+        .try_for_each(|_event| async {
+            println!("Current pod count: {}", store.state().len());
+            Ok(())
+        })
+        .await?;
+    Ok(())
+}


### PR DESCRIPTION
Fixes #286. Also adds an example for testing the the new `kube_runtime::reflector`, and a regression test.

You can repro the original issue by cherry-picking https://github.com/clux/kube-rs/pull/287/commits/5c700ea2062a7fac9a1ff054ba9de6be496e5cd8 on top of the current master (https://github.com/clux/kube-rs/commit/38e569862a11e9d23fb49c8fc646dd73b3a3dfee).