### PR TITLE
Generate schema for CRD v1

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -58,6 +58,10 @@ name = "crd_derive"
 path = "crd_derive.rs"
 
 [[example]]
+name = "crd_derive_schema"
+path = "crd_derive_schema.rs"
+
+[[example]]
 name = "crd_reflector"
 path = "crd_reflector.rs"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -31,6 +31,7 @@ snafu = { version = "0.6.8", features = ["futures"] }
 either = "1.6.0"
 # Some configuration tweaking require reqwest atm
 reqwest = { version = "0.10.8", default-features = false, features = ["json", "gzip", "stream"] }
+schemars = "0.8.0"
 
 [[example]]
 name = "configmapgen_controller"

--- a/examples/configmapgen_controller.rs
+++ b/examples/configmapgen_controller.rs
@@ -10,6 +10,7 @@ use kube::{
     Api, Client, CustomResource,
 };
 use kube_runtime::controller::{Context, Controller, ReconcilerAction};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use std::collections::BTreeMap;
@@ -32,7 +33,7 @@ enum Error {
     },
 }
 
-#[derive(CustomResource, Debug, Clone, Deserialize, Serialize)]
+#[derive(CustomResource, Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[kube(group = "nullable.se", version = "v1", kind = "ConfigMapGenerator")]
 #[kube(shortname = "cmg", namespaced)]
 struct ConfigMapGeneratorSpec {

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -1,5 +1,6 @@
 #[macro_use] extern crate log;
 use either::Either::{Left, Right};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::time::Duration;
@@ -14,7 +15,7 @@ use kube::{
 };
 
 // Own custom resource
-#[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
+#[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
 #[kube(apiextensions = "v1beta1")]
 #[kube(status = "FooStatus")]
@@ -26,7 +27,7 @@ pub struct FooSpec {
     replicas: i32,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 pub struct FooStatus {
     is_bad: bool,
     replicas: i32,

--- a/examples/crd_apply.rs
+++ b/examples/crd_apply.rs
@@ -1,5 +1,6 @@
 #[macro_use] extern crate log;
 use futures::{StreamExt, TryStreamExt};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use apiexts::CustomResourceDefinition;
@@ -14,7 +15,7 @@ use kube::{
 // Please test against Kubernetes 1.16.X!
 
 // Own custom resource
-#[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
+#[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
 #[kube(status = "FooStatus")]
 #[kube(apiextensions = "v1beta1")] // remove this if using Kubernetes >= 1.17
@@ -25,7 +26,7 @@ pub struct FooSpec {
     replicas: i32,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 pub struct FooStatus {
     is_bad: bool,
     replicas: i32,

--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -1,11 +1,12 @@
 use k8s_openapi::Resource;
 use kube::CustomResource;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Our spec for Foo
 ///
 /// A struct with our chosen Kind will be created for us, using the following kube attrs
-#[derive(CustomResource, Serialize, Deserialize, Default, Debug, PartialEq, Clone)]
+#[derive(CustomResource, Serialize, Deserialize, Default, Debug, PartialEq, Clone, JsonSchema)]
 #[kube(
     group = "clux.dev",
     version = "v1",
@@ -18,14 +19,14 @@ use serde::{Deserialize, Serialize};
     scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#,
     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
 )]
-#[kube(apiextensions = "v1beta1")] // kubernetes <= 1.16
+#[kube(apiextensions = "v1")]
 pub struct MyFoo {
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     info: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct FooStatus {
     is_bad: bool,
 }
@@ -49,7 +50,7 @@ fn verify_crd() {
     use serde_json::{self, json};
     let crd = Foo::crd();
     let output = json!({
-      "apiVersion": "apiextensions.k8s.io/v1beta1",
+      "apiVersion": "apiextensions.k8s.io/v1",
       "kind": "CustomResourceDefinition",
       "metadata": {
         "name": "foos.clux.dev"
@@ -62,26 +63,69 @@ fn verify_crd() {
           "shortNames": ["f"],
           "singular": "foo"
         },
-        "additionalPrinterColumns": [
-          {
-            "description": "name of foo",
-            "JSONPath": ".spec.name",
-            "name": "Spec",
-            "type": "string"
-          }
-        ],
         "scope": "Namespaced",
         "versions": [
           {
             "name": "v1",
             "served": true,
-            "storage": true
+            "storage": true,
+            "additionalPrinterColumns": [
+              {
+                "description": "name of foo",
+                "jsonPath": ".spec.name",
+                "name": "Spec",
+                "type": "string"
+              }
+            ],
+            "schema": {
+              "openAPIV3Schema": {
+                "description": "Auto-generated derived type for MyFoo via `CustomResource`",
+                "properties": {
+                  "spec": {
+                    "description": "Our spec for Foo\n\nA struct with our chosen Kind will be created for us, using the following kube attrs",
+                    "properties": {
+                      "info": {
+                        "nullable": true,
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  "status": {
+                    "nullable": true,
+                    "properties": {
+                      "is_bad": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "is_bad"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec"
+                ],
+                "title": "Foo",
+                "type": "object"
+              }
+            },
+            "subresources": {
+              "scale": {
+                "specReplicasPath": ".spec.replicas",
+                "statusReplicasPath": ".status.replicas"
+              },
+              "status": {}
+            },
           }
-        ],
-        "subresources": {
-          "scale": {"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"},
-          "status": {}
-        }
+        ]
       }
     });
     let outputcrd = serde_json::from_value(output).expect("expected output is valid");

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -1,0 +1,244 @@
+use anyhow::{anyhow, Result};
+use futures::{StreamExt, TryStreamExt};
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
+use kube::CustomResource;
+use kube::{
+    api::{Api, DeleteParams, ListParams, PostParams, Resource, WatchEvent},
+    Client,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// This example shows how the generated schema affects defaulting and validation.
+// The integration test `crd_schema_test` in `kube-derive` contains the full CRD JSON generated from this struct.
+//
+// References:
+// - https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#defaulting
+// - https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#defaulting-and-nullable
+
+#[derive(CustomResource, Serialize, Deserialize, Default, Debug, PartialEq, Clone, JsonSchema)]
+#[kube(
+    group = "clux.dev",
+    version = "v1",
+    kind = "Foo",
+    namespaced,
+    derive = "PartialEq",
+    derive = "Default"
+)]
+#[kube(apiextensions = "v1")]
+pub struct FooSpec {
+    // Non-nullable without default is required.
+    //
+    // There shouldn't be any ambiguity here.
+    non_nullable: String,
+
+    // Non-nullable with default value.
+    //
+    // Serializing will work as expected because the field cannot be `None`.
+    //
+    // When deserializing a response from the server, the field should always be a string because
+    // the field is non-nullable and the server sets the value to the default specified in the schema.
+    //
+    // When deserializing some input, the default value will be set if missing.
+    // However, if `null` is specified, `serde` will panic.
+    // The server prunes `null` for non-nullable field since 1.20 and the default is applied.
+    // To match the server's behavior exactly, we can use a custom deserializer.
+    #[serde(default = "default_value")]
+    non_nullable_with_default: String,
+
+    // Nullable without default, skipping None.
+    //
+    // By skipping to serialize, the field won't be present in the object.
+    // If serialized as `null` (next field), the object will have the field set to `null`.
+    //
+    // Deserializing works as expected either way. `None` if it's missing or `null`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nullable_skipped: Option<String>,
+    // Nullable without default, not skipping None.
+    nullable: Option<String>,
+
+    // Nullable with default, skipping None.
+    //
+    // By skipping to serialize when `None`, the server will set the the default value specified in the schema.
+    // If serialized as `null`, the server will conserve it and the defaulting does not happen (since 1.20).
+    //
+    // When deserializing, the default value is used only when it's missing (`null` is `None`).
+    // This is consistent with how the server handles it since 1.20.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default = "default_nullable")]
+    nullable_skipped_with_default: Option<String>,
+
+    // Nullable with default, not skipping None.
+    //
+    // The default value won't be used unless missing, so this will set the value to `null`.
+    // If the resource is created with `kubectl` and if this field was missing, defaulting will happen.
+    #[serde(default = "default_nullable")]
+    nullable_with_default: Option<String>,
+}
+
+fn default_value() -> String {
+    "default_value".into()
+}
+
+fn default_nullable() -> Option<String> {
+    Some("default_nullable".into())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Show the generated CRD
+    println!("Foo CRD:\n{}\n", serde_yaml::to_string(&Foo::crd())?);
+
+    // Creating CRD v1 works as expected.
+    println!("Creating CRD v1");
+    let client = Client::try_default().await?;
+    delete_crd(client.clone()).await?;
+    assert!(create_crd(client.clone()).await.is_ok());
+
+    // Test creating Foo resource.
+    let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
+    let foos = Api::<Foo>::namespaced(client.clone(), &namespace);
+    // Create with defaults using typed Api first.
+    // `non_nullable` and `non_nullable_with_default` are set to empty strings.
+    // Nullables defaults to `None` and only sent if it's not configured to skip.
+    let bar = Foo::new("bar", FooSpec { ..FooSpec::default() });
+    let bar = foos.create(&PostParams::default(), &bar).await?;
+    assert_eq!(
+        bar.spec,
+        FooSpec {
+            // Nonnullable without default is required.
+            non_nullable: String::default(),
+            // Defaulting didn't happen because an empty string was sent.
+            non_nullable_with_default: String::default(),
+            // `nullable_skipped` field does not exist in the object (see below).
+            nullable_skipped: None,
+            // `nullable` field exists in the object (see below).
+            nullable: None,
+            // Defaulting happened because serialization was skipped.
+            nullable_skipped_with_default: default_nullable(),
+            // Defaulting did not happen because `null` was sent.
+            // Deserialization does not apply the default either.
+            nullable_with_default: None,
+        }
+    );
+
+    // Set up dynamic resource to test using raw values.
+    let resource = Resource::dynamic("Foo")
+        .group("clux.dev")
+        .version("v1")
+        .within(&namespace)
+        .into_resource();
+
+    // Test that skipped nullable field without default is not defined.
+    let val = client
+        .request::<serde_json::Value>(resource.get("bar").unwrap())
+        .await?;
+    println!("{:?}", val["spec"]);
+    // `nullable_skipped` field does not exist, but `nullable` does.
+    let spec = val["spec"].as_object().unwrap();
+    assert!(!spec.contains_key("nullable_skipped"));
+    assert!(spec.contains_key("nullable"));
+
+    // Test defaulting of `non_nullable_with_default` field
+    let data = serde_json::to_vec(&serde_json::json!({
+        "apiVersion": "clux.dev/v1",
+        "kind": "Foo",
+        "metadata": {
+            "name": "baz"
+        },
+        "spec": {
+            "non_nullable": "a required field",
+            // `non_nullable_with_default` field is missing
+        }
+    }))?;
+    let val = client
+        .request::<serde_json::Value>(resource.create(&PostParams::default(), data).unwrap())
+        .await?;
+    println!("{:?}", val["spec"]);
+    // Defaulting happened for non-nullable field
+    assert_eq!(val["spec"]["non_nullable_with_default"], default_value());
+
+    // Missing required field (non-nullable without default) is an error
+    let data = serde_json::to_vec(&serde_json::json!({
+        "apiVersion": "clux.dev/v1",
+        "kind": "Foo",
+        "metadata": {
+            "name": "qux"
+        },
+        "spec": {}
+    }))?;
+    let res = client
+        .request::<serde_json::Value>(resource.create(&PostParams::default(), data).unwrap())
+        .await;
+    assert!(res.is_err());
+    match res.err() {
+        Some(kube::Error::Api(err)) => {
+            assert_eq!(err.code, 422);
+            assert_eq!(err.reason, "Invalid");
+            assert_eq!(err.status, "Failure");
+            assert_eq!(
+                err.message,
+                "Foo.clux.dev \"qux\" is invalid: spec.non_nullable: Required value"
+            );
+        }
+        _ => assert!(false),
+    }
+
+    delete_crd(client.clone()).await?;
+
+    Ok(())
+}
+
+// Create CRD and wait for it to be ready.
+async fn create_crd(client: Client) -> Result<CustomResourceDefinition> {
+    let api = Api::<CustomResourceDefinition>::all(client);
+    api.create(&PostParams::default(), &Foo::crd()).await?;
+
+    // Wait until ready
+    let timeout_secs = 15;
+    let lp = ListParams::default()
+        .fields("metadata.name=foos.clux.dev")
+        .timeout(timeout_secs);
+    let mut stream = api.watch(&lp, "0").await?.boxed_local();
+    while let Some(status) = stream.try_next().await? {
+        if let WatchEvent::Modified(crd) = status {
+            let accepted = crd
+                .status
+                .as_ref()
+                .and_then(|s| s.conditions.as_ref())
+                .map(|cs| {
+                    cs.iter()
+                        .any(|c| c.type_ == "NamesAccepted" && c.status == "True")
+                })
+                .unwrap_or(false);
+            if accepted {
+                return Ok(crd);
+            }
+        }
+    }
+
+    Err(anyhow!(format!("CRD not ready after {} seconds", timeout_secs)))
+}
+
+// Delete the CRD if it exists and wait until it's deleted.
+async fn delete_crd(client: Client) -> Result<()> {
+    let api = Api::<CustomResourceDefinition>::all(client);
+    if api.get("foos.clux.dev").await.is_ok() {
+        api.delete("foos.clux.dev", &DeleteParams::default()).await?;
+
+        // Wait until deleted
+        let timeout_secs = 15;
+        let lp = ListParams::default()
+            .fields("metadata.name=foos.clux.dev")
+            .timeout(timeout_secs);
+        let mut stream = api.watch(&lp, "0").await?.boxed_local();
+        while let Some(status) = stream.try_next().await? {
+            if let WatchEvent::Deleted(_) = status {
+                return Ok(());
+            }
+        }
+        Err(anyhow!(format!("CRD not deleted after {} seconds", timeout_secs)))
+    } else {
+        Ok(())
+    }
+}

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -5,9 +5,10 @@ use kube::{
     Client, CustomResource,
 };
 use kube_runtime::{reflector, utils::try_flatten_applied, watcher};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(CustomResource, Deserialize, Serialize, Clone, Debug)]
+#[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
 pub struct FooSpec {
     name: String,

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -22,3 +22,4 @@ proc-macro = true
 serde = { version = "1.0.111", features = ["derive"] }
 serde_yaml = "0.8.14"
 k8s-openapi = { version = "0.10.0", default-features = false, features = ["v1_19"] }
+schemars = "0.8.0"

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -22,4 +22,5 @@ proc-macro = true
 serde = { version = "1.0.111", features = ["derive"] }
 serde_yaml = "0.8.14"
 k8s-openapi = { version = "0.10.0", default-features = false, features = ["v1_19"] }
-schemars = "0.8.0"
+schemars = { version = "0.8.0", features = ["chrono"] }
+chrono = "0.4"

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -60,8 +60,9 @@ use custom_resource::CustomResource;
 /// use serde::{Serialize, Deserialize};
 /// use k8s_openapi::Resource;
 /// use kube_derive::CustomResource;
+/// use schemars::JsonSchema;
 ///
-/// #[derive(CustomResource, Clone, Debug, Deserialize, Serialize)]
+/// #[derive(CustomResource, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 /// #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
 /// struct FooSpec {
 ///     info: String,
@@ -140,8 +141,9 @@ use custom_resource::CustomResource;
 /// ```rust
 /// use serde::{Serialize, Deserialize};
 /// use kube_derive::CustomResource;
+/// use schemars::JsonSchema;
 ///
-/// #[derive(CustomResource, Serialize, Deserialize, Debug, PartialEq, Clone)]
+/// #[derive(CustomResource, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
 /// #[kube(
 ///     group = "clux.dev",
 ///     version = "v1",
@@ -158,7 +160,7 @@ use custom_resource::CustomResource;
 ///     replicas: i32
 /// }
 ///
-/// #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+/// #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
 /// struct FooStatus {
 ///     replicas: i32
 /// }

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -1,0 +1,120 @@
+use kube_derive::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// See `crd_derive_schema` example for how the schema generated from this struct affects defaulting and validation.
+#[derive(CustomResource, Serialize, Deserialize, Default, Debug, PartialEq, Clone, JsonSchema)]
+#[kube(
+    group = "clux.dev",
+    version = "v1",
+    kind = "Foo",
+    namespaced,
+    derive = "PartialEq",
+    derive = "Default"
+)]
+#[kube(apiextensions = "v1")]
+struct FooSpec {
+    non_nullable: String,
+
+    #[serde(default = "default_value")]
+    non_nullable_with_default: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nullable_skipped: Option<String>,
+    nullable: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default = "default_nullable")]
+    nullable_skipped_with_default: Option<String>,
+
+    #[serde(default = "default_nullable")]
+    nullable_with_default: Option<String>,
+}
+
+fn default_value() -> String {
+    "default_value".into()
+}
+
+fn default_nullable() -> Option<String> {
+    Some("default_nullable".into())
+}
+
+#[test]
+fn test_crd_schema_matches_expected() {
+    assert_eq!(
+        Foo::crd(),
+        serde_json::from_value(serde_json::json!({
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+            "metadata": {
+                "name": "foos.clux.dev"
+            },
+            "spec": {
+                "group": "clux.dev",
+                "names": {
+                    "kind": "Foo",
+                    "plural": "foos",
+                    "shortNames": [],
+                    "singular": "foo"
+                },
+                "scope": "Namespaced",
+                "versions": [
+                    {
+                        "name": "v1",
+                        "served": true,
+                        "storage": true,
+                        "additionalPrinterColumns": [],
+                        "schema": {
+                            "openAPIV3Schema": {
+                                "description": "Auto-generated derived type for FooSpec via `CustomResource`",
+                                "properties": {
+                                    "spec": {
+                                        "properties": {
+                                            "non_nullable": {
+                                                "type": "string"
+                                            },
+                                            "non_nullable_with_default": {
+                                                "default": "default_value",
+                                                "type": "string"
+                                            },
+
+                                            "nullable_skipped": {
+                                                "nullable": true,
+                                                "type": "string"
+                                            },
+                                            "nullable": {
+                                                "nullable": true,
+                                                "type": "string"
+                                            },
+                                            "nullable_skipped_with_default": {
+                                                "default": "default_nullable",
+                                                "nullable": true,
+                                                "type": "string"
+                                            },
+                                            "nullable_with_default": {
+                                                "default": "default_nullable",
+                                                "nullable": true,
+                                                "type": "string"
+                                            },
+                                        },
+                                        "required": [
+                                            "non_nullable"
+                                        ],
+                                        "type": "object"
+                                    }
+                                },
+                                "required": [
+                                    "spec"
+                                ],
+                                "title": "Foo",
+                                "type": "object"
+                            }
+                        },
+                        "subresources": {},
+                    }
+                ]
+            }
+        }))
+        .unwrap()
+    );
+}

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -1,16 +1,16 @@
+use chrono::{DateTime, Utc};
 use kube_derive::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 // See `crd_derive_schema` example for how the schema generated from this struct affects defaulting and validation.
-#[derive(CustomResource, Serialize, Deserialize, Default, Debug, PartialEq, Clone, JsonSchema)]
+#[derive(CustomResource, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
 #[kube(
     group = "clux.dev",
     version = "v1",
     kind = "Foo",
     namespaced,
-    derive = "PartialEq",
-    derive = "Default"
+    derive = "PartialEq"
 )]
 #[kube(apiextensions = "v1")]
 struct FooSpec {
@@ -29,6 +29,9 @@ struct FooSpec {
 
     #[serde(default = "default_nullable")]
     nullable_with_default: Option<String>,
+
+    // Using feature `chrono`
+    timestamp: DateTime<Utc>,
 }
 
 fn default_value() -> String {
@@ -96,9 +99,15 @@ fn test_crd_schema_matches_expected() {
                                                 "nullable": true,
                                                 "type": "string"
                                             },
+
+                                            "timestamp": {
+                                                "type": "string",
+                                                "format": "date-time"
+                                            }
                                         },
                                         "required": [
-                                            "non_nullable"
+                                            "non_nullable",
+                                            "timestamp"
                                         ],
                                         "type": "object"
                                     }

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -42,3 +42,4 @@ kube-derive = { path = "../kube-derive", version = "^0.43.0"}
 serde_json = "1.0.57"
 tokio = { version = "0.2.22", features = ["full", "test-util"] }
 rand = "0.7.3"
+schemars = "0.8.0"

--- a/kube-runtime/src/controller.rs
+++ b/kube-runtime/src/controller.rs
@@ -226,12 +226,13 @@ where
 /// use futures::StreamExt;
 /// use kube_runtime::controller::{Context, Controller, ReconcilerAction};
 /// use k8s_openapi::api::core::v1::ConfigMap;
+/// use schemars::JsonSchema;
 ///
 /// use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 /// #[derive(Debug, Snafu)]
 /// enum Error {}
 /// /// A custom resource
-/// #[derive(CustomResource, Debug, Clone, Deserialize, Serialize)]
+/// #[derive(CustomResource, Debug, Clone, Deserialize, Serialize, JsonSchema)]
 /// #[kube(group = "nullable.se", version = "v1", kind = "ConfigMapGenerator", namespaced)]
 /// struct ConfigMapGeneratorSpec {
 ///     content: String,

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -61,6 +61,7 @@ features = []
 [dev-dependencies]
 tempfile = "3.1.0"
 tokio = { version = "0.2.21", features = ["full"] }
+schemars = "0.8.0"
 
 [dev-dependencies.k8s-openapi]
 version = "0.10.0"

--- a/kube/src/api/dynamic.rs
+++ b/kube/src/api/dynamic.rs
@@ -221,8 +221,9 @@ mod test {
     #[ignore] // circle has no kubeconfig
     async fn convenient_custom_resource() {
         use crate::{Api, Client, CustomResource};
+        use schemars::JsonSchema;
         use serde::{Deserialize, Serialize};
-        #[derive(Clone, Debug, CustomResource, Deserialize, Serialize)]
+        #[derive(Clone, Debug, CustomResource, Deserialize, Serialize, JsonSchema)]
         #[kube(group = "clux.dev", version = "v1", kind = "Foo", namespaced)]
         struct FooSpec {
             foo: String,


### PR DESCRIPTION
Schema is generated with `schemars`.

Also fixed the location of `subresources` and `additionalPrinterColumns`.

Closes https://github.com/clux/kube-rs/issues/264

---

For deriving CRD v1, the spec struct must include `schemars::JsonSchema`. ~~The schemas for subresources are currently not generated, but it should be possible to add the status subresource by requiring the status struct to have `schemars::JsonSchema` and extracting the generated schema similar to the spec.~~ If there is a status subresource, its struct must include `JsonSchema` as well.

I'm not sure how to handle the new `schemars` dependency.