### PR TITLE
chore(*): Bumps reqwest version to latest patch

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -30,7 +30,7 @@ snafu = { version = "0.6.8", features = ["futures"] }
 # Some Api::delete methods use Either
 either = "1.5.3"
 # Some configuration tweaking require reqwest atm
-reqwest = { version = "0.10.6", default-features = false, features = ["json", "gzip", "stream"] }
+reqwest = { version = "0.10.7", default-features = false, features = ["json", "gzip", "stream"] }
 
 [[example]]
 name = "configmapgen_controller"

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -48,7 +48,7 @@ static_assertions = "1.1.0"
 kube-derive = { path = "../kube-derive", version = "^0.39.0", optional = true }
 
 [dependencies.reqwest]
-version = "0.10.6"
+version = "0.10.7"
 default-features = false
 features = ["json", "gzip", "stream"]
 


### PR DESCRIPTION
Primarily, this is to pick up support for the `NO_PROXY` environment
variable (see https://github.com/deislabs/krustlet/issues/170 for an
example)