### PR TITLE
Tokio 1.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .vscode/
-
+.idea/
 /target
 **/*.rs.bk
 Cargo.lock

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -29,7 +29,7 @@ log = "0.4.11"
 serde = { version = "1.0.111", features = ["derive"] }
 serde_json = "1.0.57"
 serde_yaml = "0.8.14"
-tokio = { version = "0.2.24", features = ["full"] }
+tokio = { version = "~1.0", features = ["full"] }
 color-eyre = "0.5.1"
 snafu = { version = "0.6.8", features = ["futures"] }
 # Some Api::delete methods use Either

--- a/examples/configmap_reflector.rs
+++ b/examples/configmap_reflector.rs
@@ -11,7 +11,7 @@ fn spawn_periodic_reader(reader: Store<ConfigMap>) {
     tokio::spawn(async move {
         loop {
             // Periodically read our state
-            tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
             let cms: Vec<_> = reader.state().iter().map(|obj| Meta::name(obj).clone()).collect();
             info!("Current configmaps: {:?}", cms);
         }

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::time::Duration;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 use apiexts::CustomResourceDefinition;
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as apiexts;
@@ -60,7 +60,7 @@ async fn main() -> anyhow::Result<()> {
         })
     });
     // Wait for the delete to take place (map-left case or delete from previous run)
-    delay_for(Duration::from_secs(2)).await;
+    sleep(Duration::from_secs(2)).await;
 
     // Create the CRD so we can create Foos in kube
     let foocrd = Foo::crd();
@@ -76,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
         Err(e) => return Err(e.into()),                        // any other case is probably bad
     }
     // Wait for the api to catch up
-    delay_for(Duration::from_secs(1)).await;
+    sleep(Duration::from_secs(1)).await;
 
     // Manage the Foo CR
     let foos: Api<Foo> = Api::namespaced(client.clone(), &namespace);

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -32,7 +32,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(async move {
         loop {
             // Periodically read our state
-            tokio::time::delay_for(std::time::Duration::from_secs(5)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
             let crds = reader.state().iter().map(Meta::name).collect::<Vec<_>>();
             info!("Current crds: {:?}", crds);
         }

--- a/examples/deployment_reflector.rs
+++ b/examples/deployment_reflector.rs
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
             // Periodically read our state
             let deploys: Vec<_> = reader.state().iter().map(Meta::name).collect();
             info!("Current deploys: {:?}", deploys);
-            tokio::time::delay_for(std::time::Duration::from_secs(30)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
         }
     });
 

--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -27,7 +27,7 @@ async fn main() -> anyhow::Result<()> {
         loop {
             let nodes = reader.state().iter().map(Meta::name).collect::<Vec<_>>();
             info!("Current {} nodes: {:?}", nodes.len(), nodes);
-            tokio::time::delay_for(std::time::Duration::from_secs(10)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
         }
     });
 

--- a/examples/secret_reflector.rs
+++ b/examples/secret_reflector.rs
@@ -42,7 +42,7 @@ fn spawn_periodic_reader(reader: Store<Secret>) {
                 .map(|s| format!("{}: {:?}", Meta::name(s), decode(s).keys()))
                 .collect();
             info!("Current secrets: {:?}", cms);
-            tokio::time::delay_for(std::time::Duration::from_secs(15)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(15)).await;
         }
     });
 }

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -19,7 +19,8 @@ derivative = "2.1.1"
 serde = "1.0.115"
 smallvec = "1.4.2"
 pin-project = "0.4.23"
-tokio = { version = "0.2.21", features = ["time"] }
+tokio = { version = "~1.0", features = ["time"] }
+tokio-util = {version = "0.6.0", features = ["time"]}
 snafu = { version = "0.6.8", features = ["futures"] }
 dashmap = "3.11.10"
 
@@ -40,6 +41,6 @@ features = ["v1_19"]
 [dev-dependencies]
 kube-derive = { path = "../kube-derive", version = "^0.46.0"}
 serde_json = "1.0.57"
-tokio = { version = "0.2.22", features = ["full", "test-util"] }
+tokio = { version = "~1.0", features = ["full", "test-util"] }
 rand = "0.7.3"
 schemars = "0.8.0"

--- a/kube-runtime/src/controller/runner.rs
+++ b/kube-runtime/src/controller/runner.rs
@@ -88,7 +88,7 @@ mod tests {
     use crate::scheduler::{scheduler, ScheduleRequest};
     use futures::{channel::mpsc, poll, SinkExt, TryStreamExt};
     use std::{cell::RefCell, time::Duration};
-    use tokio::time::{delay_for, pause, Instant};
+    use tokio::time::{sleep, pause, Instant};
 
     #[tokio::test]
     async fn runner_should_never_run_two_instances_at_once() {
@@ -102,7 +102,7 @@ mod tests {
                 // Panic if this ref is already held, to simulate some unsafe action..
                 let mutex_ref = rc.borrow_mut();
                 Box::pin(async move {
-                    delay_for(Duration::from_secs(1)).await;
+                    sleep(Duration::from_secs(1)).await;
                     drop(mutex_ref);
                 })
             })

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -52,7 +52,7 @@ tokio-native-tls = { version = "0.1", optional = true }
 tokio-rustls = { version = "0.14.1", optional = true }
 bytes = "0.5.6"
 Inflector = "0.11.4"
-tokio = { version = "0.2.24", features = ["time", "signal", "sync"] }
+tokio = { version = "~1.0", features = ["time", "signal", "sync"] }
 static_assertions = "1.1.0"
 kube-derive = { path = "../kube-derive", version = "^0.46.0", optional = true }
 jsonpath_lib = "0.2.5"
@@ -75,7 +75,7 @@ features = []
 
 [dev-dependencies]
 tempfile = "3.1.0"
-tokio = { version = "0.2.21", features = ["full"] }
+tokio = { version = "~1.0", features = ["full"] }
 schemars = "0.8.0"
 
 [dev-dependencies.k8s-openapi]

--- a/kube/src/runtime/informer.rs
+++ b/kube/src/runtime/informer.rs
@@ -104,8 +104,7 @@ where
             let mut needs_resync = self.needs_resync.lock().await;
             if *needs_resync {
                 // Try again in a bit
-                let dur = Duration::from_secs(10);
-                tokio::time::delay_for(dur).await;
+                tokio::time::sleep(Duration::from_secs(10)).await;
                 // If we are outside history, start over from latest
                 if *needs_resync {
                     self.reset().await;

--- a/kube/src/runtime/reflector.rs
+++ b/kube/src/runtime/reflector.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use futures::{future::FutureExt, lock::Mutex, pin_mut, select, TryStreamExt};
 use serde::de::DeserializeOwned;
-use tokio::{signal::ctrl_c, time::delay_for};
+use tokio::{signal::ctrl_c, time::sleep};
 
 #[cfg(not(target_family = "windows"))] use tokio::signal;
 
@@ -91,8 +91,7 @@ where
                     if let Err(e) = poll {
                         warn!("Poll error on {}: {}: {:?}", self.api.resource.kind, e, e);
                         // If desynched due to mismatching resourceVersion, retry in a bit
-                        let dur = Duration::from_secs(10);
-                        delay_for(dur).await;
+                        sleep(Duration::from_secs(10)).await;
                         self.reset().await?; // propagate error if this failed..
                     }
                 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -17,4 +17,4 @@ kube = { path = "../kube", version = "^0.46.0"}
 k8s-openapi = { version = "0.10.0", features = ["v1_19"], default-features = false }
 log = "0.4.11"
 serde_json = "1.0.55"
-tokio = { version = "0.2.21", features = ["full"] }
+tokio = { version = "~1.0", features = ["full"] }


### PR DESCRIPTION
Support for Tokio 1.0.

Some things were moved from `tokio` crate to `tokio-util` crate - in this project's case it's the `DelayQueue`. Enabled only the features necessary. See https://docs.rs/tokio-util/0.6.0/tokio_util/ .

Allowed myself to add .idea/ folder into gitignore :wink: .
