### PR TITLE
#317 - ReconcilerAction should be an enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.idea/
 
 /target
 **/*.rs.bk

--- a/examples/configmapgen_controller.rs
+++ b/examples/configmapgen_controller.rs
@@ -92,16 +92,12 @@ async fn reconcile(generator: ConfigMapGenerator, ctx: Context<Data>) -> Result<
         )
         .await
         .context(ConfigMapCreationFailed)?;
-    Ok(ReconcilerAction {
-        requeue_after: Some(Duration::from_secs(300)),
-    })
+    Ok(ReconcilerAction::Requeue(Duration::from_secs(300)))
 }
 
 /// The controller triggers this on reconcile errors
 fn error_policy(_error: &Error, _ctx: Context<Data>) -> ReconcilerAction {
-    ReconcilerAction {
-        requeue_after: Some(Duration::from_secs(1)),
-    }
+    ReconcilerAction::Requeue(Duration::from_secs(1))
 }
 
 // Data we want access to in error/reconcile calls

--- a/kube/src/runtime/reflector.rs
+++ b/kube/src/runtime/reflector.rs
@@ -78,11 +78,11 @@ where
             // Then pin then futures to the stack, and wait for any of them
             pin_mut!(ctrlc_fut, sigterm_fut, poll_fut);
             select! {
-                ctrlc = ctrlc_fut => {
+                _ctrlc = ctrlc_fut => {
                     info!("Received ctrl_c, exiting");
                     return Ok(());
                 },
-                sigterm = sigterm_fut => {
+                _sigterm = sigterm_fut => {
                     info!("Received SIGTERM, exiting");
                     return Ok(());
                 }


### PR DESCRIPTION
A proposal and a showcase of the effects of https://github.com/clux/kube-rs/issues/317 - `ReconcilerAction should be an enum`.