### PR TITLE
make schema a default compile feature of kube-derive - for #355

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ jobs:
       - run: cargo test --lib --all -j4
       - run: cargo test --doc --all -j4
       - run: cargo test -j4 -p examples
+      - run: cd examples && cargo test --example crd_derive_no_schema --no-default-features --features=native-tls
       - run: cd kube && cargo test --lib --no-default-features --features=rustls-tls
       - save_cache:
           paths:

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -32,6 +32,7 @@ either = "1.6.0"
 # Some configuration tweaking require reqwest atm
 reqwest = { version = "0.10.8", default-features = false, features = ["json", "gzip", "stream"] }
 schemars = "0.8.0"
+static_assertions = "1.1.0"
 
 [[example]]
 name = "configmapgen_controller"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,9 @@ publish = false
 edition = "2018"
 
 [features]
-default = ["native-tls"]
+default = ["native-tls", "schema", "kubederive"]
+kubederive = ["kube/derive"] # by default import kube-derive with its default features
+schema = ["kube-derive/schema"] # crd_derive_no_schema shows how to opt out
 native-tls = ["reqwest/native-tls", "kube/native-tls", "kube-runtime/native-tls"]
 rustls-tls = ["reqwest/rustls-tls", "kube/rustls-tls", "kube-runtime/rustls-tls"]
 
@@ -17,7 +19,8 @@ rustls-tls = ["reqwest/rustls-tls", "kube/rustls-tls", "kube-runtime/rustls-tls"
 anyhow = "1.0.32"
 env_logger = "0.7.1"
 futures = "0.3.5"
-kube = { path = "../kube", version = "^0.44.0", default-features = false, features = ["derive"] }
+kube = { path = "../kube", version = "^0.44.0", default-features = false }
+kube-derive = { path = "../kube-derive", version = "^0.44.0", default-features = false } # only needed to opt out of schema
 kube-runtime = { path = "../kube-runtime", version = "^0.44.0", default-features = false }
 k8s-openapi = { version = "0.10.0", features = ["v1_19"], default-features = false }
 log = "0.4.11"
@@ -61,6 +64,10 @@ path = "crd_derive.rs"
 [[example]]
 name = "crd_derive_schema"
 path = "crd_derive_schema.rs"
+
+[[example]] # run this without --no-default-features --features="native-tls"
+name = "crd_derive_no_schema"
+path = "crd_derive_no_schema.rs"
 
 [[example]]
 name = "crd_reflector"

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,21 @@ cargo run --example dynamic_api
 NAMESPACE=dev cargo run --example log_stream -- kafka-manager-7d4f4bd8dc-f6c44
 ```
 
+## kube-derive focused examples
+How deriving `CustomResource` works in practice, and how it interacts with the [schemars](https://github.com/GREsau/schemars/) dependency.
+
+```sh
+cargo run --example crd_derive
+cargo run --example crd_derive_schema
+cargo run --example crd_derive_no_schema --no-default-features --features=native-tls
+```
+
+The last one opts out from the default `schema` feature from `kube-derive` (and thus the need for you to derive/impl `JsonSchema`).
+
+**However**: without the `schema` feature, it's left **up to you to fill in a valid openapi v3 schema**, as schemas are **required** for [v1::CustomResourceDefinitions](https://docs.rs/k8s-openapi/0.10.0/k8s_openapi/apiextensions_apiserver/pkg/apis/apiextensions/v1/struct.CustomResourceDefinition.html), and the generated crd will be rejected by the apiserver if it's missing. As the last example shows, you can do this directly without `schemars`.
+
+Note that these examples also contain tests for CI, and are invoked with the same parameters, but using `cargo test` rather than `cargo run`.
+
 ## kube-runtime focused examples
 
 ### watchers

--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -2,7 +2,6 @@ use k8s_openapi::Resource;
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-#[macro_use] extern crate static_assertions;
 
 /// Our spec for Foo
 ///
@@ -134,6 +133,7 @@ fn verify_crd() {
 
 #[test]
 fn verify_resource() {
+    use static_assertions::{assert_impl_all, assert_impl_one};
     assert_eq!(Foo::KIND, "Foo");
     assert_eq!(Foo::GROUP, "clux.dev");
     assert_eq!(Foo::VERSION, "v1");

--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -139,6 +139,7 @@ fn verify_resource() {
     assert_eq!(Foo::VERSION, "v1");
     assert_eq!(Foo::API_VERSION, "clux.dev/v1");
     assert_impl_all!(Foo: k8s_openapi::Resource, k8s_openapi::Metadata, Default);
+    assert_impl_one!(MyFoo: JsonSchema);
 }
 
 #[test]
@@ -152,22 +153,4 @@ metadata: {}
 spec:
   name: """#;
     assert_eq!(exp, ser);
-}
-
-/// CustomResource without ::crd generated (skip_crd)
-#[derive(CustomResource, Serialize, Deserialize, Debug, Clone)]
-#[kube(group = "clux.dev", version = "v1", kind = "Bar", namespaced)]
-#[kube(skip_crd)]
-pub struct MyBar {
-    bars: u32,
-}
-
-// Verify CustomResource derivable with skip_crd
-#[test]
-fn verify_bar_is_a_custom_resource() {
-    println!("Kind {}", Bar::KIND);
-    let bar = Bar::new("five", MyBar { bars: 5 });
-    println!("Spec: {:?}", bar.spec);
-    assert_impl_all!(Bar: k8s_openapi::Resource, k8s_openapi::Metadata);
-    // TODO: not asserting crd trait (if we make it a trait)
 }

--- a/examples/crd_derive_no_schema.rs
+++ b/examples/crd_derive_no_schema.rs
@@ -1,0 +1,67 @@
+use kube_derive::CustomResource;
+use serde::{Deserialize, Serialize};
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{CustomResourceDefinition, CustomResourceValidation, JSONSchemaProps};
+
+
+/// CustomResource with manually implemented schema
+///
+/// Normally you would do this by deriving JsonSchema or manually implementing it / parts of it.
+/// But here, we simply drop in a valid schema from a string and avoid schemars from the dependency tree entirely.
+#[derive(CustomResource, Serialize, Deserialize, Debug, Clone)]
+#[kube(group = "clux.dev", version = "v1", kind = "Bar", namespaced)]
+pub struct MyBar {
+    bars: u32,
+}
+
+const MANUAL_SCHEMA: &'static str = r#"
+type: object
+properties:
+  spec:
+    type: object
+    properties:
+      bars:
+        type: int
+    required:
+    - bars
+"#;
+
+impl Bar {
+    fn crd_with_manual_schema() -> CustomResourceDefinition {
+        let schema: JSONSchemaProps = serde_yaml::from_str(MANUAL_SCHEMA).expect("invalid schema");
+
+        let mut crd = Self::crd();
+        crd.spec.versions.iter_mut().for_each(|v| {
+            v.schema = Some(CustomResourceValidation { open_api_v3_schema: Some(schema.clone()) })
+        });
+        crd
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    #[cfg(feature = "schema")]
+    compile_error!("This example assumes you turn disable default kube-derive features");
+
+    let crd = Bar::crd_with_manual_schema();
+    println!("{}", serde_yaml::to_string(&crd).unwrap());
+    Ok(())
+}
+
+// Verify CustomResource derivable still
+#[test]
+fn verify_bar_is_a_custom_resource() {
+    use k8s_openapi::Resource;
+    use schemars::JsonSchema; // only for ensuring it's not implemented
+    use static_assertions::{assert_impl_all, assert_not_impl_any};
+
+    println!("Kind {}", Bar::KIND);
+    let bar = Bar::new("five", MyBar { bars: 5 });
+    println!("Spec: {:?}", bar.spec);
+    assert_impl_all!(Bar: k8s_openapi::Resource, k8s_openapi::Metadata);
+    assert_not_impl_any!(MyBar: JsonSchema); // but no schemars schema implemented
+
+    let crd = Bar::crd_with_manual_schema();
+    for v in crd.spec.versions {
+        assert!(v.schema.unwrap().open_api_v3_schema.is_some());
+    }
+}

--- a/examples/crd_derive_no_schema.rs
+++ b/examples/crd_derive_no_schema.rs
@@ -1,6 +1,8 @@
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
+    CustomResourceDefinition, CustomResourceValidation, JSONSchemaProps,
+};
 use kube_derive::CustomResource;
 use serde::{Deserialize, Serialize};
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{CustomResourceDefinition, CustomResourceValidation, JSONSchemaProps};
 
 
 /// CustomResource with manually implemented schema
@@ -31,7 +33,9 @@ impl Bar {
 
         let mut crd = Self::crd();
         crd.spec.versions.iter_mut().for_each(|v| {
-            v.schema = Some(CustomResourceValidation { open_api_v3_schema: Some(schema.clone()) })
+            v.schema = Some(CustomResourceValidation {
+                open_api_v3_schema: Some(schema.clone()),
+            })
         });
         crd
     }

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -18,6 +18,10 @@ serde_json = "1.0.53"
 [lib]
 proc-macro = true
 
+[features]
+default = ["schema"]
+schema = []
+
 [dev-dependencies]
 serde = { version = "1.0.111", features = ["derive"] }
 serde_yaml = "0.8.14"

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -20,6 +20,7 @@ struct KubeAttrs {
     kind_struct: String,
     /// lowercase plural of kind (inferred if omitted)
     plural: Option<String>,
+    skip_crdgen: bool,
     namespaced: bool,
     apiextensions: String,
     derives: Vec<String>,
@@ -163,6 +164,9 @@ impl CustomDerive for CustomResource {
                         if path.is_ident("namespaced") {
                             ka.namespaced = true;
                             continue;
+                        } else if path.is_ident("skip_crd") {
+                            ka.skip_crdgen = true;
+                            continue;
                         } else {
                             &meta
                         }
@@ -216,6 +220,7 @@ impl CustomDerive for CustomResource {
             kind_struct,
             version,
             namespaced,
+            skip_crdgen,
             derives,
             status,
             plural,
@@ -264,7 +269,7 @@ impl CustomDerive for CustomResource {
 
         // Schema generation is always enabled for v1 because it's mandatory.
         // TODO Enable schema generation for v1beta1 if the spec derives `JsonSchema`.
-        let schema_gen_enabled = apiextensions == "v1";
+        let schema_gen_enabled = apiextensions == "v1" && !skip_crdgen;
         // We exclude fields `apiVersion`, `kind`, and `metadata` from our schema because
         // these are validated by the API server implicitly. Also, we can't generate the
         // schema for `metadata` (`ObjectMeta`) because it doesn't implement `JsonSchema`.
@@ -372,7 +377,9 @@ impl CustomDerive for CustomResource {
         let short_json = serde_json::to_string(&shortnames).unwrap();
         let crd_meta_name = format!("{}.{}", plural, group);
         let crd_meta = quote! { { "name": #crd_meta_name } };
-        let jsondata = if apiextensions == "v1" {
+        let jsondata = if skip_crdgen {
+            quote! {}
+        } else if apiextensions == "v1" {
             quote! {
                 // Don't use definitions and don't include `$schema` because these are not allowed.
                 let gen = schemars::gen::SchemaSettings::openapi3().with(|s| {
@@ -432,32 +439,36 @@ impl CustomDerive for CustomResource {
         };
 
         // TODO: should ::crd be from a trait?
-        let impl_crd = quote! {
-            impl #rootident {
-                pub fn crd() -> #apiext::CustomResourceDefinition {
-                    let columns : Vec<#apiext::CustomResourceColumnDefinition> = serde_json::from_str(#printers).expect("valid printer column json");
-                    let scale: Option<#apiext::CustomResourceSubresourceScale> = if #scale_code.is_empty() {
-                        None
-                    } else {
-                        serde_json::from_str(#scale_code).expect("valid scale subresource json")
-                    };
-                    let shorts : Vec<String> = serde_json::from_str(#short_json).expect("valid shortnames");
-                    let subres = if #has_status {
-                        if let Some(s) = &scale {
-                            serde_json::json!({
-                                "status": {},
-                                "scale": scale
-                            })
+        let impl_crd = if skip_crdgen {
+            quote! {}
+        } else {
+            quote! {
+                impl #rootident {
+                    pub fn crd() -> #apiext::CustomResourceDefinition {
+                        let columns : Vec<#apiext::CustomResourceColumnDefinition> = serde_json::from_str(#printers).expect("valid printer column json");
+                        let scale: Option<#apiext::CustomResourceSubresourceScale> = if #scale_code.is_empty() {
+                            None
                         } else {
-                            serde_json::json!({"status": {} })
-                        }
-                    } else {
-                        serde_json::json!({})
-                    };
+                            serde_json::from_str(#scale_code).expect("valid scale subresource json")
+                        };
+                        let shorts : Vec<String> = serde_json::from_str(#short_json).expect("valid shortnames");
+                        let subres = if #has_status {
+                            if let Some(s) = &scale {
+                                serde_json::json!({
+                                    "status": {},
+                                    "scale": scale
+                                })
+                            } else {
+                                serde_json::json!({"status": {} })
+                            }
+                        } else {
+                            serde_json::json!({})
+                        };
 
-                    #jsondata
-                    serde_json::from_value(jsondata)
-                        .expect("valid custom resource from #[kube(attrs..)]")
+                        #jsondata
+                        serde_json::from_value(jsondata)
+                            .expect("valid custom resource from #[kube(attrs..)]")
+                    }
                 }
             }
         };

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -112,9 +112,6 @@ use custom_resource::CustomResource;
 ///
 /// **NOTE**: Support for `v1` requires deriving the openapi v3 `JsonSchema` via the `schemars` dependency.
 ///
-/// ### `#[kube(skip_crd)]`
-/// To indicate that the generated `::crd()` method is not required. Allow eliding the `schemars` dependency.
-///
 /// ### `#[kube(namespaced)]`
 /// To specify that this is a namespaced resource rather than cluster level.
 ///

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -112,6 +112,9 @@ use custom_resource::CustomResource;
 ///
 /// **NOTE**: Support for `v1` requires deriving the openapi v3 `JsonSchema` via the `schemars` dependency.
 ///
+/// ### `#[kube(skip_crd)]`
+/// To indicate that the generated `::crd()` method is not required. Allow eliding the `schemars` dependency.
+///
 /// ### `#[kube(namespaced)]`
 /// To specify that this is a namespaced resource rather than cluster level.
 ///


### PR DESCRIPTION
~~While the issue was closed, and the solution we have seems pretty solid, I can also see a case for people wishing to minimise their dependency trees a bit.~~

~~This adds a `#[kube(skip_crd)]` bool to `kube-derive` which cases `Foo::crd` to not be implemented.~~

~~Because of how good the `crd` generation now is, it's opt-out, rather than opt-in.~~