### PR TITLE
remove pedantic enforcements in kube-derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-0.42.1 / 2020-09-XX
+0.43.0 / 2020-09-XX
 ===================
   * bug: `kube-derive` attr `#[kube(shortname)]` now working correctly
   * bug: `kube-derive` now working with badly cased existing types - #313
+  * `kube-derive` now actually requires GVK (in particular `#[kube(kind = "Foo")]` which we sometimes inferred earlier, despite documenting the contrary)
 
 0.42.0 / 2020-09-10
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.42.1 / 2020-09-XX
+===================
+  * bug: `kube-derive` attr `#[kube(shortname)]` now working correctly
+  * bug: `kube-derive` now working with badly cased existing types - #313
+
 0.42.0 / 2020-09-10
 ===================
   * bug: `kube-derive`'s `Default` derive now sets typemeta correctly - #315

--- a/examples/configmapgen_controller.rs
+++ b/examples/configmapgen_controller.rs
@@ -33,8 +33,8 @@ enum Error {
 }
 
 #[derive(CustomResource, Debug, Clone, Deserialize, Serialize)]
-#[kube(group = "nullable.se", version = "v1", namespaced)]
-#[kube(shortname = "cmg")]
+#[kube(group = "nullable.se", version = "v1", kind = "ConfigMapGenerator")]
+#[kube(shortname = "cmg", namespaced)]
 struct ConfigMapGeneratorSpec {
     content: String,
 }

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -15,7 +15,7 @@ use kube::{
 
 // Own custom resource
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
-#[kube(group = "clux.dev", version = "v1", namespaced)]
+#[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
 #[kube(apiextensions = "v1beta1")]
 #[kube(status = "FooStatus")]
 #[kube(scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]

--- a/examples/crd_apply.rs
+++ b/examples/crd_apply.rs
@@ -15,7 +15,7 @@ use kube::{
 
 // Own custom resource
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
-#[kube(group = "clux.dev", version = "v1", namespaced)]
+#[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
 #[kube(status = "FooStatus")]
 #[kube(apiextensions = "v1beta1")] // remove this if using Kubernetes >= 1.17
 #[kube(scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#)]

--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -59,7 +59,7 @@ fn verify_crd() {
         "names": {
           "kind": "Foo",
           "plural": "foos",
-          "shortNames": [],
+          "shortNames": ["f"],
           "singular": "foo"
         },
         "additionalPrinterColumns": [

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -8,7 +8,7 @@ use kube_runtime::{reflector, utils::try_flatten_applied, watcher};
 use serde::{Deserialize, Serialize};
 
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
-#[kube(group = "clux.dev", version = "v1", namespaced)]
+#[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
 pub struct FooSpec {
     name: String,
     info: String,

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -1,5 +1,5 @@
 use crate::{CustomDerive, ResultExt};
-use inflector::{cases::pascalcase::is_pascal_case, string::pluralize::to_plural};
+use inflector::string::pluralize::to_plural;
 use proc_macro2::{Ident, Span};
 use syn::{Data, DeriveInput, Result, Visibility};
 
@@ -8,14 +8,22 @@ pub(crate) struct CustomResource {
     tokens: proc_macro2::TokenStream,
     ident: proc_macro2::Ident,
     visibility: Visibility,
-    kind: String,
+    kubeattrs: KubeAttrs,
+}
+
+/// Values we can parse from #[kube(attrs)]
+#[derive(Debug, Default)]
+struct KubeAttrs {
     group: String,
     version: String,
+    kind: String,
+    /// lowercase plural of kind (inferred if omitted)
+    plural: Option<String>,
     namespaced: bool,
+    apiextensions: String,
     derives: Vec<String>,
     status: Option<String>,
     shortnames: Vec<String>,
-    apiextensions: String,
     printcolums: Vec<String>,
     scale: Option<String>,
 }
@@ -32,16 +40,9 @@ impl CustomDerive for CustomResource {
         };
 
         // Outputs
-        let mut group = None;
-        let mut version = None;
-        let mut namespaced = false;
-        let mut derives = vec![];
-        let mut status = None;
-        let mut apiextensions = "v1".to_string();
-        let mut scale = None;
-        let mut printcolums = vec![];
-        let mut shortnames = vec![];
-        let mut kind = None;
+        let mut ka = KubeAttrs::default();
+        let (mut group, mut version, mut kind) = (None, None, None); // mandatory GVK
+        ka.apiextensions = "v1".to_string(); // implicit stable crd version expected
 
         // Arg parsing
         for attr in &input.attrs {
@@ -76,25 +77,33 @@ impl CustomDerive for CustomResource {
                                 return Err(r#"#[kube(version = "...")] expects a string literal value"#)
                                     .spanning(meta);
                             }
-                        } else if meta.path.is_ident("scale") {
+                        } else if meta.path.is_ident("kind") {
                             if let syn::Lit::Str(lit) = &meta.lit {
-                                scale = Some(lit.value());
+                                kind = Some(lit.value());
                                 continue;
                             } else {
-                                return Err(r#"#[kube(scale = "...")] expects a string literal value"#)
+                                return Err(r#"#[kube(kind = "...")] expects a string literal value"#)
+                                    .spanning(meta);
+                            }
+                        } else if meta.path.is_ident("plural") {
+                            if let syn::Lit::Str(lit) = &meta.lit {
+                                ka.plural = Some(lit.value());
+                                continue;
+                            } else {
+                                return Err(r#"#[kube(plural = "...")] expects a string literal value"#)
                                     .spanning(meta);
                             }
                         } else if meta.path.is_ident("shortname") {
                             if let syn::Lit::Str(lit) = &meta.lit {
-                                shortnames.push(lit.value());
+                                ka.shortnames.push(lit.value());
                                 continue;
                             } else {
                                 return Err(r#"#[kube(shortname = "...")] expects a string literal value"#)
                                     .spanning(meta);
                             }
-                        } else if meta.path.is_ident("kind") {
+                        } else if meta.path.is_ident("scale") {
                             if let syn::Lit::Str(lit) = &meta.lit {
-                                kind = Some(lit.value());
+                                ka.scale = Some(lit.value());
                                 continue;
                             } else {
                                 return Err(r#"#[kube(scale = "...")] expects a string literal value"#)
@@ -102,7 +111,7 @@ impl CustomDerive for CustomResource {
                             }
                         } else if meta.path.is_ident("status") {
                             if let syn::Lit::Str(lit) = &meta.lit {
-                                status = Some(lit.value());
+                                ka.status = Some(lit.value());
                                 continue;
                             } else {
                                 return Err(r#"#[kube(status = "...")] expects a string literal value"#)
@@ -110,7 +119,7 @@ impl CustomDerive for CustomResource {
                             }
                         } else if meta.path.is_ident("apiextensions") {
                             if let syn::Lit::Str(lit) = &meta.lit {
-                                apiextensions = lit.value();
+                                ka.apiextensions = lit.value();
                                 continue;
                             } else {
                                 return Err(
@@ -120,7 +129,7 @@ impl CustomDerive for CustomResource {
                             }
                         } else if meta.path.is_ident("printcolumn") {
                             if let syn::Lit::Str(lit) = &meta.lit {
-                                printcolums.push(lit.value());
+                                ka.printcolums.push(lit.value());
                                 continue;
                             } else {
                                 return Err(r#"#[kube(printcolumn = "...")] expects a string literal value"#)
@@ -128,7 +137,7 @@ impl CustomDerive for CustomResource {
                             }
                         } else if meta.path.is_ident("derive") {
                             if let syn::Lit::Str(lit) = &meta.lit {
-                                derives.push(lit.value());
+                                ka.derives.push(lit.value());
                                 continue;
                             } else {
                                 return Err(r#"#[kube(derive = "...")] expects a string literal value"#)
@@ -142,7 +151,7 @@ impl CustomDerive for CustomResource {
                     // indicator arguments
                     syn::NestedMeta::Meta(syn::Meta::Path(path)) => {
                         if path.is_ident("namespaced") {
-                            namespaced = true;
+                            ka.namespaced = true;
                             continue;
                         } else {
                             &meta
@@ -157,53 +166,27 @@ impl CustomDerive for CustomResource {
             }
         }
 
-        // Find our Kind
-        let struct_name = ident.to_string();
-        let kind = if let Some(k) = kind {
-            if k == struct_name {
-                return Err(r#"#[derive(CustomResource)] `kind = "..."` must not equal the struct name (this is generated)"#)
-                    .spanning(ident);
-            }
-            k
-        } else {
-            // Fallback, infer from struct name
-
-            if !struct_name.ends_with("Spec") {
-                return Err(r#"#[derive(CustomResource)] requires either a `kind = "..."` or the struct to end with `Spec`"#)
-                    .spanning(ident);
-            }
-            struct_name[..(struct_name.len() - 4)].to_owned()
-        };
-        if !is_pascal_case(&kind) || to_plural(&kind) == kind {
-            return Err(
-                r#"#[derive(CustomResource)] requires a non-plural PascalCase `kind = "..."` or non-plural PascalCase struct name"#,
-            )
-            .spanning(ident);
-        }
-
+        // Unpack the mandatory GVK
         let mkerror = |arg| {
             format!(
                 r#"#[derive(CustomResource)] did not find a #[kube({} = "...")] attribute on the struct"#,
                 arg
             )
         };
-        let group = group.ok_or_else(|| mkerror("group")).spanning(&tokens)?;
-        let version = version.ok_or_else(|| mkerror("version")).spanning(&tokens)?;
+        ka.group = group.ok_or_else(|| mkerror("group")).spanning(&tokens)?;
+        ka.version = version.ok_or_else(|| mkerror("version")).spanning(&tokens)?;
+        ka.kind = kind.ok_or_else(|| mkerror("kind")).spanning(&tokens)?;
 
+        let struct_name = ident.to_string();
+        if ka.kind == struct_name {
+            return Err(r#"#[derive(CustomResource)] `kind = "..."` must not equal the struct name (this is generated)"#)
+                    .spanning(ident);
+        }
         Ok(CustomResource {
+            kubeattrs: ka,
             tokens,
             ident,
             visibility,
-            kind,
-            group,
-            version,
-            namespaced,
-            derives,
-            printcolums,
-            status,
-            shortnames,
-            apiextensions,
-            scale,
         })
     }
 
@@ -213,17 +196,22 @@ impl CustomDerive for CustomResource {
             tokens,
             ident,
             visibility,
+            kubeattrs,
+        } = self;
+
+        let KubeAttrs {
             group,
             kind,
             version,
             namespaced,
             derives,
             status,
+            plural,
             shortnames,
             printcolums,
             apiextensions,
             scale,
-        } = self;
+        } = kubeattrs;
 
         // 1. Create root object Foo and truncate name from FooSpec
 
@@ -334,7 +322,7 @@ impl CustomDerive for CustomResource {
 
         // 5. Implement CustomResource
         let name = kind.to_ascii_lowercase();
-        let plural = to_plural(&name);
+        let plural = plural.unwrap_or_else(|| to_plural(&name));
         let scope = if namespaced { "Namespaced" } else { "Cluster" };
 
         // Compute a bunch of crd props

--- a/kube-runtime/src/controller.rs
+++ b/kube-runtime/src/controller.rs
@@ -232,7 +232,7 @@ where
 /// enum Error {}
 /// /// A custom resource
 /// #[derive(CustomResource, Debug, Clone, Deserialize, Serialize)]
-/// #[kube(group = "nullable.se", version = "v1", namespaced)]
+/// #[kube(group = "nullable.se", version = "v1", kind = "ConfigMapGenerator", namespaced)]
 /// struct ConfigMapGeneratorSpec {
 ///     content: String,
 /// }

--- a/kube/src/api/dynamic.rs
+++ b/kube/src/api/dynamic.rs
@@ -223,7 +223,7 @@ mod test {
         use crate::{Api, Client, CustomResource};
         use serde::{Deserialize, Serialize};
         #[derive(Clone, Debug, CustomResource, Deserialize, Serialize)]
-        #[kube(group = "clux.dev", version = "v1", namespaced)]
+        #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
         struct FooSpec {
             foo: String,
         };


### PR DESCRIPTION
does not work with stuff like `DNSEndpoint` anyway, and we did already clean this up in `dynamic.rs`.

also:
- refactors kube-derive a bit for reabability
- fixed a bug that caused it not to pick up on the `shortname` attr
- makes the full GVK required to specify (even if using FooSpec struct, inferring was very magical and strange)