### PR TITLE
add DeleteParams to Api::delete_collection + use body params for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   * `kube::DynamicResource` exposed at top level
   * Bug: `PatchParams::default_apply()` now requires a manager and renamed to `PatchParams::apply(manager: &str)` for #300
   * Bug: `DeleteParams` no longer missing for `Api::delete_collection` - #53
+  * Removed paramter `ListParams::include_uninitialized` deprecated since 1.14
+  * Added optional `PostParams::field_manager` was missing for `Api::create` case
 
 0.39.0 / 2020-07-05
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * `Client::list_core_api_resources` added
   * `kube::DynamicResource` exposed at top level
   * Bug: `PatchParams::default_apply()` now requires a manager and renamed to `PatchParams::apply(manager: &str)` for #300
+  * Bug: `DeleteParams` no longer missing for `Api::delete_collection` - #53
 
 0.39.0 / 2020-07-05
 ===================

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -199,7 +199,7 @@ async fn main() -> anyhow::Result<()> {
     assert!(foos.delete("qux", &dp).await?.is_right());
 
     // Cleanup the full collection - expect a wait
-    match foos.delete_collection(&lp).await? {
+    match foos.delete_collection(&dp, &lp).await? {
         Left(list) => {
             let deleted: Vec<_> = list.iter().map(Meta::name).collect();
             info!("Deleting collection of foos: {:?}", deleted);

--- a/examples/crd_apply.rs
+++ b/examples/crd_apply.rs
@@ -6,7 +6,7 @@ use apiexts::CustomResourceDefinition;
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as apiexts;
 
 use kube::{
-    api::{Api, ListParams, Meta, PatchParams, PatchStrategy, WatchEvent},
+    api::{Api, ListParams, Meta, PatchParams, WatchEvent},
     Client, CustomResource,
 };
 

--- a/examples/job_api.rs
+++ b/examples/job_api.rs
@@ -71,6 +71,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Clean up the old job record..
     info!("Deleting the job record.");
-    jobs.delete("empty-job", &DeleteParams::default()).await?;
+    let mut dp = DeleteParams::default();
+    dp.dry_run = true;
+    jobs.delete("empty-job", &dp).await?;
+    dp.dry_run = false;
+    jobs.delete("empty-job", &dp).await?;
     Ok(())
 }

--- a/examples/job_api.rs
+++ b/examples/job_api.rs
@@ -71,7 +71,6 @@ async fn main() -> anyhow::Result<()> {
 
     // Clean up the old job record..
     info!("Deleting the job record.");
-    let dp = DeleteParams::default();
-    jobs.delete("empty-job", &dp).await.expect("failed to delete job");
+    jobs.delete("empty-job", &DeleteParams::default()).await?;
     Ok(())
 }

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
   "clux <sszynrae@gmail.com>",
 ]
 license = "Apache-2.0"
+repository = "https://github.com/clux/kube-rs"
 keywords = ["kubernetes", "runtime", "reflector", "watcher", "controller"]
 categories = ["web-programming::http-client"]
 edition = "2018"

--- a/kube/src/api/mod.rs
+++ b/kube/src/api/mod.rs
@@ -9,10 +9,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Deserialize, Serialize, Default, Debug)]
 pub struct NotUsed {}
 
-pub(crate) mod resource;
-pub use resource::{
-    DeleteParams, ListParams, PatchParams, PatchStrategy, PostParams, PropagationPolicy, Resource,
-};
+pub(crate) mod params;
+pub use params::{DeleteParams, ListParams, PatchParams, PatchStrategy, PostParams, PropagationPolicy};
+mod resource;
+pub use resource::Resource;
 
 pub(crate) mod typed;
 pub use typed::Api;

--- a/kube/src/api/params.rs
+++ b/kube/src/api/params.rs
@@ -1,0 +1,311 @@
+///! A port of *Optionals from apimachinery/types.go
+use crate::{Error, Result};
+use serde::Serialize;
+
+/// Common query parameters used in watch/list/delete calls on collections
+#[derive(Default, Clone)]
+#[allow(missing_docs)]
+pub struct ListParams {
+    /// A selector to restrict the list of returned objects by their labels.
+    ///
+    /// Defaults to everything if `None`.
+    pub label_selector: Option<String>,
+
+    /// A selector to restrict the list of returned objects by their fields.
+    ///
+    /// Defaults to everything if `None`.
+    pub field_selector: Option<String>,
+
+    /// Timeout for the list/watch call.
+    ///
+    /// This limits the duration of the call, regardless of any activity or inactivity.
+    /// If unset for a watch call, we will use 290s.
+    /// We limit this to 295s due to [inherent watch limitations](https://github.com/kubernetes/kubernetes/issues/6513).
+    pub timeout: Option<u32>,
+
+    /// Enables watch events with type "BOOKMARK".
+    ///
+    /// Servers that do not implement bookmarks ignore this flag and
+    /// bookmarks are sent at the server's discretion. Clients should not
+    /// assume bookmarks are returned at any specific interval, nor may they
+    /// assume the server will send any BOOKMARK event during a session.
+    /// If this is not a watch, this field is ignored.
+    /// If the feature gate WatchBookmarks is not enabled in apiserver,
+    /// this field is ignored.
+    pub allow_bookmarks: bool,
+}
+
+impl ListParams {
+    pub(crate) fn validate(&self) -> Result<()> {
+        if let Some(to) = &self.timeout {
+            // https://github.com/kubernetes/kubernetes/issues/6513
+            if *to >= 295 {
+                return Err(Error::RequestValidation(
+                    "ListParams::timeout must be < 295s".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Builder interface to ListParams
+///
+/// Usage:
+/// ```
+/// use kube::api::ListParams;
+/// let lp = ListParams::default()
+///     .timeout(60)
+///     .labels("kubernetes.io/lifecycle=spot");
+/// ```
+impl ListParams {
+    /// Configure the timeout for list/watch calls
+    ///
+    /// This limits the duration of the call, regardless of any activity or inactivity.
+    /// Defaults to 290s
+    pub fn timeout(mut self, timeout_secs: u32) -> Self {
+        self.timeout = Some(timeout_secs);
+        self
+    }
+
+    /// Configure the selector to restrict the list of returned objects by their fields.
+    ///
+    /// Defaults to everything.
+    /// Supports '=', '==', and '!=', and can comma separate: key1=value1,key2=value2
+    /// The server only supports a limited number of field queries per type.
+    pub fn fields(mut self, field_selector: &str) -> Self {
+        self.field_selector = Some(field_selector.to_string());
+        self
+    }
+
+    /// Configure the selector to restrict the list of returned objects by their labels.
+    ///
+    /// Defaults to everything.
+    /// Supports '=', '==', and '!=', and can comma separate: key1=value1,key2=value2
+    pub fn labels(mut self, label_selector: &str) -> Self {
+        self.label_selector = Some(label_selector.to_string());
+        self
+    }
+
+    /// Enables watch bookmarks from the api server if supported
+    pub fn allow_bookmarks(mut self) -> Self {
+        self.allow_bookmarks = true;
+        self
+    }
+}
+
+/// Common query parameters for put/post calls
+#[derive(Default, Clone)]
+pub struct PostParams {
+    /// Whether to run this as a dry run
+    pub dry_run: bool,
+    /// fieldManager is a name of the actor that is making changes
+    pub field_manager: Option<String>,
+}
+
+impl PostParams {
+    pub(crate) fn validate(&self) -> Result<()> {
+        if let Some(field_manager) = &self.field_manager {
+            // Implement the easy part of validation, in future this may be extended to provide validation as in go code
+            // For now it's fine, because k8s API server will return an error
+            if field_manager.len() > 128 {
+                return Err(Error::RequestValidation(
+                    "Failed to validate PostParams::field_manager!".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Common query parameters for patch calls
+#[derive(Default, Clone)]
+pub struct PatchParams {
+    /// Whether to run this as a dry run
+    pub dry_run: bool,
+    /// Strategy which will be used. Defaults to `PatchStrategy::Strategic`
+    pub patch_strategy: PatchStrategy,
+    /// force Apply requests. Applicable only to `PatchStrategy::Apply`
+    pub force: bool,
+    /// fieldManager is a name of the actor that is making changes. Required for `PatchStrategy::Apply`
+    /// optional for everything else
+    pub field_manager: Option<String>,
+}
+impl PatchParams {
+    pub(crate) fn validate(&self) -> Result<()> {
+        if let Some(field_manager) = &self.field_manager {
+            // Implement the easy part of validation, in future this may be extended to provide validation as in go code
+            // For now it's fine, because k8s API server will return an error
+            if field_manager.len() > 128 {
+                return Err(Error::RequestValidation(
+                    "Failed to validate PatchParams::field_manager!".into(),
+                ));
+            }
+        }
+
+        if self.patch_strategy != PatchStrategy::Apply && self.force {
+            // if not force, all other fields are valid for all types of patch requests
+            Err(Error::RequestValidation(
+                "Force is applicable only for Apply strategy!".into(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn populate_qp(&self, qp: &mut url::form_urlencoded::Serializer<String>) {
+        if self.dry_run {
+            qp.append_pair("dryRun", "true");
+        }
+        if self.force {
+            qp.append_pair("force", "true");
+        }
+        if let Some(ref field_manager) = self.field_manager {
+            qp.append_pair("fieldManager", &field_manager);
+        }
+    }
+
+    /// Construct PatchParams for server-side apply
+    pub fn apply(manager: &str) -> Self {
+        Self {
+            patch_strategy: PatchStrategy::Apply,
+            field_manager: Some(manager.into()),
+            ..Self::default()
+        }
+    }
+
+    /// Force the result through on conflicts
+    pub fn force(mut self) -> Self {
+        self.force = true;
+        self
+    }
+
+    /// Perform a dryRun only
+    pub fn dry_run(mut self) -> Self {
+        self.dry_run = true;
+        self
+    }
+}
+
+/// Four different patch types are supported.
+///
+/// Apply strategy is kinda special
+#[derive(Clone, PartialEq)]
+pub enum PatchStrategy {
+    /// [Server side apply](https://kubernetes.io/docs/reference/using-api/api-concepts/#server-side-apply)
+    ///
+    /// Requires kubernetes >=1.16
+    Apply,
+    /// A [JSON merge](https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment)
+    JSON,
+    /// A regular merge
+    Merge,
+    /// A [stategic merge](https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/#use-a-strategic-merge-patch-to-update-a-deployment)
+    Strategic,
+}
+
+impl std::fmt::Display for PatchStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let content_type = match &self {
+            Self::Apply => "application/apply-patch+yaml",
+            Self::JSON => "application/json-patch+json",
+            Self::Merge => "application/merge-patch+json",
+            Self::Strategic => "application/strategic-merge-patch+json",
+        };
+        f.write_str(content_type)
+    }
+}
+
+// Kubectl defaults to Strategic strategy, but doing so will break existing consumers
+// so, currently we still default to Merge it may change in future versions
+// Strategic merge doesn't work with CRD types https://github.com/kubernetes/kubernetes/issues/52772
+impl Default for PatchStrategy {
+    fn default() -> Self {
+        PatchStrategy::Merge
+    }
+}
+
+/// Common query parameters for delete calls
+#[derive(Default, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteParams {
+    /// When present, indicates that modifications should not be persisted.
+    #[serde(serialize_with = "true_as_all", skip_serializing_if = "std::ops::Not::not")]
+    pub dry_run: bool,
+
+    /// The duration in seconds before the object should be deleted.
+    ///
+    /// Value must be non-negative integer. The value zero indicates delete immediately.
+    /// If this value is None, the default grace period for the specified type will be used.
+    /// Defaults to a per object value if not specified. Zero means delete immediately.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grace_period_seconds: Option<u32>,
+
+    /// Whether or how garbage collection is performed.
+    ///
+    /// The default policy is decided by the existing finalizer set in
+    /// metadata.finalizers, and the resource-specific default policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub propagation_policy: Option<PropagationPolicy>,
+
+    /// Condtions that must be fulfilled before a deletion is carried out
+    ///
+    /// If not possible, a 409 Conflict status will be returned.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preconditions: Option<Preconditions>,
+}
+
+
+fn true_as_all<S>(t: &bool, s: S) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::ser::Serializer,
+{
+    use serde::ser::SerializeTuple;
+    match t {
+        true => {
+            let mut map = s.serialize_tuple(1)?;
+            map.serialize_element("All")?;
+            map.end()
+        },
+        false => s.serialize_none(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::DeleteParams;
+    #[test]
+    fn delete_param_serialize() {
+        let mut dp = DeleteParams::default();
+        let emptyser = serde_json::to_string(&dp).unwrap();
+        println!("emptyser is: {}", emptyser);
+        assert_eq!(emptyser, "{}");
+
+        dp.dry_run = true;
+        let ser = serde_json::to_string(&dp).unwrap();
+        println!("ser is: {}", ser);
+        assert_eq!(ser, "{\"dryRun\":[\"All\"]}");
+    }
+}
+
+
+/// Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.
+#[derive(Default, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Preconditions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
+}
+
+/// Propagation policy when deleting single objects
+#[derive(Clone, Debug, Serialize)]
+pub enum PropagationPolicy {
+    /// Orphan dependents
+    Orphan,
+    /// Allow the garbage collector to delete the dependents in the background
+    Background,
+    /// A cascading policy that deletes all dependents in the foreground
+    Foreground,
+}

--- a/kube/src/api/resource.rs
+++ b/kube/src/api/resource.rs
@@ -1,6 +1,6 @@
+use super::params::{DeleteParams, ListParams, PatchParams, PostParams};
 use crate::{api::DynamicResource, Error, Result};
 use inflector::string::pluralize::to_plural;
-use serde::Serialize;
 
 /// A Kubernetes resource that can be accessed through the API
 #[derive(Clone, Debug)]
@@ -88,254 +88,6 @@ impl Resource {
     }
 }
 
-/// Common query parameters used in watch/list/delete calls on collections
-#[derive(Default, Clone)]
-#[allow(missing_docs)]
-pub struct ListParams {
-    pub field_selector: Option<String>,
-    pub include_uninitialized: bool,
-    pub label_selector: Option<String>,
-    pub timeout: Option<u32>,
-    pub allow_bookmarks: bool,
-}
-
-impl ListParams {
-    fn validate(&self) -> Result<()> {
-        if let Some(to) = &self.timeout {
-            // https://github.com/kubernetes/kubernetes/issues/6513
-            if *to >= 295 {
-                return Err(Error::RequestValidation(
-                    "ListParams::timeout must be < 295s".into(),
-                ));
-            }
-        }
-        Ok(())
-    }
-}
-
-/// Builder interface to ListParams
-///
-/// Usage:
-/// ```
-/// use kube::api::ListParams;
-/// let lp = ListParams::default()
-///     .timeout(60)
-///     .labels("kubernetes.io/lifecycle=spot");
-/// ```
-impl ListParams {
-    /// Configure the timeout for list/watch calls
-    ///
-    /// This limits the duration of the call, regardless of any activity or inactivity.
-    /// Defaults to 290s
-    pub fn timeout(mut self, timeout_secs: u32) -> Self {
-        self.timeout = Some(timeout_secs);
-        self
-    }
-
-    /// Configure the selector to restrict the list of returned objects by their fields.
-    ///
-    /// Defaults to everything.
-    /// Supports '=', '==', and '!=', and can comma separate: key1=value1,key2=value2
-    /// The server only supports a limited number of field queries per type.
-    pub fn fields(mut self, field_selector: &str) -> Self {
-        self.field_selector = Some(field_selector.to_string());
-        self
-    }
-
-    /// Configure the selector to restrict the list of returned objects by their labels.
-    ///
-    /// Defaults to everything.
-    /// Supports '=', '==', and '!=', and can comma separate: key1=value1,key2=value2
-    pub fn labels(mut self, label_selector: &str) -> Self {
-        self.label_selector = Some(label_selector.to_string());
-        self
-    }
-
-    /// If called, partially initialized resources are included in watch/list responses.
-    pub fn include_uninitialized(mut self) -> Self {
-        self.include_uninitialized = true;
-        self
-    }
-
-    /// Enables watch bookmarks from the api server if supported
-    pub fn allow_bookmarks(mut self) -> Self {
-        self.allow_bookmarks = true;
-        self
-    }
-}
-
-// TODO: WatchParams (same as ListParams but with extra resource_version + allow_watch_bookmarks)
-
-/// Common query parameters for put/post calls
-#[derive(Default, Clone)]
-pub struct PostParams {
-    /// Whether to run this as a dry run
-    pub dry_run: bool,
-}
-
-/// Common query parameters for patch calls
-#[derive(Default, Clone)]
-pub struct PatchParams {
-    /// Whether to run this as a dry run
-    pub dry_run: bool,
-    /// Strategy which will be used. Defaults to `PatchStrategy::Strategic`
-    pub patch_strategy: PatchStrategy,
-    /// force Apply requests. Applicable only to `PatchStrategy::Apply`
-    pub force: bool,
-    /// fieldManager is a name of the actor that is making changes. Required for `PatchStrategy::Apply`
-    /// optional for everything else
-    pub field_manager: Option<String>,
-}
-impl PatchParams {
-    fn validate(&self) -> Result<()> {
-        if let Some(field_manager) = &self.field_manager {
-            // Implement the easy part of validation, in future this may be extended to provide validation as in go code
-            // For now it's fine, because k8s API server will return an error
-            if field_manager.len() > 128 {
-                return Err(Error::RequestValidation(
-                    "Failed to validate PatchParams::field_manager!".into(),
-                ));
-            }
-        }
-
-        if self.patch_strategy != PatchStrategy::Apply && self.force {
-            // if not force, all other fields are valid for all types of patch requests
-            Err(Error::RequestValidation(
-                "Force is applicable only for Apply strategy!".into(),
-            ))
-        } else {
-            Ok(())
-        }
-    }
-
-    fn populate_qp(&self, qp: &mut url::form_urlencoded::Serializer<String>) {
-        if self.dry_run {
-            qp.append_pair("dryRun", "true");
-        }
-        if self.force {
-            qp.append_pair("force", "true");
-        }
-        if let Some(ref field_manager) = self.field_manager {
-            qp.append_pair("fieldManager", &field_manager);
-        }
-    }
-
-    /// Construct PatchParams for server-side apply
-    pub fn apply(manager: &str) -> Self {
-        Self {
-            patch_strategy: PatchStrategy::Apply,
-            field_manager: Some(manager.into()),
-            ..Self::default()
-        }
-    }
-
-    /// Force the result through on conflicts
-    pub fn force(mut self) -> Self {
-        self.force = true;
-        self
-    }
-
-    /// Perform a dryRun only
-    pub fn dry_run(mut self) -> Self {
-        self.dry_run = true;
-        self
-    }
-}
-
-/// Four different patch types are supported.
-///
-/// Apply strategy is kinda special
-#[derive(Clone, PartialEq)]
-pub enum PatchStrategy {
-    /// [Server side apply](https://kubernetes.io/docs/reference/using-api/api-concepts/#server-side-apply)
-    ///
-    /// Requires kubernetes >=1.16
-    Apply,
-    /// A [JSON merge](https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment)
-    JSON,
-    /// A regular merge
-    Merge,
-    /// A [stategic merge](https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/#use-a-strategic-merge-patch-to-update-a-deployment)
-    Strategic,
-}
-
-impl std::fmt::Display for PatchStrategy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let content_type = match &self {
-            Self::Apply => "application/apply-patch+yaml",
-            Self::JSON => "application/json-patch+json",
-            Self::Merge => "application/merge-patch+json",
-            Self::Strategic => "application/strategic-merge-patch+json",
-        };
-        f.write_str(content_type)
-    }
-}
-
-// Kubectl defaults to Strategic strategy, but doing so will break existing consumers
-// so, currently we still default to Merge it may change in future versions
-// Strategic merge doesn't work with CRD types https://github.com/kubernetes/kubernetes/issues/52772
-impl Default for PatchStrategy {
-    fn default() -> Self {
-        PatchStrategy::Merge
-    }
-}
-
-/// Common query parameters for delete calls
-#[derive(Default, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DeleteParams {
-    /// When present, indicates that modifications should not be persisted.
-    ///
-    /// An invalid or unrecognized dryRun directive will result in an error response
-    /// and no further processing of the request.
-    /// Valid values are:
-    /// - All: all dry run stages will be processed
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub dry_run: Vec<String>,
-
-    /// The duration in seconds before the object should be deleted.
-    ///
-    /// Value must be non-negative integer. The value zero indicates delete immediately.
-    /// If this value is None, the default grace period for the specified type will be used.
-    /// Defaults to a per object value if not specified. Zero means delete immediately.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub grace_period_seconds: Option<u32>,
-
-    /// Whether or how garbage collection is performed.
-    ///
-    /// The default policy is decided by the existing finalizer set in
-    /// metadata.finalizers, and the resource-specific default policy.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub propagation_policy: Option<PropagationPolicy>,
-
-    /// Condtions that must be fulfilled before a deletion is carried out
-    ///
-    /// If not possible, a 409 Conflict status will be returned.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub preconditions: Option<Preconditions>,
-}
-
-/// Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.
-#[derive(Default, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Preconditions {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource_version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub uid: Option<String>,
-}
-
-/// Propagation policy when deleting single objects
-#[derive(Clone, Debug, Serialize)]
-pub enum PropagationPolicy {
-    /// Orphan dependents
-    Orphan,
-    /// Allow the garbage collector to delete the dependents in the background
-    Background,
-    /// A cascading policy that deletes all dependents in the foreground
-    Foreground,
-}
-
 /// Convenience methods found from API conventions
 impl Resource {
     /// List a collection of a resource
@@ -345,9 +97,6 @@ impl Resource {
 
         if let Some(fields) = &lp.field_selector {
             qp.append_pair("fieldSelector", &fields);
-        }
-        if lp.include_uninitialized {
-            qp.append_pair("includeUninitialized", "true");
         }
         if let Some(labels) = &lp.label_selector {
             qp.append_pair("labelSelector", &labels);
@@ -372,9 +121,6 @@ impl Resource {
         if let Some(fields) = &lp.field_selector {
             qp.append_pair("fieldSelector", &fields);
         }
-        if lp.include_uninitialized {
-            qp.append_pair("includeUninitialized", "true");
-        }
         if let Some(labels) = &lp.label_selector {
             qp.append_pair("labelSelector", &labels);
         }
@@ -398,6 +144,7 @@ impl Resource {
 
     /// Create an instance of a resource
     pub fn create(&self, pp: &PostParams, data: Vec<u8>) -> Result<http::Request<Vec<u8>>> {
+        pp.validate()?;
         let base_url = self.make_url() + "?";
         let mut qp = url::form_urlencoded::Serializer::new(base_url);
         if pp.dry_run {
@@ -424,9 +171,6 @@ impl Resource {
         let mut qp = url::form_urlencoded::Serializer::new(base_url);
         if let Some(fields) = &lp.field_selector {
             qp.append_pair("fieldSelector", &fields);
-        }
-        if lp.include_uninitialized {
-            qp.append_pair("includeUninitialized", "true");
         }
         if let Some(labels) = &lp.label_selector {
             qp.append_pair("labelSelector", &labels);

--- a/kube/src/api/resource.rs
+++ b/kube/src/api/resource.rs
@@ -288,22 +288,30 @@ pub struct DeleteParams {
     ///
     /// An invalid or unrecognized dryRun directive will result in an error response
     /// and no further processing of the request.
-    pub dry_run: bool,
+    /// Valid values are:
+    /// - All: all dry run stages will be processed
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub dry_run: Vec<String>,
+
     /// The duration in seconds before the object should be deleted.
     ///
     /// Value must be non-negative integer. The value zero indicates delete immediately.
     /// If this value is None, the default grace period for the specified type will be used.
     /// Defaults to a per object value if not specified. Zero means delete immediately.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub grace_period_seconds: Option<u32>,
+
     /// Whether or how garbage collection is performed.
     ///
     /// The default policy is decided by the existing finalizer set in
     /// metadata.finalizers, and the resource-specific default policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub propagation_policy: Option<PropagationPolicy>,
 
     /// Condtions that must be fulfilled before a deletion is carried out
     ///
     /// If not possible, a 409 Conflict status will be returned.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub preconditions: Option<Preconditions>,
 }
 
@@ -311,7 +319,9 @@ pub struct DeleteParams {
 #[derive(Default, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Preconditions {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resource_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub uid: Option<String>,
 }
 

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -166,13 +166,13 @@ where
     /// 4XX and 5XX status types are returned as an `Err(kube::Error::Api)`
     ///
     /// ```no_run
-    /// use kube::{api::{Api, ListParams, Meta}, Client};
+    /// use kube::{api::{Api, DeleteParams, ListParams, Meta}, Client};
     /// use k8s_openapi::api::core::v1::Pod;
     /// #[tokio::main]
     /// async fn main() -> Result<(), kube::Error> {
     ///     let client = Client::try_default().await?;
     ///     let pods: Api<Pod> = Api::namespaced(client, "apps");
-    ///     match pods.delete_collection(&ListParams::default()).await? {
+    ///     match pods.delete_collection(&DeleteParams::default(), &ListParams::default()).await? {
     ///         either::Left(list) => {
     ///             let names: Vec<_> = list.iter().map(Meta::name).collect();
     ///             println!("Deleting collection of pods: {:?}", names);
@@ -184,8 +184,12 @@ where
     ///     Ok(())
     /// }
     /// ```
-    pub async fn delete_collection(&self, lp: &ListParams) -> Result<Either<ObjectList<K>, Status>> {
-        let req = self.resource.delete_collection(&lp)?;
+    pub async fn delete_collection(
+        &self,
+        dp: &DeleteParams,
+        lp: &ListParams,
+    ) -> Result<Either<ObjectList<K>, Status>> {
+        let req = self.resource.delete_collection(&dp, &lp)?;
         self.client.request_status::<ObjectList<K>>(req).await
     }
 


### PR DESCRIPTION
This is to match `client-go`'s delete and methods: https://github.com/kubernetes/client-go/blob/e7a1d9ada0d5ef8eee6e55f0a84ad6e3d08441f6/kubernetes/typed/apps/v1/deployment.go#L160-L183

DeleteParams should always go in body params, and `Api::delete_collection` needs both `ListParams` and `DeleteParams`.