### PR TITLE
Add limit and continue-token support to ListParams …

### DIFF
--- a/kube/src/api/params.rs
+++ b/kube/src/api/params.rs
@@ -33,6 +33,18 @@ pub struct ListParams {
     /// If the feature gate WatchBookmarks is not enabled in apiserver,
     /// this field is ignored.
     pub allow_bookmarks: bool,
+
+    /// Limit the number of results.
+    /// 
+    /// If there are more results, the server will respond with a continue token which can be used to fetch another page
+    /// of results. See the [kubernetes API docs](https://kubernetes.io/docs/reference/using-api/api-concepts/#retrieving-large-results-sets-in-chunks)
+    /// for pagination details.
+    pub limit: Option<u32>,
+
+    /// Fetch a second page of results.
+    /// 
+    /// After listing results with a limit, a continue token can be used to fetch another page of results.
+    pub continue_token: Option<String>,
 }
 
 impl ListParams {
@@ -90,6 +102,18 @@ impl ListParams {
     /// Enables watch bookmarks from the api server if supported
     pub fn allow_bookmarks(mut self) -> Self {
         self.allow_bookmarks = true;
+        self
+    }
+
+    /// Sets a result limit.
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Sets a continue token.
+    pub fn continue_token(mut self, token: &str) -> Self {
+        self.continue_token = Some(token.to_string());
         self
     }
 }

--- a/kube/src/api/resource.rs
+++ b/kube/src/api/resource.rs
@@ -101,6 +101,12 @@ impl Resource {
         if let Some(labels) = &lp.label_selector {
             qp.append_pair("labelSelector", &labels);
         }
+        if let Some(limit) = &lp.limit {
+            qp.append_pair("limit", &limit.to_string());
+        }
+        if let Some(continue_token) = &lp.continue_token {
+            qp.append_pair("continue", continue_token);
+        }
 
         let urlstr = qp.finish();
         let req = http::Request::get(urlstr);
@@ -112,6 +118,16 @@ impl Resource {
         let base_url = self.make_url() + "?";
         let mut qp = url::form_urlencoded::Serializer::new(base_url);
         lp.validate()?;
+        if lp.limit.is_some() {
+            return Err(Error::RequestValidation(
+                "ListParams::limit cannot be used with a watch.".into(),
+            ));
+        }
+        if lp.continue_token.is_some() {
+            return Err(Error::RequestValidation(
+                "ListParams::continue_token cannot be used with a watch.".into(),
+            ));
+        }
 
         qp.append_pair("watch", "true");
         qp.append_pair("resourceVersion", ver);


### PR DESCRIPTION
…to support paginated listing of large collections.

I didn't see a specific contributing document, nor did I see existing test coverage to emulate this. But I've verified in my own project that this works as expected when doing paginated listings, e.g. all the pods in a cluster in batches of 100.