### PR TITLE
Adding google cloud auth per exec

### DIFF
--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -46,6 +46,7 @@ Inflector = "0.11.4"
 tokio = { version = "0.2.22", features = ["time", "signal", "sync"] }
 static_assertions = "1.1.0"
 kube-derive = { path = "../kube-derive", version = "^0.42.0", optional = true }
+jsonpath_lib = "0.2.5"
 
 [dependencies.reqwest]
 version = "0.10.7"

--- a/kube/src/config/file_config.rs
+++ b/kube/src/config/file_config.rs
@@ -234,9 +234,9 @@ impl AuthInfo {
                                         ConfigError::AuthExec(format!("Result is not a string {:?} ", e))
                                 )?.to_owned());
                         }
+                    } else {
+                        return Err(ConfigError::AuthExec(format!("no token or command provided. Authoring mechanism {:} not supported", provider.name)).into());
                     }
-                } else {
-                    return Err(ConfigError::AuthExec(format!("no token or command provided. Authoring mechanism {:} not supported", provider.name)).into());
                 }
             }
             None => {}

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -175,6 +175,8 @@ pub enum ConfigError {
     },
     #[error("Failed to parse auth exec output: {0}")]
     AuthExecParse(#[source] serde_json::Error),
+    #[error("Failed exec auth: {0}")]
+    AuthExec(String),
 }
 
 /// An Error response from the API


### PR DESCRIPTION
Looks like the latest `gcloud`-setup uses some exec-path-features in the `kubectl` config system, that is not yet implemented. This PR implements it. If there is not access-token nor id-token given, but a command specified, that command is run with the configured parameters and the output is searched (considered to be `json`) with the path configured. The token is then used. Errors are thrown as appropriate.

Example kubectl config:
```yaml
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: XXXXXXX
    server: https://36.XXX.XXX.XX
  name: generic_name
contexts:
- context:
    cluster: generic_name
    user: generic_name
  name: generic_name
current-context: generic_name
kind: Config
preferences: {}
users:
- name: generic_name
  user:
    auth-provider:
      config:
        cmd-args: config config-helper --format=json
        cmd-path: /opt/google-cloud-sdk/bin/gcloud
        expiry-key: '{.credential.token_expiry}'
        token-key: '{.credential.access_token}'
      name: gcp
```