### PR TITLE
Implement `Display` for `ObjectRef`

### DIFF
--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -1,7 +1,10 @@
 use derivative::Derivative;
 use k8s_openapi::{apimachinery::pkg::apis::meta::v1::OwnerReference, Resource};
 use kube::api::Meta;
-use std::{fmt::Debug, hash::Hash};
+use std::{
+    fmt::{Debug, Display},
+    hash::Hash,
+};
 
 #[derive(Derivative)]
 #[derivative(Debug, PartialEq, Eq, Hash, Clone)]
@@ -82,6 +85,23 @@ impl<K: Resource> ObjectRef<K> {
     }
 }
 
+impl<K: RuntimeResource> Display for ObjectRef<K> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}.{}.{}/{}",
+            K::kind(&self.kind),
+            K::version(&self.kind),
+            K::group(&self.kind),
+            self.name
+        )?;
+        if let Some(namespace) = &self.namespace {
+            write!(f, ".{}", namespace)?;
+        }
+        Ok(())
+    }
+}
+
 /// A Kubernetes type that is known at runtime
 pub trait RuntimeResource {
     type State: Debug + PartialEq + Eq + Hash + Clone;
@@ -152,5 +172,52 @@ impl<K: Resource> From<ObjectRef<K>> for ObjectRef<ErasedResource> {
             name: old.name,
             namespace: old.namespace,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ErasedResource, ObjectRef};
+    use k8s_openapi::api::{
+        apps::v1::Deployment,
+        core::v1::{Node, Pod},
+    };
+
+    #[test]
+    fn display_should_follow_expected_format() {
+        assert_eq!(
+            format!("{}", ObjectRef::<Pod>::new("my-pod").within("my-namespace")),
+            "Pod.v1./my-pod.my-namespace"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                ObjectRef::<Deployment>::new("my-deploy").within("my-namespace")
+            ),
+            "Deployment.v1.apps/my-deploy.my-namespace"
+        );
+        assert_eq!(
+            format!("{}", ObjectRef::<Node>::new("my-node")),
+            "Node.v1./my-node"
+        );
+    }
+
+    #[test]
+    fn display_should_be_transparent_to_representation() {
+        let pod_ref = ObjectRef::<Pod>::new("my-pod").within("my-namespace");
+        assert_eq!(
+            format!("{}", pod_ref),
+            format!("{}", ObjectRef::<ErasedResource>::from(pod_ref))
+        );
+        let deploy_ref = ObjectRef::<Deployment>::new("my-deploy").within("my-namespace");
+        assert_eq!(
+            format!("{}", deploy_ref),
+            format!("{}", ObjectRef::<ErasedResource>::from(deploy_ref))
+        );
+        let node_ref = ObjectRef::<Node>::new("my-node");
+        assert_eq!(
+            format!("{}", node_ref),
+            format!("{}", ObjectRef::<ErasedResource>::from(node_ref))
+        );
     }
 }


### PR DESCRIPTION
The format is an amalgamation of `kubectl` and `istioctl` syntaxes, but generally follows the format `kind.version.[group]/name[.namespace]`, where `group` is empty for the `core` group (to match `kubectl`), and `.namespace` is missing for cluster-global objects.