### PR TITLE
Follow up on WebSocket connection support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,8 @@ jobs:
       - run: cargo test -j4 -p examples
       - run: cd examples && cargo test --example crd_derive_no_schema --no-default-features --features=native-tls
       - run: cd kube && cargo test --lib --no-default-features --features=rustls-tls
+      - run: cd kube && cargo test --lib --no-default-features --features=native-tls,ws,ws-native-tls
+      - run: cd kube && cargo test --lib --no-default-features --features=rustls-tls,ws,ws-rustls-tls
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -57,7 +57,7 @@ tokio = { version = "1.0.1", features = ["time", "signal", "sync"] }
 static_assertions = "1.1.0"
 kube-derive = { path = "../kube-derive", version = "^0.46.0", optional = true }
 jsonpath_lib = "0.2.6"
-tokio-util = { version = "0.6.0", optional = true }
+tokio-util = { version = "0.6.0", optional = true, features = ["io"] }
 
 [dependencies.async-tungstenite]
 version = "0.11.0"

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -23,7 +23,7 @@ derive = ["kube-derive"]
 ws = ["async-tungstenite", "tokio-util"]
 # We can merge these with `native-tls`/`rustls-tls` when `dep?/feature` syntax becomes stable.
 # https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#weak-dependency-features
-ws-native-tls = ["real-native-tls", "tokio-native-tls", "async-tungstenite/tokio-native-tls"]
+ws-native-tls = ["tokio-native-tls", "async-tungstenite/tokio-native-tls"]
 ws-rustls-tls = ["tokio-rustls", "async-tungstenite/tokio-rustls"]
 
 [package.metadata.docs.rs]
@@ -47,7 +47,6 @@ futures = "0.3.8"
 pem = "0.8.2"
 openssl = { version = "0.10.32", optional = true }
 rustls = { version = "0.19.0", optional = true }
-real-native-tls = { version = "0.2.7", optional = true, package = "native-tls" }
 tokio-native-tls = { version = "0.3.0", optional = true }
 tokio-rustls = { version = "0.22.0", optional = true }
 bytes = "1.0.0"

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -28,6 +28,8 @@ ws-rustls-tls = ["tokio-rustls", "async-tungstenite/tokio-rustls"]
 
 [package.metadata.docs.rs]
 features = ["derive", "ws", "ws-native-tls"]
+# Define the configuration attribute `docsrs`. Used to enable `doc_cfg` feature.
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 base64 = "0.13.0"

--- a/kube/src/api/remote_command.rs
+++ b/kube/src/api/remote_command.rs
@@ -37,6 +37,7 @@ const MAX_BUF_SIZE: usize = 1024;
 /// [`attach`]: crate::Api::attach
 /// [`exec`]: crate::Api::exec
 /// [`Status`]: k8s_openapi::apimachinery::pkg::apis::meta::v1::Status
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 pub struct AttachedProcess {
     has_stdin: bool,
     has_stdout: bool,

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -219,6 +219,7 @@ where
 /// - One of `stdin`, `stdout`, or `stderr` must be `true`.
 /// - `stderr` and `tty` cannot both be `true` because multiplexing is not supported with TTY.
 #[cfg(feature = "ws")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 pub struct AttachParams {
     /// The name of the container to attach.
     /// Defaults to the only container if there is only one container in the pod.
@@ -375,6 +376,7 @@ impl AttachParams {
 }
 
 #[cfg(feature = "ws")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 impl Resource {
     /// Attach to a pod
     pub fn attach(&self, name: &str, ap: &AttachParams) -> Result<http::Request<()>> {
@@ -406,12 +408,15 @@ fn attach_path() {
 
 /// Marker trait for objects that has attach
 #[cfg(feature = "ws")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 pub trait AttachableObject {}
 
 #[cfg(feature = "ws")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 impl AttachableObject for k8s_openapi::api::core::v1::Pod {}
 
 #[cfg(feature = "ws")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 impl<K> Api<K>
 where
     K: Clone + DeserializeOwned + AttachableObject,
@@ -428,6 +433,7 @@ where
 // Exec subresource
 // ----------------------------------------------------------------------------
 #[cfg(feature = "ws")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 impl Resource {
     /// Execute command in a pod
     pub fn exec<I, T>(&self, name: &str, command: I, ap: &AttachParams) -> Result<http::Request<()>>
@@ -467,12 +473,15 @@ fn exec_path() {
 
 /// Marker trait for objects that has exec
 #[cfg(feature = "ws")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 pub trait ExecutingObject {}
 
 #[cfg(feature = "ws")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 impl ExecutingObject for k8s_openapi::api::core::v1::Pod {}
 
 #[cfg(feature = "ws")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 impl<K> Api<K>
 where
     K: Clone + DeserializeOwned + ExecutingObject,

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -130,35 +130,48 @@ impl Client {
         match connect_async_with_tls_connector(http::Request::from_parts(parts, ()), tls).await {
             Ok((stream, _)) => Ok(stream),
 
-            // tungstenite only gives us the status code.
-            Err(ws2::Error::Http(code)) => Err(Error::Api(ErrorResponse {
-                status: code.to_string(),
-                code: code.as_u16(),
-                message: "".to_owned(),
-                reason: "".to_owned(),
-            })),
+            Err(err) => match err {
+                // tungstenite only gives us the status code.
+                ws2::Error::Http(code) => Err(Error::Api(ErrorResponse {
+                    status: code.to_string(),
+                    code: code.as_u16(),
+                    message: "".to_owned(),
+                    reason: "".to_owned(),
+                })),
 
-            Err(ws2::Error::HttpFormat(err)) => Err(Error::HttpError(err)),
-            #[cfg(feature = "ws-native-tls")]
-            Err(ws2::Error::Tls(err)) => Err(Error::SslError(format!("{}", err))),
+                ws2::Error::HttpFormat(err) => Err(Error::HttpError(err)),
 
-            // URL errors:
-            // - No host found in URL
-            // - Unsupported scheme (not ws/wss)
-            // shouldn't happen in our case
-            Err(ws2::Error::Url(msg)) => Err(Error::RequestValidation(msg.into())),
+                // `tungstenite::Error::Tls` is only available when using `ws-native-tls` (`async-tungstenite/tokio-native-tls`)
+                // because it comes from `tungstenite/tls` feature.
+                #[cfg(feature = "ws-native-tls")]
+                ws2::Error::Tls(err) => Err(Error::SslError(format!("{}", err))),
 
-            // Protocol errors:
-            // - Only GET is supported
-            // - Only HTTP version >= 1.1 is supported
-            // shouldn't happen in our case
-            Err(ws2::Error::Protocol(msg)) => Err(Error::RequestValidation(msg.into())),
+                // URL errors:
+                // - No host found in URL
+                // - Unsupported scheme (not ws/wss)
+                // shouldn't happen in our case
+                ws2::Error::Url(msg) => Err(Error::RequestValidation(msg.into())),
 
-            // Fatal error with undelying connection.
-            Err(ws2::Error::Io(err)) => panic!("WebSocket connection error: {}", err),
+                // Protocol errors:
+                // - Only GET is supported
+                // - Only HTTP version >= 1.1 is supported
+                // shouldn't happen in our case
+                ws2::Error::Protocol(msg) => Err(Error::RequestValidation(msg.into())),
 
-            // Unknown error. `tungstenite::Error` includes those that only happens after connecting.
-            Err(err) => panic!("Unknown WebSocket error: {}", err),
+                // `tungstenite` docs says that `Error::Io` should probably be considered fatal.
+                // However, `async-tungstenite` seems to use it for some recoverable errors we don't want to panic.
+                // TODO Figure out how to extract those cases or fix upstream. See https://github.com/clux/kube-rs/issues/369
+                ws2::Error::Io(err) => panic!("WebSocket connection error: {}", err),
+
+                // Unexpected errors. `tungstenite::Error` contains errors that doesn't happen when trying to conect.
+                ws2::Error::ConnectionClosed
+                | ws2::Error::AlreadyClosed
+                | ws2::Error::Utf8
+                | ws2::Error::Capacity(_)
+                | ws2::Error::SendQueueFull(_) => {
+                    panic!("Unexpected {}", err);
+                }
+            },
         }
     }
 

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -105,6 +105,7 @@ impl Client {
 
     /// Make WebSocket connection.
     #[cfg(feature = "ws")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
     pub async fn connect(&self, request: http::Request<()>) -> Result<WebSocketStream<ConnectStream>> {
         let (mut parts, _) = request.into_parts();
         if let Some(auth_header) = self.config.get_auth_header().await? {

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -166,9 +166,7 @@ impl Client {
                 | ws2::Error::AlreadyClosed
                 | ws2::Error::Utf8
                 | ws2::Error::Capacity(_)
-                | ws2::Error::SendQueueFull(_) => {
-                    panic!("Unexpected {}", err);
-                }
+                | ws2::Error::SendQueueFull(_) => Err(Error::WsOther(err.to_string())),
             },
         }
     }

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -159,10 +159,7 @@ impl Client {
                 // shouldn't happen in our case
                 ws2::Error::Protocol(msg) => Err(Error::RequestValidation(msg.into())),
 
-                // `tungstenite` docs says that `Error::Io` should probably be considered fatal.
-                // However, `async-tungstenite` seems to use it for some recoverable errors we don't want to panic.
-                // TODO Figure out how to extract those cases or fix upstream. See https://github.com/clux/kube-rs/issues/369
-                ws2::Error::Io(err) => panic!("WebSocket connection error: {}", err),
+                ws2::Error::Io(err) => Err(Error::Connection(err)),
 
                 // Unexpected errors. `tungstenite::Error` contains errors that doesn't happen when trying to conect.
                 ws2::Error::ConnectionClosed

--- a/kube/src/client/ws.rs
+++ b/kube/src/client/ws.rs
@@ -40,8 +40,11 @@ mod tls {
 mod tls {
     use std::{convert::TryFrom, sync::Arc};
 
-    use tokio_rustls::rustls::{self, Certificate, ClientConfig};
     pub use tokio_rustls::TlsConnector as AsyncTlsConnector;
+    use tokio_rustls::{
+        rustls::{self, Certificate, ClientConfig},
+        webpki,
+    };
 
     use crate::{config::Config, Error, Result};
 
@@ -96,29 +99,27 @@ mod tls {
                 }
             }
 
-            // TODO Need rustls 0.17.0+. Need to update tokio first.
-            // if config.accept_invalid_certs {
-            //     client_config
-            //         .dangerous()
-            //         .set_certificate_verifier(Arc::new(NoCertificateVerification {}));
-            // }
+            if config.accept_invalid_certs {
+                client_config
+                    .dangerous()
+                    .set_certificate_verifier(Arc::new(NoCertificateVerification {}));
+            }
 
             Ok(AsyncTlsConnector::from(Arc::new(client_config)))
         }
     }
 
-    // TODO Need rustls 0.17.0+. Need to update tokio first.
-    // struct NoCertificateVerification {}
-    //
-    // impl rustls::ServerCertVerifier for NoCertificateVerification {
-    //     fn verify_server_cert(
-    //         &self,
-    //         _roots: &rustls::RootCertStore,
-    //         _presented_certs: &[rustls::Certificate],
-    //         _dns_name: webpki::DNSNameRef<'_>,
-    //         _ocsp: &[u8],
-    //     ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
-    //         Ok(rustls::ServerCertVerified::assertion())
-    //     }
-    // }
+    struct NoCertificateVerification {}
+
+    impl rustls::ServerCertVerifier for NoCertificateVerification {
+        fn verify_server_cert(
+            &self,
+            _roots: &rustls::RootCertStore,
+            _presented_certs: &[rustls::Certificate],
+            _dns_name: webpki::DNSNameRef<'_>,
+            _ocsp: &[u8],
+        ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
+            Ok(rustls::ServerCertVerified::assertion())
+        }
+    }
 }

--- a/kube/src/client/ws.rs
+++ b/kube/src/client/ws.rs
@@ -4,8 +4,7 @@ pub use tls::AsyncTlsConnector;
 mod tls {
     use std::convert::TryFrom;
 
-    // TODO Newer version of tokio_native_tls re-exports native_tls.
-    use real_native_tls::{Certificate, Identity, TlsConnector};
+    use tokio_native_tls::native_tls::{Certificate, Identity, TlsConnector};
     pub use tokio_native_tls::TlsConnector as AsyncTlsConnector;
 
     use crate::{config::Config, Error, Result};

--- a/kube/src/config/mod.rs
+++ b/kube/src/config/mod.rs
@@ -107,7 +107,7 @@ pub struct Config {
     pub(crate) identity: Option<(Vec<u8>, String)>,
     /// The authentication header from the credentials available in the kubeconfig. This supports
     /// exec plugins as well as specified in
-    /// https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
+    /// <https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins>
     pub(crate) auth_header: Authentication,
 }
 

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -19,6 +19,10 @@ pub enum Error {
     #[error("ApiError: {0} ({0:?})")]
     Api(#[source] ErrorResponse),
 
+    /// ConnectionError for when TcpStream fails to connect.
+    #[error("ConnectionError: {0}")]
+    Connection(std::io::Error),
+
     /// Reqwest error
     #[error("ReqwestError: {0}")]
     ReqwestError(#[from] reqwest::Error),

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -74,6 +74,11 @@ pub enum Error {
     #[cfg(feature = "native-tls")]
     #[error("OpensslError: {0}")]
     OpensslError(#[from] openssl::error::ErrorStack),
+
+    /// Unexpected error from making WebSocket connection.
+    #[cfg(feature = "ws")]
+    #[error("Unexpected WebSocket error: {0}")]
+    WsOther(String),
 }
 
 #[derive(Error, Debug)]

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! # Example
 //!
-//! The following example will create a [`Pod`][k8s_openapi::api::core::v1::Pod]
+//! The following example will create a [`Pod`](k8s_openapi::api::core::v1::Pod)
 //! and then watch for it to become available using a manual [`Api::watch`] call.
 //!
 //! ```rust,no_run

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -70,6 +70,7 @@
 //! }
 //! ```
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 
@@ -95,7 +96,9 @@ pub mod runtime;
 pub mod error;
 mod oauth2;
 
-#[cfg(feature = "derive")] pub use kube_derive::CustomResource;
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub use kube_derive::CustomResource;
 
 pub use api::{Api, DynamicResource, Resource};
 #[doc(inline)] pub use client::Client;

--- a/kube/src/runtime/informer.rs
+++ b/kube/src/runtime/informer.rs
@@ -21,7 +21,7 @@ use std::{sync::Arc, time::Duration};
 ///
 /// On boot, the initial watch causes added events for every currently live object.
 ///
-/// Because of https://github.com/clux/kube-rs/issues/219 we recommend you use this
+/// Because of <https://github.com/clux/kube-rs/issues/219> we recommend you use this
 /// with kubernetes >= 1.16 and watch bookmarks enabled.
 #[derive(Clone)]
 #[deprecated(note = "Replaced by kube_runtime::watcher", since = "0.38.0")]


### PR DESCRIPTION
- Use re-exported `native_tls`
- Support `config.accept_invalid_certs` with `ws-rustls-tls`
- Run `ws` tests on Circle CI (mostly to make sure it compiles on both TLS)
- Remove catch all panic from WS connect
- Use `doc_cfg` on docs.rs (closes #365)
    - To try: `cargo +nightly rustdoc --lib --features=derive,ws,ws-native-tls -- --cfg docsrs`
- Fix broken links in docs
- Avoid panicking on connection failure (closes #369)