### PR TITLE
kube-derive rename kind_struct -> struct

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,8 @@ jobs:
       - run: kubectl describe deploy dapp -n apps
       - run: timeout 60 kubectl logs -f deploy/dapp -n apps || kubectl logs -f deploy/dapp -p -n apps
       - run: kubectl get all -n apps
-      - run: kubectl get pods -n apps | grep dapp | grep Completed
-      - run: kubectl get pods -n apps | grep empty-job | grep Completed
+      - run: kubectl get all -n apps | grep pod/dapp | grep Completed
+      - run: kubectl get all -n apps | grep empty-job | grep Completed
 
   cargo_test:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ===================
   * feat: `kube-derive` now has a default enabled `schema` feature
     * allows opting out of `schemars` dependency for handwriting crds - #355
-  * breaking: `kube-derive` attr `struct_name` renamed to `struct`
+  * breaking: `kube-derive` attr `struct_name` renamed to `struct` - #359
   * docs: improvements on `kube`, `kube-runtime`, `kube-derive`
 
 0.44.0 / 2020-12-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.45.0 / 2020-12-26
+===================
+  * feat: `kube-derive` now has a default enabled `schema` feature
+    * allows opting out of `schemars` dependency for handwriting crds - #355
+  * breaking: `kube-derive` attr `struct_name` renamed to `struct`
+  * docs: improvements on `kube`, `kube-runtime`, `kube-derive`
+
 0.44.0 / 2020-12-23
 ===================
   * feat: `kube-derive` now generates openapi v3 schemas and is thus usable with v1 `CustomResourceDefinition` - #129 and #264 via #348

--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -19,7 +19,6 @@ use serde::{Deserialize, Serialize};
     scale = r#"{"specReplicasPath":".spec.replicas", "statusReplicasPath":".status.replicas"}"#,
     printcolumn = r#"{"name":"Spec", "type":"string", "description":"name of foo", "jsonPath":".spec.name"}"#
 )]
-#[kube(apiextensions = "v1")]
 pub struct MyFoo {
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
     group = "clux.dev",
     version = "v1",
     kind = "Foo",
+    struct = "FooCrd",
     namespaced,
     status = "FooStatus",
     derive = "PartialEq",
@@ -31,22 +32,21 @@ pub struct FooStatus {
 }
 
 fn main() {
-    println!("Kind {}", Foo::KIND);
-    let mut foo = Foo::new("hi", MyFoo {
+    println!("Kind {}", FooCrd::KIND);
+    let mut foo = FooCrd::new("hi", MyFoo {
         name: "hi".into(),
         info: None,
     });
     foo.status = Some(FooStatus { is_bad: true });
     println!("Spec: {:?}", foo.spec);
-    let crd = serde_json::to_string_pretty(&Foo::crd()).unwrap();
+    let crd = serde_json::to_string_pretty(&FooCrd::crd()).unwrap();
     println!("Foo CRD: \n{}", crd);
 }
 
 // some tests
-// Verify Foo::crd
+// Verify FooCrd::crd
 #[test]
 fn verify_crd() {
-    let crd = Foo::crd();
     let output = serde_json::json!({
       "apiVersion": "apiextensions.k8s.io/v1",
       "kind": "CustomResourceDefinition",
@@ -111,7 +111,7 @@ fn verify_crd() {
                 "required": [
                   "spec"
                 ],
-                "title": "Foo",
+                "title": "FooCrd",
                 "type": "object"
               }
             },
@@ -126,24 +126,24 @@ fn verify_crd() {
         ]
       }
     });
-    let outputcrd = serde_json::from_value(output).expect("expected output is valid");
-    assert_eq!(crd, outputcrd);
+    let crd = serde_json::to_value(FooCrd::crd()).unwrap();
+    assert_eq!(crd, output);
 }
 
 #[test]
 fn verify_resource() {
     use static_assertions::{assert_impl_all, assert_impl_one};
-    assert_eq!(Foo::KIND, "Foo");
-    assert_eq!(Foo::GROUP, "clux.dev");
-    assert_eq!(Foo::VERSION, "v1");
-    assert_eq!(Foo::API_VERSION, "clux.dev/v1");
-    assert_impl_all!(Foo: k8s_openapi::Resource, k8s_openapi::Metadata, Default);
+    assert_eq!(FooCrd::KIND, "Foo");
+    assert_eq!(FooCrd::GROUP, "clux.dev");
+    assert_eq!(FooCrd::VERSION, "v1");
+    assert_eq!(FooCrd::API_VERSION, "clux.dev/v1");
+    assert_impl_all!(FooCrd: k8s_openapi::Resource, k8s_openapi::Metadata, Default);
     assert_impl_one!(MyFoo: JsonSchema);
 }
 
 #[test]
 fn verify_default() {
-    let fdef = Foo::default();
+    let fdef = FooCrd::default();
     let ser = serde_yaml::to_string(&fdef).unwrap();
     let exp = r#"---
 apiVersion: clux.dev/v1

--- a/examples/crd_derive_no_schema.rs
+++ b/examples/crd_derive_no_schema.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 /// But here, we simply drop in a valid schema from a string and avoid schemars from the dependency tree entirely.
 #[cfg(not(feature = "schema"))]
 #[derive(CustomResource, Serialize, Deserialize, Debug, Clone)]
-#[kube(group = "clux.dev", version = "v1", kind = "Bar", struct = "BarCr", namespaced)]
+#[kube(group = "clux.dev", version = "v1", kind = "Bar", namespaced)]
 pub struct MyBar {
     bars: u32,
 }
@@ -30,7 +30,7 @@ properties:
 "#;
 
 #[cfg(not(feature = "schema"))]
-impl BarCr {
+impl Bar {
     fn crd_with_manual_schema() -> CustomResourceDefinition {
         let schema: JSONSchemaProps = serde_yaml::from_str(MANUAL_SCHEMA).expect("invalid schema");
 
@@ -47,7 +47,7 @@ impl BarCr {
 
 #[cfg(not(feature = "schema"))]
 fn main() {
-    let crd = BarCr::crd_with_manual_schema();
+    let crd = Bar::crd_with_manual_schema();
     println!("{}", serde_yaml::to_string(&crd).unwrap());
 }
 #[cfg(feature = "schema")]
@@ -63,13 +63,13 @@ fn verify_bar_is_a_custom_resource() {
     use schemars::JsonSchema; // only for ensuring it's not implemented
     use static_assertions::{assert_impl_all, assert_not_impl_any};
 
-    println!("Kind {}", BarCr::KIND);
-    let bar = BarCr::new("five", MyBar { bars: 5 });
+    println!("Kind {}", Bar::KIND);
+    let bar = Bar::new("five", MyBar { bars: 5 });
     println!("Spec: {:?}", bar.spec);
-    assert_impl_all!(BarCr: k8s_openapi::Resource, k8s_openapi::Metadata);
+    assert_impl_all!(Bar: k8s_openapi::Resource, k8s_openapi::Metadata);
     assert_not_impl_any!(MyBar: JsonSchema); // but no schemars schema implemented
 
-    let crd = BarCr::crd_with_manual_schema();
+    let crd = Bar::crd_with_manual_schema();
     for v in crd.spec.versions {
         assert!(v.schema.unwrap().open_api_v3_schema.is_some());
     }

--- a/examples/crd_derive_no_schema.rs
+++ b/examples/crd_derive_no_schema.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 /// But here, we simply drop in a valid schema from a string and avoid schemars from the dependency tree entirely.
 #[cfg(not(feature = "schema"))]
 #[derive(CustomResource, Serialize, Deserialize, Debug, Clone)]
-#[kube(group = "clux.dev", version = "v1", kind = "Bar", namespaced)]
+#[kube(group = "clux.dev", version = "v1", kind = "Bar", struct = "BarCr", namespaced)]
 pub struct MyBar {
     bars: u32,
 }
@@ -30,7 +30,7 @@ properties:
 "#;
 
 #[cfg(not(feature = "schema"))]
-impl Bar {
+impl BarCr {
     fn crd_with_manual_schema() -> CustomResourceDefinition {
         let schema: JSONSchemaProps = serde_yaml::from_str(MANUAL_SCHEMA).expect("invalid schema");
 
@@ -47,7 +47,7 @@ impl Bar {
 
 #[cfg(not(feature = "schema"))]
 fn main() {
-    let crd = Bar::crd_with_manual_schema();
+    let crd = BarCr::crd_with_manual_schema();
     println!("{}", serde_yaml::to_string(&crd).unwrap());
 }
 #[cfg(feature = "schema")]
@@ -63,13 +63,13 @@ fn verify_bar_is_a_custom_resource() {
     use schemars::JsonSchema; // only for ensuring it's not implemented
     use static_assertions::{assert_impl_all, assert_not_impl_any};
 
-    println!("Kind {}", Bar::KIND);
-    let bar = Bar::new("five", MyBar { bars: 5 });
+    println!("Kind {}", BarCr::KIND);
+    let bar = BarCr::new("five", MyBar { bars: 5 });
     println!("Spec: {:?}", bar.spec);
-    assert_impl_all!(Bar: k8s_openapi::Resource, k8s_openapi::Metadata);
+    assert_impl_all!(BarCr: k8s_openapi::Resource, k8s_openapi::Metadata);
     assert_not_impl_any!(MyBar: JsonSchema); // but no schemars schema implemented
 
-    let crd = Bar::crd_with_manual_schema();
+    let crd = BarCr::crd_with_manual_schema();
     for v in crd.spec.versions {
         assert!(v.schema.unwrap().open_api_v3_schema.is_some());
     }

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -87,12 +87,12 @@ impl CustomDerive for CustomResource {
                                 return Err(r#"#[kube(kind = "...")] expects a string literal value"#)
                                     .spanning(meta);
                             }
-                        } else if meta.path.is_ident("kind_struct") {
+                        } else if meta.path.is_ident("struct") {
                             if let syn::Lit::Str(lit) = &meta.lit {
                                 kind_struct = Some(lit.value());
                                 continue;
                             } else {
-                                return Err(r#"#[kube(kind_struct = "...")] expects a string literal value"#)
+                                return Err(r#"#[kube(struct = "...")] expects a string literal value"#)
                                     .spanning(meta);
                             }
                         } else if meta.path.is_ident("plural") {

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -147,6 +147,7 @@ use custom_resource::CustomResource;
 ///     group = "clux.dev",
 ///     version = "v1",
 ///     kind = "Foo",
+///     struct = "FooCrd",
 ///     namespaced,
 ///     status = "FooStatus",
 ///     derive = "PartialEq",
@@ -171,17 +172,17 @@ use custom_resource::CustomResource;
 /// ```ignore
 /// #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
 /// #[serde(rename_all = "camelCase")]
-/// pub struct Foo {
+/// pub struct FooCrd {
 ///     api_version: String,
 ///     kind: String,
 ///     metadata: ObjectMeta,
 ///     spec: FooSpec,
 ///     status: Option<FooStatus>,
 /// }
-/// impl k8s_openapi::Resource for Foo {...}
-/// impl k8s_openapi::Metadata for Foo {...}
+/// impl k8s_openapi::Resource for FooCrd {...}
+/// impl k8s_openapi::Metadata for FooCrd {...}
 ///
-/// impl Foo {
+/// impl FooCrd {
 ///     pub fn new(name: &str, spec: FooSpec) -> Self { ... }
 ///     pub fn crd() -> k8s_openapi::...::CustomResourceDefinition { ... }
 /// }

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -115,7 +115,7 @@ use custom_resource::CustomResource;
 /// ### `#[kube(namespaced)]`
 /// To specify that this is a namespaced resource rather than cluster level.
 ///
-/// ### `#[kube(kind_struct = "KindStructName")]`
+/// ### `#[kube(struct = "StructName")]`
 /// Customize the name of the generated root struct (defaults to `kind`).
 ///
 /// ### `#[kube(status = "StatusStructName")]`


### PR DESCRIPTION
more memorable, ultimately a pretty major thing; what struct are we generating.
`kind_struct` is also not entirely clear, it's the struct for the custom resource describing a kind, so the specificity doesn't add anything here.