### PR TITLE
AttachParams tweaks

### DIFF
--- a/examples/pod_shell.rs
+++ b/examples/pod_shell.rs
@@ -52,8 +52,8 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    // Do an exec to a blog pod with the `sh` command and allow an input (stdin) stream
-    let ap = AttachParams::default().stdin(true).stdout(true).stderr(false).tty(true);
+    // Do an interactive exec to a blog pod with the `sh` command
+    let ap = AttachParams::interactive_tty();
     let mut attached = pods.exec("example", vec!["sh"], &ap).await?;
 
     // The received streams from `AttachedProcess`

--- a/examples/pod_shell.rs
+++ b/examples/pod_shell.rs
@@ -60,6 +60,8 @@ async fn main() -> anyhow::Result<()> {
     let mut stdin_writer = attached.stdin().unwrap();
     let mut stdout_reader = attached.stdout().unwrap();
 
+    // > For interactive uses, it is recommended to spawn a thread dedicated to user input and use blocking IO directly in that thread.
+    // > https://docs.rs/tokio/0.2.24/tokio/io/fn.stdin.html
     let mut stdin = tokio::io::stdin();
     let mut stdout = tokio::io::stdout();
     // pipe current stdin to the stdin writer from ws

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -289,6 +289,7 @@ impl AttachParams {
             ..Default::default()
         }
     }
+
     /// Specify the container to execute in.
     pub fn container<T: Into<String>>(mut self, container: T) -> Self {
         self.container = Some(container.into());

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -280,49 +280,49 @@ impl Default for AttachParams {
 #[cfg(feature = "ws")]
 impl AttachParams {
     /// Specify the container to execute in.
-    pub fn container<T: Into<String>>(&mut self, container: T) -> &mut Self {
+    pub fn container<T: Into<String>>(mut self, container: T) -> Self {
         self.container = Some(container.into());
         self
     }
 
     /// Set `stdin` field.
-    pub fn stdin(&mut self, enable: bool) -> &mut Self {
+    pub fn stdin(mut self, enable: bool) -> Self {
         self.stdin = enable;
         self
     }
 
     /// Set `stdout` field.
-    pub fn stdout(&mut self, enable: bool) -> &mut Self {
+    pub fn stdout(mut self, enable: bool) -> Self {
         self.stdout = enable;
         self
     }
 
     /// Set `stderr` field.
-    pub fn stderr(&mut self, enable: bool) -> &mut Self {
+    pub fn stderr(mut self, enable: bool) -> Self {
         self.stderr = enable;
         self
     }
 
     /// Set `tty` field.
-    pub fn tty(&mut self, enable: bool) -> &mut Self {
+    pub fn tty(mut self, enable: bool) -> Self {
         self.tty = enable;
         self
     }
 
     /// Set `max_stdin_buf_size` field.
-    pub fn max_stdin_buf_size(&mut self, size: usize) -> &mut Self {
+    pub fn max_stdin_buf_size(mut self, size: usize) -> Self {
         self.max_stdin_buf_size = Some(size);
         self
     }
 
     /// Set `max_stdout_buf_size` field.
-    pub fn max_stdout_buf_size(&mut self, size: usize) -> &mut Self {
+    pub fn max_stdout_buf_size(mut self, size: usize) -> Self {
         self.max_stdout_buf_size = Some(size);
         self
     }
 
     /// Set `max_stderr_buf_size` field.
-    pub fn max_stderr_buf_size(&mut self, size: usize) -> &mut Self {
+    pub fn max_stderr_buf_size(mut self, size: usize) -> Self {
         self.max_stderr_buf_size = Some(size);
         self
     }

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -279,6 +279,16 @@ impl Default for AttachParams {
 
 #[cfg(feature = "ws")]
 impl AttachParams {
+    /// Default parameters for an tty exec with stdin and stdout
+    pub fn interactive_tty() -> Self {
+        Self {
+            stdin: true,
+            stdout: true,
+            stderr: false,
+            tty: true,
+            ..Default::default()
+        }
+    }
     /// Specify the container to execute in.
     pub fn container<T: Into<String>>(mut self, container: T) -> Self {
         self.container = Some(container.into());


### PR DESCRIPTION
found one inconsistency in the way the parameters were being built, and created a shorthand ctor for the `exec -it` equivalent.