### PR TITLE
Fix v0.46.0 docs failing to build

### DIFF
--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -27,7 +27,7 @@ ws-native-tls = ["real-native-tls", "tokio-native-tls", "async-tungstenite/tokio
 ws-rustls-tls = ["tokio-rustls", "async-tungstenite/tokio-rustls"]
 
 [package.metadata.docs.rs]
-features = ["derive", "ws"]
+features = ["derive", "ws", "ws-native-tls"]
 
 [dependencies]
 base64 = "0.12.1"


### PR DESCRIPTION
```
cargo rustdoc --lib --features "derive ws"
```
failed with the same error as docs.rs.

```
cargo rustdoc --lib --features "derive ws ws-native-tls"
```
worked.

Closes #366

We should consider `all-features = true` and #365.