### PR TITLE
Improve documentation readability

### DIFF
--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -48,11 +48,11 @@ use custom_resource::CustomResource;
 /// A custom derive for kubernetes custom resource definitions.
 ///
 /// This will generate a **root object** containing your spec and metadata.
-/// This root object will implement the `k8s_openapi::Metadata` + `k8s_openapi::Resource`
-/// traits so it can be used with `kube::Api`.
+/// This root object will implement the [`k8s_openapi::Metadata`] + [`k8s_openapi::Resource`]
+/// traits so it can be used with [`kube::Api`].
 ///
 /// The generated type will also implement a `::crd` method to generate the crd
-/// at the specified api version (or v1 if unspecified).
+/// at the specified api version (or `v1` if unspecified).
 ///
 /// # Example
 ///
@@ -77,8 +77,8 @@ use custom_resource::CustomResource;
 /// ```
 ///
 /// This example creates a `struct Foo` containing metadata, the spec,
-/// and optionally status. The **generated** type `Foo` can be used with the `kube` crate
-/// as an `Api<Foo>` object (`FooSpec` can not be used with `Api`).
+/// and optionally status. The **generated** type `Foo` can be used with the [`kube`] crate
+/// as an `Api<Foo>` object (`FooSpec` can not be used with [`Api`][`kube::Api`]).
 ///
 /// ```rust,ignore
 ///  let client = Client::try_default().await?;
@@ -169,7 +169,7 @@ use custom_resource::CustomResource;
 ///
 /// The example above will roughly generate:
 /// ```ignore
-/// #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+/// #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
 /// #[serde(rename_all = "camelCase")]
 /// pub struct Foo {
 ///     api_version: String,
@@ -196,6 +196,10 @@ use custom_resource::CustomResource;
 /// ```toml
 /// kube = { version = "...", features = ["derive"] }
 /// ```
+/// [`kube`]: https://docs.rs/kube
+/// [`kube::Api`]: https://docs.rs/kube/*/kube/struct.Api.html
+/// [`k8s_openapi::Metadata`]: https://docs.rs/k8s-openapi/*/k8s_openapi/trait.Metadata.html
+/// [`k8s_openapi::Resource`]: https://docs.rs/k8s-openapi/*/k8s_openapi/trait.Resource.html
 #[proc_macro_derive(CustomResource, attributes(kube))]
 pub fn derive_custom_resource(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     run_custom_derive::<CustomResource>(input)

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -55,7 +55,7 @@ pub struct ReconcilerAction {
     pub requeue_after: Option<Duration>,
 }
 
-/// Helper for building custom trigger filters, see `trigger_self` and `trigger_owners` for some examples
+/// Helper for building custom trigger filters, see [`trigger_self`] and [`trigger_owners`] for some examples.
 pub fn trigger_with<T, K, I, S>(
     stream: S,
     mapper: impl Fn(T) -> I,
@@ -98,15 +98,15 @@ where
 
 /// A context data type that's passed through to the controllers callbacks
 ///
-/// Context<T> gets passed to both the `reconciler` and the `error_policy` callbacks.
+/// `Context` gets passed to both the `reconciler` and the `error_policy` callbacks,
 /// allowing a read-only view of the world without creating a big nested lambda.
-/// More or less the same as actix's Data<T>
+/// More or less the same as Actix's [`Data`](https://docs.rs/actix-web/3.x/actix_web/web/struct.Data.html).
 #[derive(Debug, Derivative)]
 #[derivative(Clone(bound = ""))]
 pub struct Context<T>(Arc<T>);
 
 impl<T> Context<T> {
-    /// Create new `Data` instance.
+    /// Create new `Context` instance.
     #[must_use]
     pub fn new(state: T) -> Context<T> {
         Context(Arc::new(state))
@@ -118,7 +118,7 @@ impl<T> Context<T> {
         self.0.as_ref()
     }
 
-    /// Convert to the internal Arc<T>
+    /// Convert to the internal `Arc<T>`.
     #[must_use]
     pub fn into_inner(self) -> Arc<T> {
         self.0
@@ -131,9 +131,9 @@ impl<T> Context<T> {
 ///
 /// The `queue` is a source of external events that trigger the reconciler,
 /// usually taken from a `reflector` and then passed through a trigger function such as
-/// `trigger_self`.
+/// [`trigger_self`].
 ///
-/// This is the "hard-mode" version of `Controller`, which allows you some more customization
+/// This is the "hard-mode" version of [`Controller`], which allows you some more customization
 /// (such as triggering from arbitrary `Stream`s), at the cost of some more verbosity.
 pub fn applier<K, QueueStream, ReconcilerFut, T>(
     mut reconciler: impl FnMut(K, Context<T>) -> ReconcilerFut,
@@ -309,10 +309,12 @@ where
 
     /// Indicate child objets `K` owns and be notified when they change
     ///
-    /// This type `Child` must have `OwnerReference`s set to point back to `K`.
+    /// This type `Child` must have [`OwnerReference`] set to point back to `K`.
     /// You can customize the parameters used by the underlying `watcher` if
     /// only a subset of `Child` entries are required.
     /// The `api` must have the correct scope (cluster/all namespaces, or namespaced)
+    ///
+    /// [`OwnerReference`]: https://docs.rs/k8s-openapi/0.10.0/k8s_openapi/apimachinery/pkg/apis/meta/v1/struct.OwnerReference.html
     pub fn owns<Child: Clone + Meta + DeserializeOwned + Send + 'static>(
         mut self,
         api: Api<Child>,
@@ -325,7 +327,7 @@ where
 
     /// Indicate an object to watch with a custom mapper
     ///
-    /// This mapper should return something like Option<ObjectRef<K>>
+    /// This mapper should return something like `Option<ObjectRef<K>>`
     pub fn watches<
         Other: Clone + Meta + DeserializeOwned + Send + 'static,
         I: 'static + IntoIterator<Item = ObjectRef<K>>,
@@ -347,7 +349,7 @@ where
     ///
     /// This creates a stream from all builder calls and starts an applier with
     /// a specified `reconciler` and `error_policy` callbacks. Each of these will be called
-    /// with a configurable `Context`.
+    /// with a configurable [`Context`].
     pub fn run<ReconcilerFut, T>(
         self,
         mut reconciler: impl FnMut(K, Context<T>) -> ReconcilerFut,

--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -4,7 +4,7 @@
 //! controllers/operators/watchers that need to synchronize/reconcile kubernetes
 //! state.
 //!
-//! Newcomers should generally get started with the `Controller` builder, which manages
+//! Newcomers should generally get started with the [`Controller`] builder, which manages
 //! all state internals for you.
 
 #![deny(unsafe_code)]

--- a/kube-runtime/src/scheduler.rs
+++ b/kube-runtime/src/scheduler.rs
@@ -184,11 +184,11 @@ where
     /// they are ready.
     ///
     /// The returned [`HoldUnless`] is designed to be short-lived: it has no allocations, and
-    /// no messages will be lost, even if it is reconstructed on each call to [`poll_next`].
+    /// no messages will be lost, even if it is reconstructed on each call to [`poll_next`](Self::poll_next).
     /// In fact, this is often desirable, to avoid long-lived borrows in `can_take_message`'s closure.
     ///
     /// NOTE: `can_take_message` should be considered fairly performance-sensitive, since
-    /// it will generally be executed for each pending message, for each [`poll_next`].
+    /// it will generally be executed for each pending message, for each [`poll_next`](Self::poll_next).
     pub fn hold_unless<C: Fn(&T) -> bool>(self: Pin<&mut Self>, can_take_message: C) -> HoldUnless<T, R, C> {
         HoldUnless {
             scheduler: self,

--- a/kube-runtime/src/utils.rs
+++ b/kube-runtime/src/utils.rs
@@ -15,7 +15,7 @@ use std::{
 use stream::IntoStream;
 use tokio::{runtime::Handle, task::JoinHandle};
 
-/// Flattens each item in the list following the rules of `watcher::Event::into_iter_applied`
+/// Flattens each item in the list following the rules of [`watcher::Event::into_iter_applied`].
 pub fn try_flatten_applied<K, S: TryStream<Ok = watcher::Event<K>>>(
     stream: S,
 ) -> impl Stream<Item = Result<K, S::Error>> {
@@ -24,7 +24,7 @@ pub fn try_flatten_applied<K, S: TryStream<Ok = watcher::Event<K>>>(
         .try_flatten()
 }
 
-/// Flattens each item in the list following the rules of `watcher::Event::into_iter_touched`
+/// Flattens each item in the list following the rules of [`watcher::Event::into_iter_touched`].
 pub fn try_flatten_touched<K, S: TryStream<Ok = watcher::Event<K>>>(
     stream: S,
 ) -> impl Stream<Item = Result<K, S::Error>> {

--- a/kube/src/api/dynamic.rs
+++ b/kube/src/api/dynamic.rs
@@ -26,8 +26,10 @@ use std::iter;
 /// It is recommended to use [`kube::CustomResource`] (from kube's `derive` feature)
 /// for CRD cases where you own a struct rather than this.
 ///
-/// **Note:** You will need to implement `k8s_openapi` traits yourself to use the typed `Api`
-/// with a `Resource` built from a `DynamicResource` (and this is not always feasible).
+/// **Note:** You will need to implement [`k8s_openapi`] traits yourself to use the typed [`Api`]
+/// with a [`Resource`] built from a [`DynamicResource`] (and this is not always feasible).
+///
+/// [`kube::CustomResource`]: crate::CustomResource
 #[derive(Default)]
 pub struct DynamicResource {
     pub(crate) kind: String,
@@ -37,7 +39,7 @@ pub struct DynamicResource {
 }
 
 impl DynamicResource {
-    /// Creates `DynamicResource` from an [`APIResource`](https://docs.rs/k8s-openapi/0.9.0/k8s_openapi/apimachinery/pkg/apis/meta/v1/struct.APIResource.html)
+    /// Creates `DynamicResource` from an [`APIResource`].
     ///
     /// `APIResource` objects can be extracted from [`Client::list_api_group_resources`].
     /// If it does not specify version and/or group, they will be taken
@@ -56,6 +58,8 @@ impl DynamicResource {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// [`API Resource`]: k8s_openapi::apimachinery::pkg::apis::meta::v1::APIResource
     pub fn from_api_resource(ar: &APIResource, group_version: &str) -> Self {
         let gvsplit = group_version.splitn(2, '/').collect::<Vec<_>>();
         let (default_group, default_version) = match *gvsplit.as_slice() {
@@ -73,11 +77,14 @@ impl DynamicResource {
         }
     }
 
-    /// Create a DynamicResource specifying the kind
+    /// Create a `DynamicResource` specifying the kind.
     ///
     /// The kind must not be plural and it must be in PascalCase
-    /// **Note:** You **must** call `group` and `version` to successfully convert
-    /// this object into something useful
+    /// **Note:** You **must** call [`group`] and [`version`] to successfully convert
+    /// this object into something useful.
+    ///
+    /// [`group`]: Self::group
+    /// [`version`]: Self::version
     pub fn new(kind: &str) -> Self {
         Self {
             kind: kind.into(),
@@ -103,18 +110,18 @@ impl DynamicResource {
         self
     }
 
-    /// Consume the DynamicResource and build a Resource
+    /// Consume the `DynamicResource` and build a `Resource`.
     ///
     /// Note this crashes on invalid group/version/kinds.
-    /// Use `try_into_resource` to handle the errors.
+    /// Use [`try_into_resource`](Self::try_into_resource) to handle the errors.
     pub fn into_resource(self) -> Resource {
         Resource::try_from(self).unwrap()
     }
 
-    /// Consume the DynamicResource and convert to an Api object
+    /// Consume the `DynamicResource` and convert to an `Api` object.
     ///
     /// Note this crashes on invalid group/version/kinds.
-    /// Use `try_into_api` to handle the errors.
+    /// Use [`try_into_api`](Self::try_into_api) to handle the errors.
     pub fn into_api<K>(self, client: Client) -> Api<K> {
         let resource = Resource::try_from(self).unwrap();
         Api {
@@ -124,14 +131,14 @@ impl DynamicResource {
         }
     }
 
-    /// Consume the `DynamicResource` and attempt to build a `Resource`
+    /// Consume the `DynamicResource` and attempt to build a `Resource`.
     ///
     /// Equivalent to importing TryFrom trait into scope.
     pub fn try_into_resource(self) -> Result<Resource> {
         Resource::try_from(self)
     }
 
-    /// Consume the `DynamicResource` and and attempt to convert to an Api object
+    /// Consume the `DynamicResource` and and attempt to convert to an `Api` object.
     pub fn try_into_api<K>(self, client: Client) -> Result<Api<K>> {
         let resource = Resource::try_from(self)?;
         Ok(Api {

--- a/kube/src/api/metadata.rs
+++ b/kube/src/api/metadata.rs
@@ -2,17 +2,18 @@ pub use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ListMeta, ObjectMeta};
 use k8s_openapi::Metadata;
 use serde::{Deserialize, Serialize};
 
-/// An accessor trait for Metadata
+/// An accessor trait for Metadata.
 ///
-/// This for a subset of Kubernetes type that do not end in List
-/// These types, using ObjectMeta, SHOULD all have required properties:
-/// - .metadata
-/// - .metadata.name
+/// This is for a subset of Kubernetes type that do not end in `List`.
+/// These types, using [`ObjectMeta`], SHOULD all have required properties:
+/// - `.metadata`
+/// - `.metadata.name`
+///
 /// And these optional properties:
-/// - .metadata.namespace
-/// - .metadata.resource_version
+/// - `.metadata.namespace`
+/// - `.metadata.resource_version`
 ///
-/// This avoids a bunch of the unnecessary unwrap mechanics for apps
+/// This avoids a bunch of the unnecessary unwrap mechanics for apps.
 pub trait Meta: Metadata {
     /// Metadata that all persisted resources must have
     fn meta(&self) -> &ObjectMeta;
@@ -20,7 +21,7 @@ pub trait Meta: Metadata {
     fn name(&self) -> String;
     /// The namespace the resource is in
     fn namespace(&self) -> Option<String>;
-    /// Tthe resource version
+    /// The resource version
     fn resource_ver(&self) -> Option<String>;
 }
 
@@ -46,9 +47,9 @@ where
     }
 }
 
-/// A convenience struct for ad-hoc serialization
+/// A convenience struct for ad-hoc serialization.
 ///
-/// Mostly useful for `Object`
+/// Mostly useful for [`Object`](super::Object).
 #[derive(Deserialize, Serialize, Clone, Default, Debug, Eq, PartialEq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct TypeMeta {

--- a/kube/src/api/mod.rs
+++ b/kube/src/api/mod.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Empty struct for when data should be discarded
 ///
 /// Not using [`()`](https://doc.rust-lang.org/stable/std/primitive.unit.html), because serde's
-/// [`Deserialize`](https://docs.rs/serde/1.0.104/serde/trait.Deserialize.html) `impl` is too strict.
+/// [`Deserialize`](serde::Deserialize) `impl` is too strict.
 #[derive(Clone, Deserialize, Serialize, Default, Debug)]
 pub struct NotUsed {}
 

--- a/kube/src/api/object.rs
+++ b/kube/src/api/object.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 
 /// A raw event returned from a watch query
 ///
-/// Note that a watch query returns many of these as newline separated json.
+/// Note that a watch query returns many of these as newline separated JSON.
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(tag = "type", content = "object", rename_all = "UPPERCASE")]
 pub enum WatchEvent<K>
@@ -20,11 +20,11 @@ where
     Modified(K),
     /// Resource was deleted
     Deleted(K),
-    /// Resource bookmark
+    /// Resource bookmark. `Bookmark` is a slimmed down `K` due to [#285](https://github.com/clux/kube-rs/issues/285).
     ///
-    /// From [Watch bookmarks](https://kubernetes.io/docs/reference/using-api/api-concepts/#watch-bookmarks)
-    /// NB: This became Beta first in Kubernetes 1.16
-    /// Slimmed down K for Bookmark WatchEvents due to #285
+    /// From [Watch bookmarks](https://kubernetes.io/docs/reference/using-api/api-concepts/#watch-bookmarks).
+    ///
+    /// NB: This became Beta first in Kubernetes 1.16.
     Bookmark(Bookmark),
     /// There was some kind of error
     Error(ErrorResponse),
@@ -45,11 +45,10 @@ where
     }
 }
 
-/// Slimed down K for WatchEvent::Bookmark
+/// Slimed down K for [`WatchEvent::Bookmark`] due to [#285](https://github.com/clux/kube-rs/issues/285).
 ///
-/// Can only be relied upon to have metadata with resource version
-/// Slimmed down K for Bookmark WatchEvents due to #285
-/// Bookmarks contain apiVersion + kind + basically empty metadata
+/// Can only be relied upon to have metadata with resource version.
+/// Bookmarks contain apiVersion + kind + basically empty metadata.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Bookmark {
     /// apiVersion + kind
@@ -69,11 +68,11 @@ pub struct BookmarkMeta {
 
 // -------------------------------------------------------
 
-/// A standard Kubernetes object with .spec and .status
+/// A standard Kubernetes object with `.spec` and `.status`.
 ///
 /// This is a convenience struct provided for serialization/deserialization
 /// It is not useful within the library anymore, because it can not easily implement
-/// the k8s_openapi traits.
+/// the [`k8s_openapi`] traits.
 ///
 /// This is what Kubernetes maintainers tell you the world looks like.
 /// It's.. generally true.
@@ -131,24 +130,24 @@ where
 /// A generic Kubernetes object list
 ///
 /// This is used instead of a full struct for `DeploymentList`, `PodList`, etc.
-/// Kubernetes' API [always seem to expose list structs in this manner](https://docs.rs/k8s-openapi/0.4.0/k8s_openapi/apimachinery/pkg/apis/meta/v1/struct.ObjectMeta.html?search=List).
+/// Kubernetes' API [always seem to expose list structs in this manner](https://docs.rs/k8s-openapi/0.10.0/k8s_openapi/apimachinery/pkg/apis/meta/v1/struct.ObjectMeta.html?search=List).
 ///
 /// Note that this is only used internally within reflectors and informers,
-/// and is generally produced from list/watch/delete collection queries on an `Resource`.
+/// and is generally produced from list/watch/delete collection queries on an [`Resource`](super::Resource).
 ///
-/// This almost equivalent to k8s_openapi::List<T>, but iterable
+/// This is almost equivalent to [`k8s_openapi::List<T>`](k8s_openapi::List), but iterable.
 #[derive(Deserialize, Debug)]
 pub struct ObjectList<T>
 where
     T: Clone,
 {
     // NB: kind and apiVersion can be set here, but no need for it atm
-    /// ListMeta - only really used for its resourceVersion
+    /// ListMeta - only really used for its `resourceVersion`
     ///
-    /// See [ListMeta](https://arnavion.github.io/k8s-openapi/v0.7.x/k8s_openapi/apimachinery/pkg/apis/meta/v1/struct.ListMeta.html)
+    /// See [ListMeta](k8s_openapi::apimachinery::pkg::apis::meta::v1::ListMeta)
     pub metadata: ListMeta,
 
-    /// The items we are actually interested in. In practice; T:= Resource<T,U>.
+    /// The items we are actually interested in. In practice; `T := Resource<T,U>`.
     #[serde(bound(deserialize = "Vec<T>: Deserialize<'de>"))]
     pub items: Vec<T>,
 }

--- a/kube/src/api/params.rs
+++ b/kube/src/api/params.rs
@@ -37,7 +37,7 @@ pub struct ListParams {
     /// Limit the number of results.
     ///
     /// If there are more results, the server will respond with a continue token which can be used to fetch another page
-    /// of results. See the [kubernetes API docs](https://kubernetes.io/docs/reference/using-api/api-concepts/#retrieving-large-results-sets-in-chunks)
+    /// of results. See the [Kubernetes API docs](https://kubernetes.io/docs/reference/using-api/api-concepts/#retrieving-large-results-sets-in-chunks)
     /// for pagination details.
     pub limit: Option<u32>,
 
@@ -83,7 +83,7 @@ impl ListParams {
     /// Configure the selector to restrict the list of returned objects by their fields.
     ///
     /// Defaults to everything.
-    /// Supports '=', '==', and '!=', and can comma separate: key1=value1,key2=value2
+    /// Supports `=`, `==`, `!=`, and can be comma separated: `key1=value1,key2=value2`.
     /// The server only supports a limited number of field queries per type.
     pub fn fields(mut self, field_selector: &str) -> Self {
         self.field_selector = Some(field_selector.to_string());
@@ -93,7 +93,7 @@ impl ListParams {
     /// Configure the selector to restrict the list of returned objects by their labels.
     ///
     /// Defaults to everything.
-    /// Supports '=', '==', and '!=', and can comma separate: key1=value1,key2=value2
+    /// Supports `=`, `==`, `!=`, and can be comma separated: `key1=value1,key2=value2`.
     pub fn labels(mut self, label_selector: &str) -> Self {
         self.label_selector = Some(label_selector.to_string());
         self
@@ -147,12 +147,12 @@ impl PostParams {
 pub struct PatchParams {
     /// Whether to run this as a dry run
     pub dry_run: bool,
-    /// Strategy which will be used. Defaults to `PatchStrategy::Strategic`
+    /// Strategy which will be used. Defaults to [`PatchStrategy::Strategic`].
     pub patch_strategy: PatchStrategy,
-    /// force Apply requests. Applicable only to `PatchStrategy::Apply`
+    /// force Apply requests. Applicable only to [`PatchStrategy::Apply`].
     pub force: bool,
-    /// fieldManager is a name of the actor that is making changes. Required for `PatchStrategy::Apply`
-    /// optional for everything else
+    /// fieldManager is a name of the actor that is making changes. Required for [`PatchStrategy::Apply`]
+    /// optional for everything else.
     pub field_manager: Option<String>,
 }
 impl PatchParams {
@@ -189,7 +189,7 @@ impl PatchParams {
         }
     }
 
-    /// Construct PatchParams for server-side apply
+    /// Construct `PatchParams` for server-side apply
     pub fn apply(manager: &str) -> Self {
         Self {
             patch_strategy: PatchStrategy::Apply,
@@ -263,7 +263,7 @@ pub struct DeleteParams {
     /// The duration in seconds before the object should be deleted.
     ///
     /// Value must be non-negative integer. The value zero indicates delete immediately.
-    /// If this value is None, the default grace period for the specified type will be used.
+    /// If this value is `None`, the default grace period for the specified type will be used.
     /// Defaults to a per object value if not specified. Zero means delete immediately.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub grace_period_seconds: Option<u32>,
@@ -271,13 +271,13 @@ pub struct DeleteParams {
     /// Whether or how garbage collection is performed.
     ///
     /// The default policy is decided by the existing finalizer set in
-    /// metadata.finalizers, and the resource-specific default policy.
+    /// `metadata.finalizers`, and the resource-specific default policy.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub propagation_policy: Option<PropagationPolicy>,
 
     /// Condtions that must be fulfilled before a deletion is carried out
     ///
-    /// If not possible, a 409 Conflict status will be returned.
+    /// If not possible, a `409 Conflict` status will be returned.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preconditions: Option<Preconditions>,
 }

--- a/kube/src/api/resource.rs
+++ b/kube/src/api/resource.rs
@@ -7,10 +7,10 @@ use inflector::string::pluralize::to_plural;
 pub struct Resource {
     /// The API version of the resource.
     ///
-    /// This is a composite of Resource::GROUP and Resource::VERSION
+    /// This is a composite of `Resource::GROUP` and `Resource::VERSION`
     /// (eg "apiextensions.k8s.io/v1beta1")
     /// or just the version for resources without a group (eg "v1").
-    /// This is the string used in the apiVersion field of the resource's serialized form.
+    /// This is the string used in the `apiVersion` field of the resource's serialized form.
     pub api_version: String,
 
     /// The group of the resource
@@ -61,9 +61,9 @@ impl Resource {
 
     /// Manually configured resource or custom resource
     ///
-    /// This is the only entrypoint to `Resource` that bypasses `k8s-openapi` entirely.
+    /// This is the only entrypoint to `Resource` that bypasses [`k8s_openapi`] entirely.
     /// If you need a `CustomResource` consider using `kube-derive` for its
-    /// #[derive(CustomResource)] proc-macro.
+    /// `#[derive(CustomResource)]` proc-macro.
     pub fn dynamic(kind: &str) -> DynamicResource {
         DynamicResource::new(kind)
     }
@@ -216,7 +216,7 @@ impl Resource {
 
     /// Replace an instance of a resource
     ///
-    /// Requires metadata.resourceVersion set in data
+    /// Requires `metadata.resourceVersion` set in data
     pub fn replace(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<http::Request<Vec<u8>>> {
         let base_url = self.make_url() + "/" + name + "?";
         let mut qp = url::form_urlencoded::Serializer::new(base_url);

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -9,9 +9,7 @@ use crate::{
 
 pub use k8s_openapi::api::autoscaling::v1::{Scale, ScaleSpec, ScaleStatus};
 
-/// Scale subresource
-///
-/// https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#scale-subresource
+/// Methods for [scale subresource](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#scale-subresource).
 impl<K> Api<K>
 where
     K: Clone + DeserializeOwned,
@@ -37,11 +35,9 @@ where
 
 // ----------------------------------------------------------------------------
 
-/// Status subresource
-///
-/// https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#status-subresource
-/// TODO: Replace examples with owned custom resources. Bad practice to write to owned objects
-/// These examples work, but the job controller will totally overwrite what we do.
+// TODO: Replace examples with owned custom resources. Bad practice to write to owned objects
+// These examples work, but the job controller will totally overwrite what we do.
+/// Methods for [status subresource](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#status-subresource).
 impl<K> Api<K>
 where
     K: Clone + DeserializeOwned,
@@ -84,8 +80,8 @@ where
 
     /// Replace every field on the status object
     ///
-    /// This works similarly to the `Api::replace` method, but .spec is ignored.
-    /// You can leave out the .spec entirely from the serialized output.
+    /// This works similarly to the [`Api::replace`] method, but `.spec` is ignored.
+    /// You can leave out the `.spec` entirely from the serialized output.
     ///
     /// ```no_run
     /// use kube::{api::{Api, PostParams}, Client};
@@ -116,14 +112,14 @@ where
 pub struct LogParams {
     /// The container for which to stream logs. Defaults to only container if there is one container in the pod.
     pub container: Option<String>,
-    /// Follow the log stream of the pod. Defaults to false.
+    /// Follow the log stream of the pod. Defaults to `false`.
     pub follow: bool,
     /// If set, the number of bytes to read from the server before terminating the log output.
     /// This may not display a complete final line of logging, and may return slightly more or slightly less than the specified limit.
     pub limit_bytes: Option<i64>,
-    /// If 'true', then the output is pretty printed.
+    /// If `true`, then the output is pretty printed.
     pub pretty: bool,
-    /// Return previous terminated container logs. Defaults to false.
+    /// Return previous terminated container logs. Defaults to `false`.
     pub previous: bool,
     /// A relative time in seconds before the current time from which to show logs.
     /// If this value precedes the time a pod was started, only logs since the pod start will be returned.
@@ -132,7 +128,7 @@ pub struct LogParams {
     /// If set, the number of lines from the end of the logs to show.
     /// If not specified, logs are shown from the creation of the container or sinceSeconds or sinceTime
     pub tail_lines: Option<i64>,
-    /// If true, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output. Defaults to false.
+    /// If `true`, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output. Defaults to `false`.
     pub timestamps: bool,
 }
 

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -11,9 +11,9 @@ use crate::{
 
 /// A generic Api abstraction
 ///
-/// This abstracts over a `Resource` and a type `K` so that
+/// This abstracts over a [`Resource`] and a type `K` so that
 /// we get automatic serialization/deserialization on the api calls
-/// implemented by the dynamic `Resource`.
+/// implemented by the dynamic [`Resource`].
 #[derive(Clone)]
 pub struct Api<K> {
     /// The request creator object
@@ -108,19 +108,19 @@ where
     /// Create a resource
     ///
     /// This function requires a type that Serializes to `K`, which can be:
-    /// 1. Raw string yaml
-    ///   - easy to port from existing files
-    ///   - error prone (run-time errors on typos due to failed serialize attempts)
-    ///   - very error prone (can write invalid yaml)
+    /// 1. Raw string YAML
+    ///     - easy to port from existing files
+    ///     - error prone (run-time errors on typos due to failed serialize attempts)
+    ///     - very error prone (can write invalid YAML)
     /// 2. An instance of the struct itself
-    ///   - easy to instantiate for CRDs (you define the struct)
-    ///   - dense to instantiate for k8s-openapi types (due to many optionals)
-    ///   - compile-time safety
-    ///   - but still possible to write invalid native types (validation at apiserver)
-    /// 3. `serde_json::json!` macro instantiated `serde_json::Value`
-    ///   - Tradeoff between the two
-    ///   - Easy partially filling of native k8s-openapi types (most fields optional)
-    ///   - Partial safety against runtime errors (at least you must write valid json)
+    ///     - easy to instantiate for CRDs (you define the struct)
+    ///     - dense to instantiate for [`k8s_openapi`] types (due to many optionals)
+    ///     - compile-time safety
+    ///     - but still possible to write invalid native types (validation at apiserver)
+    /// 3. [`serde_json::json!`] macro instantiated [`serde_json::Value`]
+    ///     - Tradeoff between the two
+    ///     - Easy partially filling of native [`k8s_openapi`] types (most fields optional)
+    ///     - Partial safety against runtime errors (at least you must write valid JSON)
     pub async fn create(&self, pp: &PostParams, data: &K) -> Result<K>
     where
         K: Serialize,
@@ -136,7 +136,7 @@ where
     /// When you get a `Status` via `Right`, this should be a a 2XX style
     /// confirmation that the object being gone.
     ///
-    /// 4XX and 5XX status types are returned as an `Err(kube::Error::Api)`
+    /// 4XX and 5XX status types are returned as an [`Err(kube::Error::Api)`](crate::Error::Api).
     ///
     /// ```no_run
     /// use kube::{api::{Api, DeleteParams}, Client};
@@ -163,7 +163,7 @@ where
     /// When you get a `Status` via `Right`, this should be a a 2XX style
     /// confirmation that the object being gone.
     ///
-    /// 4XX and 5XX status types are returned as an `Err(kube::Error::Api)`
+    /// 4XX and 5XX status types are returned as an [`Err(kube::Error::Api)`](crate::Error::Api).
     ///
     /// ```no_run
     /// use kube::{api::{Api, DeleteParams, ListParams, Meta}, Client};
@@ -195,19 +195,10 @@ where
 
     /// Patch a resource a subset of its properties
     ///
-    /// Note that some of the [`PatchStrategy`](crate::api::PatchStrategy) variants require different serialization.
-    ///
-    /// The original strategies such as `PatchStrategy::Merge`, `PatchStrategy::JSON`
-    /// and `PatchStrategy::Merge` should be serialized using `serde_json::to_vec`.
-    ///
-    /// See [kubernetes json patch types](https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment)
-    /// for more information about their distinction.
-    ///
-    ///
-    /// When using `PatchStrategy::Apply`, you **must** serialize your
-    /// data using `serde_yaml`:
-    ///
-    ///
+    /// Note that some of the [`PatchStrategy`](super::PatchStrategy) variants require different
+    /// serialization. The original strategies such as [`Merge`], [`JSON`] and [`Strategic`] should be
+    /// serialized using [`serde_json::to_vec`].
+    /// When using [`Apply`], you **must** serialize your data using [`serde_yaml::to_vec`]:
     /// ```no_run
     /// use kube::{api::{Api, PatchParams, Meta}, Client};
     /// use k8s_openapi::api::core::v1::Pod;
@@ -230,8 +221,15 @@ where
     ///     Ok(())
     /// }
     /// ```
-    ///
     /// Note that you can still create the data any way you like (like with `serde_json`).
+    ///
+    /// See [kubernetes json patch types](https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment)
+    /// for more information about their distinction.
+    ///
+    /// [`Merge`]: super::PatchStrategy::Merge
+    /// [`JSON`]: super::PatchStrategy::JSON
+    /// [`Strategic`]: super::PatchStrategy::Strategic
+    /// [`Apply`]: super::PatchStrategy::Apply
     pub async fn patch(&self, name: &str, pp: &PatchParams, patch: Vec<u8>) -> Result<K> {
         let req = self.resource.patch(name, &pp, patch)?;
         self.client.request::<K>(req).await
@@ -239,7 +237,7 @@ where
 
     /// Replace a resource entirely with a new one
     ///
-    /// This is used just like `Api::create`, but with one additional instruction:
+    /// This is used just like [`Api::create`], but with one additional instruction:
     /// You must set `metadata.resourceVersion` in the provided data because k8s
     /// will not accept an update unless you actually knew what the last version was.
     ///

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! This client can be used on its own or in conjuction with
 //! the [`Api`][crate::api::Api] type for more structured
-//! interaction with the kuberneres API
+//! interaction with the kuberneres API.
 
 use crate::{
     api::{Meta, WatchEvent},
@@ -46,7 +46,7 @@ impl Client {
     /// Panics if the configuration supplied leads to an invalid HTTP client.
     /// Refer to the [`reqwest::ClientBuilder::build`] docs for information
     /// on situations where this might fail. If you want to handle this error case
-    /// use `Config::try_from` (note that this requires [`std::convert::TryFrom`]
+    /// use [`Config::try_from`](Self::try_from) (note that this requires [`std::convert::TryFrom`]
     /// to be in scope.)
     pub fn new(config: Config) -> Self {
         Self::try_from(config).expect("Could not create a client from the supplied config")
@@ -60,7 +60,7 @@ impl Client {
     ///
     /// Will fail if neither configuration could be loaded.
     ///
-    /// If you already have a [`Config`] then use `Client::try_from`
+    /// If you already have a [`Config`] then use [`Client::try_from`](Self::try_from)
     /// instead
     pub async fn try_default() -> Result<Self> {
         let client_config = Config::infer().await?;

--- a/kube/src/config/mod.rs
+++ b/kube/src/config/mod.rs
@@ -1,8 +1,8 @@
-//! Kubernetes configuration objects from ~/.kube/config or in cluster environment
+//! Kubernetes configuration objects from `~/.kube/config` or in cluster environment.
 //!
 //! Used to populate [`Config`] that is ultimately used to construct a [`Client`][crate::Client].
 //!
-//! Unless you have issues, prefer using `Config::infer` and pass it to a [`Client`][crate::Client].
+//! Unless you have issues, prefer using [`Config::infer`] and pass it to a [`Client`][crate::Client].
 
 mod exec;
 mod file_config;
@@ -62,7 +62,7 @@ impl Authentication {
     }
 }
 
-/// Configuration object detailing things like cluster_url, default namespace, root certificates, and timeouts
+/// Configuration object detailing things like cluster URL, default namespace, root certificates, and timeouts.
 #[derive(Debug, Clone)]
 pub struct Config {
     /// The configured cluster url

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -11,11 +11,11 @@ pub enum Error {
     /// ApiError for when things fail
     ///
     /// This can be parsed into as an error handling fallback.
-    /// Replacement data for reqwest::Response::error_for_status,
+    /// Replacement data for [`reqwest::Response::error_for_status`],
     /// which is often lacking in good permission errors.
     /// It's also used in `WatchEvent` from watch calls.
     ///
-    /// It's quite common to get a `410 Gone` when the resourceVersion is too old.
+    /// It's quite common to get a `410 Gone` when the `resourceVersion` is too old.
     #[error("ApiError: {0} ({0:?})")]
     Api(#[source] ErrorResponse),
 
@@ -179,7 +179,7 @@ pub enum ConfigError {
     AuthExec(String),
 }
 
-/// An Error response from the API
+/// An error response from the API.
 #[derive(Error, Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 #[error("{message}: {reason}")]
 pub struct ErrorResponse {

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -6,7 +6,7 @@
 //! # Example
 //!
 //! The following example will create a [`Pod`][k8s_openapi::api::core::v1::Pod]
-//! and then watch for it to become available using a manual `Api::watch` call.
+//! and then watch for it to become available using a manual [`Api::watch`] call.
 //!
 //! ```rust,no_run
 //! use futures::{StreamExt, TryStreamExt};


### PR DESCRIPTION
- Fix typos
- Fix inconsistency
- Fix unclickable URLs
- Fix unintentional rendering (e.g., collapsed lists and paragraphs)
- Remove comments that shouldn't be in the docs (e.g., TODO rewrite examples)
- Add more useful links to jump to

Didn't fix missing periods for now unless the line had something else to fix.