### PR TITLE
Better interop with prost-build (and tonic-build)

### DIFF
--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -251,7 +251,7 @@ impl CustomDerive for CustomResource {
         let mut has_default = false;
 
         let mut derive_paths: Vec<Path> = vec![];
-        for d in ["Serialize", "Deserialize", "Clone", "Debug"].iter() {
+        for d in ["::serde::Serialize", "::serde::Deserialize", "Clone", "Debug"].iter() {
             derive_paths.push(syn::parse_str(*d)?);
         }
         for d in &derives {

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -117,6 +117,9 @@ use custom_resource::CustomResource;
 /// ### `#[kube(namespaced)]`
 /// To specify that this is a namespaced resource rather than cluster level.
 ///
+/// ### `#[kube(kind_struct = "KindStructName")]`
+/// Customize the name of the generated root struct (defaults to `kind`).
+///
 /// ### `#[kube(status = "StatusStructName")]`
 /// Adds a status struct to the top level generated type and enables the status
 /// subresource in your crd.


### PR DESCRIPTION
These changes allow you to generate resources from Prost protobufs. The inciting use-case for me is to be able to reuse the canonical [Istio API definition](https://github.com/istio/api). For example (from a `build.rs`):

```rust
    tonic_build::configure()
        .build_client(true)
        .build_server(false)
        .type_attribute(".", "#[derive(::serde::Serialize, ::serde::Deserialize)]")
        .type_attribute(
            "istio.security.v1beta1.PeerAuthentication",
            r#"
#[derive(::kube_derive::CustomResource)]
#[kube(group = "security.istio.io", version = "v1beta1", kind = "PeerAuthentication", kind_struct = "PeerAuthenticationKind", namespaced)]
"#,
        )
        .compile(
            &["vendor/istio-api/security/v1beta1/peer_authentication.proto"],
            &["vendor/istio-api", "vendor/istio-api/common-protos"],
        )?;
```