### PR TITLE
better docs and links between for Api::watch and watcher

### DIFF
--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -187,8 +187,8 @@ async fn step<K: Meta + Clone + DeserializeOwned + Send + 'static>(
 /// of [returned resource versions](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes).
 /// It tries to recover (by reconnecting and resyncing as required) if polled again after an error.
 ///
-/// This is intended to provide a safe input interface for a state store like a [`reflector`],
-/// so if used directly, it's recommended to use it with with [`try_flatten_applied`]:
+/// This is intended to provide a safe and atomic input interface for a state store like a [`reflector`],
+/// direct users may want to flatten composite events with [`try_flatten_applied`]:
 ///
 /// ```no_run
 /// use kube::{api::{Api, ListParams, Meta}, Client};

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -183,7 +183,7 @@ async fn step<K: Meta + Clone + DeserializeOwned + Send + 'static>(
 
 /// Watches a Kubernetes Resource for changes continuously
 ///
-/// Creates an indefinite read stream through continual [`Api::watch`] calls, and keepint track
+/// Creates an indefinite read stream through continual [`Api::watch`] calls, and keeping track
 /// of [returned resource versions](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes).
 /// It tries to recover (by reconnecting and resyncing as required) if polled again after an error.
 ///

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -186,6 +186,8 @@ async fn step<K: Meta + Clone + DeserializeOwned + Send + 'static>(
 /// Creates an indefinite read stream through continual [`Api::watch`] calls, and keeping track
 /// of [returned resource versions](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes).
 /// It tries to recover (by reconnecting and resyncing as required) if polled again after an error.
+/// However, keep in mind that most terminal `TryStream` combinators (such as [`TryFutureExt::try_for_each`)
+/// and [`TryFutureExt::try_concat`] will terminate eagerly if an `Error` reaches them.
 ///
 /// This is intended to provide a safe and atomic input interface for a state store like a [`reflector`],
 /// direct users may want to flatten composite events with [`try_flatten_applied`]:

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -186,8 +186,8 @@ async fn step<K: Meta + Clone + DeserializeOwned + Send + 'static>(
 /// Creates an indefinite read stream through continual [`Api::watch`] calls, and keeping track
 /// of [returned resource versions](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes).
 /// It tries to recover (by reconnecting and resyncing as required) if polled again after an error.
-/// However, keep in mind that most terminal `TryStream` combinators (such as [`TryFutureExt::try_for_each`)
-/// and [`TryFutureExt::try_concat`] will terminate eagerly if an `Error` reaches them.
+/// However, keep in mind that most terminal `TryStream` combinators (such as `TryFutureExt::try_for_each`
+/// and `TryFutureExt::try_concat` will terminate eagerly if an `Error` reaches them.
 ///
 /// This is intended to provide a safe and atomic input interface for a state store like a [`reflector`],
 /// direct users may want to flatten composite events with [`try_flatten_applied`]:

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -293,6 +293,10 @@ where
     /// This returns a future that awaits the initial response,
     /// then you can stream the remaining buffered `WatchEvent` objects.
     ///
+    /// Note that a watch call __will terminate in <5 minutes__, based on [`ListParams::timeout`],
+    /// and as such, is best suited for __short term__ watches.
+    /// For continual tracking of resources, consider a managed [`watcher`].
+    ///
     /// ```no_run
     /// use kube::{api::{Api, ListParams, Meta, WatchEvent}, Client};
     /// use k8s_openapi::api::batch::v1::Job;
@@ -317,6 +321,8 @@ where
     ///     Ok(())
     /// }
     /// ```
+    /// [`ListParams::timeout`]: super::ListParams::timeout
+    /// [`watcher`]: https://docs.rs/kube_runtime/*/kube_runtime/watcher/fn.watcher.html
     pub async fn watch(
         &self,
         lp: &ListParams,

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -293,9 +293,11 @@ where
     /// This returns a future that awaits the initial response,
     /// then you can stream the remaining buffered `WatchEvent` objects.
     ///
-    /// Note that a watch call __will terminate in <5 minutes__, based on [`ListParams::timeout`],
-    /// and as such, is best suited for __short term__ watches.
-    /// For continual tracking of resources, consider a managed [`watcher`].
+    /// Note that a `watch` call can terminate for many reasons (even before the specified
+    /// [`ListParams::timeout`] is triggered), and will have to be re-issued
+    /// with the last seen resource version when or if it closes.
+    ///
+    /// Consider using a managed [`watcher`] to deal with automatic re-watches and error cases.
     ///
     /// ```no_run
     /// use kube::{api::{Api, ListParams, Meta, WatchEvent}, Client};


### PR DESCRIPTION
trying to make it clear that a straight `Api::watch` is not recommended for anything but <a few minute watch times