### PR TITLE
manually implement Default in kube-derive if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.40.1 / 2020-09-XX
 ===================
   * `kube-derive`'s `Default` derive now sets typemeta correctly - #315
+  * `ListParams` now supports `continue_token` and `limit` - #320
 
 0.40.0 / 2020-08-17
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.40.1 / 2020-09-XX
+===================
+  * `kube-derive`'s `Default` derive now sets typemeta correctly - #315
+
 0.40.0 / 2020-08-17
 ===================
   * `DynamicResource::from_api_resource` added to allow apiserver returned resources - #305 via #301

--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -97,14 +97,14 @@ fn verify_resource() {
 }
 
 #[test]
-fn verify_serialize() {
-  let fdef = Foo::default();
-  let ser = serde_yaml::to_string(&fdef).unwrap();
-  let exp = r#"---
-apiVersion: "clux.dev/v1"
-kind: "Foo"
+fn verify_default() {
+    let fdef = Foo::default();
+    let ser = serde_yaml::to_string(&fdef).unwrap();
+    let exp = r#"---
+apiVersion: clux.dev/v1
+kind: Foo
 metadata: {}
 spec:
   name: """#;
-  assert_eq!(exp, ser);
+    assert_eq!(exp, ser);
 }

--- a/kube/src/api/params.rs
+++ b/kube/src/api/params.rs
@@ -35,14 +35,14 @@ pub struct ListParams {
     pub allow_bookmarks: bool,
 
     /// Limit the number of results.
-    /// 
+    ///
     /// If there are more results, the server will respond with a continue token which can be used to fetch another page
     /// of results. See the [kubernetes API docs](https://kubernetes.io/docs/reference/using-api/api-concepts/#retrieving-large-results-sets-in-chunks)
     /// for pagination details.
     pub limit: Option<u32>,
 
     /// Fetch a second page of results.
-    /// 
+    ///
     /// After listing results with a limit, a continue token can be used to fetch another page of results.
     pub continue_token: Option<String>,
 }

--- a/kube/src/config/mod.rs
+++ b/kube/src/config/mod.rs
@@ -298,7 +298,7 @@ fn load_auth_header(loader: &ConfigLoader) -> Result<Authentication> {
         None => {
             if let Some(exec) = &loader.user.exec {
                 let creds = exec::auth_exec(exec)?;
-                let status = creds.status.ok_or_else(|| ConfigError::ExecPluginFailed)?;
+                let status = creds.status.ok_or(ConfigError::ExecPluginFailed)?;
                 let expiration = match status.expiration_timestamp {
                     Some(ts) => Some(
                         ts.parse::<DateTime<Utc>>()

--- a/kube/src/oauth2/mod.rs
+++ b/kube/src/oauth2/mod.rs
@@ -70,7 +70,7 @@ impl Credentials {
     pub fn load() -> Result<Credentials> {
         let path = env::var_os(GOOGLE_APPLICATION_CREDENTIALS)
             .map(PathBuf::from)
-            .ok_or_else(|| ConfigError::MissingGoogleCredentials)?;
+            .ok_or(ConfigError::MissingGoogleCredentials)?;
         let f = File::open(path).map_err(ConfigError::OAuth2LoadCredentials)?;
         let config = serde_json::from_reader(f).map_err(ConfigError::OAuth2ParseCredentials)?;
         Ok(config)


### PR DESCRIPTION
Avoids overriding `Serialize` to do this (like in #316). Fixes #315.

Maybe it's possible to do this by figuring out if the spec type implements Default though? Couldn't find a way to detect this:

- it's either derived or has a manual impl elsewhere
- we cannot make the `impl Default for K` constrain a member of `K` being `Default`