### PR TITLE
Make tls features additive

### DIFF
--- a/examples/configmap_reflector.rs
+++ b/examples/configmap_reflector.rs
@@ -1,10 +1,7 @@
 #[macro_use] extern crate log;
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::ConfigMap;
-use kube::{
-    api::{Api, ListParams, Meta},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, ListParams, Meta}};
 use kube_runtime::{reflector, reflector::Store, utils::try_flatten_applied, watcher};
 
 fn spawn_periodic_reader(reader: Store<ConfigMap>) {
@@ -22,7 +19,7 @@ fn spawn_periodic_reader(reader: Store<ConfigMap>) {
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let cms: Api<ConfigMap> = Api::namespaced(client, &namespace);

--- a/examples/configmap_watcher.rs
+++ b/examples/configmap_watcher.rs
@@ -1,17 +1,14 @@
 #[macro_use] extern crate log;
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::ConfigMap;
-use kube::{
-    api::{Api, ListParams},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, ListParams}};
 use kube_runtime::watcher;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let cms: Api<ConfigMap> = Api::namespaced(client, &namespace);

--- a/examples/configmapgen_controller.rs
+++ b/examples/configmapgen_controller.rs
@@ -5,10 +5,7 @@ use k8s_openapi::{
     api::core::v1::ConfigMap,
     apimachinery::pkg::apis::meta::v1::{ObjectMeta, OwnerReference},
 };
-use kube::{
-    api::{ListParams, Meta, PatchParams, PatchStrategy},
-    Api, Client, CustomResource,
-};
+use kube::{Api, Client, CustomResource, Tls, api::{ListParams, Meta, PatchParams, PatchStrategy}};
 use kube_runtime::controller::{Context, Controller, ReconcilerAction};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -114,7 +111,7 @@ struct Data {
 async fn main() -> Result<()> {
     std::env::set_var("RUST_LOG", "info,kube-runtime=debug,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
 
     let cmgs = Api::<ConfigMapGenerator>::all(client.clone());
     let cms = Api::<ConfigMap>::all(client.clone());

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -9,10 +9,7 @@ use tokio::time::sleep;
 use apiexts::CustomResourceDefinition;
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as apiexts;
 
-use kube::{
-    api::{Api, DeleteParams, ListParams, Meta, PatchParams, PostParams},
-    Client, CustomResource,
-};
+use kube::{Client, CustomResource, Tls, api::{Api, DeleteParams, ListParams, Meta, PatchParams, PostParams}};
 
 // Own custom resource
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
@@ -37,7 +34,7 @@ pub struct FooStatus {
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // Manage CRDs first

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -1,10 +1,7 @@
 use anyhow::{anyhow, Result};
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
-use kube::{
-    api::{Api, DeleteParams, ListParams, PostParams, Resource, WatchEvent},
-    Client, CustomResource,
-};
+use kube::{Client, CustomResource, Tls, api::{Api, DeleteParams, ListParams, PostParams, Resource, WatchEvent}};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -90,7 +87,7 @@ async fn main() -> Result<()> {
 
     // Creating CRD v1 works as expected.
     println!("Creating CRD v1");
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     delete_crd(client.clone()).await?;
     assert!(create_crd(client.clone()).await.is_ok());
 

--- a/examples/crd_reflector.rs
+++ b/examples/crd_reflector.rs
@@ -1,9 +1,6 @@
 #[macro_use] extern crate log;
 use futures::{StreamExt, TryStreamExt};
-use kube::{
-    api::{Api, ListParams, Meta},
-    Client, CustomResource,
-};
+use kube::{Client, CustomResource, Tls, api::{Api, ListParams, Meta}};
 use kube_runtime::{reflector, utils::try_flatten_applied, watcher};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -19,7 +16,7 @@ pub struct FooSpec {
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // This example requires `kubectl apply -f examples/foo.yaml` run first

--- a/examples/deployment_reflector.rs
+++ b/examples/deployment_reflector.rs
@@ -1,17 +1,14 @@
 #[macro_use] extern crate log;
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::apps::v1::Deployment;
-use kube::{
-    api::{Api, ListParams, Meta},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, ListParams, Meta}};
 use kube_runtime::{reflector, utils::try_flatten_applied, watcher};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
 
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 

--- a/examples/dynamic_api.rs
+++ b/examples/dynamic_api.rs
@@ -1,11 +1,11 @@
 #[macro_use] extern crate log;
-use kube::{api::DynamicResource, Client};
+use kube::{Client, Tls, api::DynamicResource};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
 
     let v = client.apiserver_version().await?;
     info!("api version: {:?}", v);

--- a/examples/event_watcher.rs
+++ b/examples/event_watcher.rs
@@ -1,17 +1,14 @@
 #[macro_use] extern crate log;
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Event;
-use kube::{
-    api::{Api, ListParams},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, ListParams}};
 use kube_runtime::{utils::try_flatten_applied, watcher};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
 
     let events: Api<Event> = Api::all(client);
     let lp = ListParams::default();

--- a/examples/job_api.rs
+++ b/examples/job_api.rs
@@ -3,16 +3,13 @@ use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::batch::v1::Job;
 use serde_json::json;
 
-use kube::{
-    api::{Api, DeleteParams, ListParams, Meta, PostParams, WatchEvent},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, DeleteParams, ListParams, Meta, PostParams, WatchEvent}};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // Create a Job

--- a/examples/log_stream.rs
+++ b/examples/log_stream.rs
@@ -2,17 +2,14 @@
 use anyhow::{anyhow, Result};
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Pod;
-use kube::{
-    api::{Api, LogParams},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, LogParams}};
 use std::env;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let mypod = env::args()

--- a/examples/multi_watcher.rs
+++ b/examples/multi_watcher.rs
@@ -4,17 +4,14 @@ use k8s_openapi::api::{
     apps::v1::Deployment,
     core::v1::{ConfigMap, Secret},
 };
-use kube::{
-    api::{Api, ListParams, Meta},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, ListParams, Meta}};
 use kube_runtime::{utils::try_flatten_applied, watcher};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,multi_watcher=debug,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let deploys: Api<Deployment> = Api::namespaced(client.clone(), &namespace);

--- a/examples/node_reflector.rs
+++ b/examples/node_reflector.rs
@@ -1,17 +1,14 @@
 #[macro_use] extern crate log;
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Node;
-use kube::{
-    api::{Api, ListParams, Meta},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, ListParams, Meta}};
 use kube_runtime::{reflector, utils::try_flatten_applied, watcher};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
 
     let nodes: Api<Node> = Api::all(client.clone());
     let lp = ListParams::default()

--- a/examples/node_watcher.rs
+++ b/examples/node_watcher.rs
@@ -1,17 +1,14 @@
 #[macro_use] extern crate log;
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::{Event, Node};
-use kube::{
-    api::{Api, ListParams, Meta},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, ListParams, Meta}};
 use kube_runtime::{utils::try_flatten_applied, watcher};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,node_watcher=debug,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let events: Api<Event> = Api::all(client.clone());
     let nodes: Api<Node> = Api::all(client.clone());
 

--- a/examples/pod_api.rs
+++ b/examples/pod_api.rs
@@ -3,16 +3,13 @@ use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Pod;
 use serde_json::json;
 
-use kube::{
-    api::{Api, DeleteParams, ListParams, Meta, PatchParams, PostParams, WatchEvent},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, DeleteParams, ListParams, Meta, PatchParams, PostParams, WatchEvent}};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     // Manage pods

--- a/examples/pod_attach.rs
+++ b/examples/pod_attach.rs
@@ -5,16 +5,13 @@ use std::io::Write;
 use futures::{join, stream, StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Pod;
 
-use kube::{
-    api::{Api, AttachParams, AttachedProcess, DeleteParams, ListParams, Meta, PostParams, WatchEvent},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, AttachParams, AttachedProcess, DeleteParams, ListParams, Meta, PostParams, WatchEvent}};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or_else(|_| "default".into());
 
     info!("Creating a Pod that outputs numbers for 15s");

--- a/examples/pod_exec.rs
+++ b/examples/pod_exec.rs
@@ -3,17 +3,14 @@
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Pod;
 
-use kube::{
-    api::{Api, AttachParams, AttachedProcess, DeleteParams, ListParams, Meta, PostParams, WatchEvent},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, AttachParams, AttachedProcess, DeleteParams, ListParams, Meta, PostParams, WatchEvent}};
 use tokio::io::AsyncWriteExt;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or_else(|_| "default".into());
 
     let p: Pod = serde_json::from_value(serde_json::json!({

--- a/examples/pod_reflector.rs
+++ b/examples/pod_reflector.rs
@@ -1,12 +1,12 @@
 use color_eyre::Result;
 use futures::prelude::*;
 use k8s_openapi::api::core::v1::Pod;
-use kube::{api::ListParams, Api, Client, Config};
+use kube::{Api, Client, Config, Tls, api::ListParams};
 use kube_runtime::{reflector, watcher};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let config = Config::infer().await?;
+    let config = Config::infer(Tls::pick()).await?;
     let client = Client::new(config);
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 

--- a/examples/pod_shell.rs
+++ b/examples/pod_shell.rs
@@ -3,16 +3,13 @@
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Pod;
 
-use kube::{
-    api::{Api, AttachParams, DeleteParams, ListParams, Meta, PostParams, WatchEvent},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, AttachParams, DeleteParams, ListParams, Meta, PostParams, WatchEvent}};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or_else(|_| "default".into());
 
     let p: Pod = serde_json::from_value(serde_json::json!({

--- a/examples/pod_watcher.rs
+++ b/examples/pod_watcher.rs
@@ -1,17 +1,14 @@
 use color_eyre::Result;
 use futures::prelude::*;
 use k8s_openapi::api::core::v1::Pod;
-use kube::{
-    api::{ListParams, Meta},
-    Api, Client,
-};
+use kube::{Api, Client, Tls, api::{ListParams, Meta}};
 use kube_runtime::{utils::try_flatten_applied, watcher};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
     let api = Api::<Pod>::namespaced(client, &namespace);
     let watcher = watcher(api, ListParams::default());

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -1,18 +1,14 @@
 #[macro_use] extern crate log;
 use k8s_openapi::api::core::v1::Namespace;
 
-use kube::{
-    api::{Api, ListParams},
-    config::KubeConfigOptions,
-    Client, Config,
-};
+use kube::{Client, Config, Tls, api::{Api, ListParams}, config::KubeConfigOptions};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
 
-    let mut config = Config::from_kubeconfig(&KubeConfigOptions::default()).await?;
+    let mut config = Config::from_kubeconfig(&KubeConfigOptions::default(), Tls::pick()).await?;
 
     if let Ok(proxy_url) = &std::env::var("PROXY_URL") {
         info!("PROXY_URL is {}", proxy_url);

--- a/examples/secret_reflector.rs
+++ b/examples/secret_reflector.rs
@@ -1,10 +1,7 @@
 #[macro_use] extern crate log;
 use futures::TryStreamExt;
 use k8s_openapi::api::core::v1::Secret;
-use kube::{
-    api::{Api, ListParams, Meta},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, ListParams, Meta}};
 use kube_runtime::{reflector, reflector::Store, utils::try_flatten_applied, watcher};
 use std::collections::BTreeMap;
 
@@ -51,7 +48,7 @@ fn spawn_periodic_reader(reader: Store<Secret>) {
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let secrets: Api<Secret> = Api::namespaced(client, &namespace);

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -54,7 +54,7 @@ tokio-rustls = { version = "0.22.0", optional = true }
 bytes = "1.0.0"
 Inflector = "0.11.4"
 tokio = { version = "1.0.1", features = ["time", "signal", "sync"] }
-static_assertions = "1.1.0"
+# static_assertions = "1.1.0"
 kube-derive = { path = "../kube-derive", version = "^0.47.0", optional = true }
 jsonpath_lib = "0.2.6"
 tokio-util = { version = "0.6.0", optional = true, features = ["io"] }

--- a/kube/src/api/dynamic.rs
+++ b/kube/src/api/dynamic.rs
@@ -190,10 +190,7 @@ impl TryFrom<DynamicResource> for Resource {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        api::{PatchParams, PostParams, Resource},
-        Result,
-    };
+    use crate::{Result, Tls, api::{PatchParams, PostParams, Resource}};
     #[test]
     fn raw_custom_resource() {
         let r = Resource::dynamic("Foo")
@@ -235,7 +232,7 @@ mod test {
         struct FooSpec {
             foo: String,
         };
-        let client = Client::try_default().await.unwrap();
+        let client = Client::try_default(Tls::pick()).await.unwrap();
         let a1: Api<Foo> = Api::namespaced(client.clone(), "myns");
 
         let a2: Api<Foo> = Resource::dynamic("Foo")

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -6,12 +6,7 @@
 //! the [`Api`][crate::api::Api] type for more structured
 //! interaction with the kuberneres API.
 
-use crate::{
-    api::{Meta, WatchEvent},
-    config::Config,
-    error::ErrorResponse,
-    Error, Result,
-};
+use crate::{Error, Result, Tls, api::{Meta, WatchEvent}, config::Config, error::ErrorResponse};
 
 #[cfg(feature = "ws")] mod ws;
 #[cfg(feature = "ws")] use ws::AsyncTlsConnector;
@@ -72,8 +67,8 @@ impl Client {
     ///
     /// If you already have a [`Config`] then use [`Client::try_from`](Self::try_from)
     /// instead
-    pub async fn try_default() -> Result<Self> {
-        let client_config = Config::infer().await?;
+    pub async fn try_default(tls: Tls) -> Result<Self> {
+        let client_config = Config::infer(tls).await?;
         Self::try_from(client_config)
     }
 

--- a/kube/src/client/ws.rs
+++ b/kube/src/client/ws.rs
@@ -37,7 +37,7 @@ mod tls {
 }
 
 #[cfg(feature = "ws-rustls-tls")]
-mod tls {
+mod tls_rustls {
     use std::{convert::TryFrom, sync::Arc};
 
     pub use tokio_rustls::TlsConnector as AsyncTlsConnector;

--- a/kube/src/config/file_loader.rs
+++ b/kube/src/config/file_loader.rs
@@ -1,14 +1,8 @@
-#[cfg(feature = "native-tls")]
-use openssl::{pkcs12::Pkcs12, pkey::PKey, x509::X509};
-use reqwest::Identity;
-
 use super::{
     file_config::{AuthInfo, Cluster, Context, Kubeconfig},
     utils, Der,
 };
-use crate::{error::ConfigError, Result};
-
-#[cfg(feature = "rustls-tls")] use crate::Error;
+use crate::{error::ConfigError, tls::Tls, Result};
 
 /// KubeConfigOptions stores options used when loading kubeconfig file.
 #[derive(Default, Clone)]
@@ -28,11 +22,12 @@ pub struct ConfigLoader {
     pub current_context: Context,
     pub cluster: Cluster,
     pub user: AuthInfo,
+    tls: Tls,
 }
 
 impl ConfigLoader {
     /// Returns a config loader based on the cluster information from the kubeconfig file.
-    pub async fn new_from_options(options: &KubeConfigOptions) -> Result<Self> {
+    pub async fn new_from_options(options: &KubeConfigOptions, tls: Tls) -> Result<Self> {
         let kubeconfig_path = utils::find_kubeconfig()
             .map_err(Box::new)
             .map_err(ConfigError::LoadConfigFile)?;
@@ -43,18 +38,24 @@ impl ConfigLoader {
             options.context.as_ref(),
             options.cluster.as_ref(),
             options.user.as_ref(),
+            tls,
         )
         .await?;
 
         Ok(loader)
     }
 
-    pub async fn new_from_kubeconfig(config: Kubeconfig, options: &KubeConfigOptions) -> Result<Self> {
+    pub async fn new_from_kubeconfig(
+        config: Kubeconfig,
+        options: &KubeConfigOptions,
+        tls: Tls,
+    ) -> Result<Self> {
         let loader = Self::load(
             config,
             options.context.as_ref(),
             options.cluster.as_ref(),
             options.user.as_ref(),
+            tls,
         )
         .await?;
 
@@ -66,6 +67,7 @@ impl ConfigLoader {
         context: Option<&String>,
         cluster: Option<&String>,
         user: Option<&String>,
+        tls: Tls,
     ) -> Result<Self> {
         let context_name = context.unwrap_or(&config.current_context);
         let current_context = config
@@ -91,7 +93,7 @@ impl ConfigLoader {
         for named_user in config.auth_infos {
             if &named_user.name == user_name {
                 let mut user = named_user.auth_info.clone();
-                user.load_gcp().await?;
+                user.load_gcp(tls).await?;
                 user_opt = Some(user);
             }
         }
@@ -102,68 +104,20 @@ impl ConfigLoader {
             current_context: current_context.clone(),
             cluster: cluster.clone(),
             user,
+            tls,
         })
     }
 
-    #[cfg(feature = "native-tls")]
+    pub fn ca_bundle(&self) -> Result<Option<Vec<Der>>> {
+        match self.cluster.load_certificate_authority()? {
+            Some(ca) => self.tls.ca_bundle(&ca).map(Some),
+            None => Ok(None),
+        }
+    }
+
     pub fn identity(&self, password: &str) -> Result<Vec<u8>> {
-        let client_cert = &self.user.load_client_certificate()?;
-        let client_key = &self.user.load_client_key()?;
-
-        let x509 = X509::from_pem(&client_cert)?;
-        let pkey = PKey::private_key_from_pem(&client_key)?;
-
-        let p12 = Pkcs12::builder().build(password, "kubeconfig", &pkey, &x509)?;
-
-        let der = p12.to_der()?;
-        // Make sure the buffer can be parsed properly but throw away the result
-        let _identity = Identity::from_pkcs12_der(&der, password)?;
-        Ok(der)
-    }
-
-    #[cfg(feature = "rustls-tls")]
-    pub fn identity(&self, _password: &str) -> Result<Vec<u8>> {
-        let client_cert = &self.user.load_client_certificate()?;
-        let client_key = &self.user.load_client_key()?;
-
-        let mut buffer = client_key.clone();
-        buffer.extend_from_slice(client_cert);
-        // Make sure the buffer can be parsed properly but throw away the result
-        let _identity = Identity::from_pem(&buffer.as_slice())?;
-        Ok(buffer)
-    }
-
-    #[cfg(feature = "native-tls")]
-    pub fn ca_bundle(&self) -> Result<Option<Vec<Der>>> {
-        let bundle = self.cluster.load_certificate_authority()?;
-
-        if let Some(bundle) = bundle {
-            let bundle = X509::stack_from_pem(&bundle)?;
-
-            let mut stack = vec![];
-            for ca in bundle {
-                let der = ca.to_der()?;
-                stack.push(Der(der))
-            }
-            return Ok(Some(stack));
-        }
-        Ok(None)
-    }
-
-    #[cfg(feature = "rustls-tls")]
-    pub fn ca_bundle(&self) -> Result<Option<Vec<Der>>> {
-        use rustls::internal::pemfile;
-        use std::io::Cursor;
-        if let Some(bundle) = self.cluster.load_certificate_authority()? {
-            let mut pem = Cursor::new(bundle);
-            pem.set_position(0);
-
-            let mut stack = vec![];
-            for ca in pemfile::certs(&mut pem).map_err(|e| Error::SslError(format!("{:?}", e)))? {
-                stack.push(Der(ca.0))
-            }
-            return Ok(Some(stack));
-        }
-        Ok(None)
+        let client_cert = self.user.load_client_certificate()?;
+        let client_key = self.user.load_client_key()?;
+        self.tls.identity(password, &client_cert, &client_key)
     }
 }

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -74,14 +74,7 @@
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 
-#[macro_use] extern crate static_assertions;
-assert_cfg!(
-    all(
-        not(all(feature = "native-tls", feature = "rustls-tls")),
-        any(feature = "native-tls", feature = "rustls-tls")
-    ),
-    "Must use exactly one of native-tls or rustls-tls features"
-);
+// #[macro_use] extern crate static_assertions;
 
 #[macro_use] extern crate log;
 
@@ -95,6 +88,9 @@ pub mod runtime;
 
 pub mod error;
 mod oauth2;
+mod tls;
+
+pub use tls::Tls;
 
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]

--- a/kube/src/tls.rs
+++ b/kube/src/tls.rs
@@ -1,0 +1,78 @@
+use crate::config::Der;
+use crate::Result;
+
+#[cfg(feature = "native-tls")]
+mod native_impl;
+mod rustls_impl;
+/// Abstraction layer for TLS implementations
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub enum Tls {
+    /// Use `rustls`
+    #[cfg(feature = "native-tls")]
+    Native,
+    /// Use `openssl`
+    #[cfg(feature = "rustls-tls")]
+    Rustls,
+}
+
+impl Tls {
+    /// Creates a TLS backend.
+    /// This function only works when exactly one backend
+    /// was configured, otherwise it will panic. This function
+    /// is only intended to use in tests.
+    #[allow(unreachable_code)]
+    pub fn pick() -> Tls {
+        let mut backend_count = 0;
+        if cfg!(feature = "native-tls") {
+            backend_count += 1;
+        }
+        if cfg!(feature = "rustls-tls") {
+            backend_count += 1;
+        }
+        assert_eq!(backend_count, 1);
+        #[cfg(feature = "native-tls")]
+        return Tls::Native;
+        #[cfg(feature = "rustls-tls")]
+        return Tls::Rustls;
+        unreachable!()
+    }
+
+    pub(crate) fn ca_bundle(&self, bundle: &[u8]) -> Result<Vec<Der>> {
+        match self {
+            #[cfg(feature = "native-tls")]
+            Tls::Native => native_impl::ca_bundle(bundle),
+            #[cfg(feature = "rustls-tls")]
+            Tls::Rustls => rustls_impl::ca_bundle(bundle),
+        }
+    }
+
+    pub(crate) fn identity(&self, password: &str, client_cert: &[u8], client_key: &[u8]) -> Result<Vec<u8>> {
+        match self {
+            #[cfg(feature = "native-tls")]
+            Tls::Native => native_impl::identity(password, client_cert, client_key),
+            #[cfg(feature = "rustls-tls")]
+            Tls::Rustls => rustls_impl::identity(password, client_cert, client_key),
+        }
+    }
+
+    pub(crate) fn sign(&self, signature_base: &str, private_key: &str) -> Result<Vec<u8>> {
+        match self {
+            #[cfg(feature = "native-tls")]
+            Tls::Native => native_impl::sign(signature_base, private_key),
+            #[cfg(feature = "rustls-tls")]
+            Tls::Rustls => rustls_impl::sign(signature_base, private_key),
+        }
+    }
+
+    pub(crate) fn reqwest(&self) -> reqwest::Client {
+        let mut builder = reqwest::Client::builder();
+        builder = match self {
+            #[cfg(feature = "native-tls")]
+            Tls::Native => builder.use_native_tls(),
+            #[cfg(feature = "rustls-tls")]
+            Tls::Rustls => builder.use_rustls_tls(),
+        };
+        builder.build().expect("reqwest initialization error")
+    }
+}

--- a/kube/src/tls/native_impl.rs
+++ b/kube/src/tls/native_impl.rs
@@ -1,0 +1,35 @@
+use openssl::{hash::MessageDigest, pkcs12::Pkcs12, pkey::PKey, rsa::Padding, sign::Signer, x509::X509};
+use reqwest::Identity;
+
+use crate::{config::Der, Result};
+
+pub fn identity(password: &str, client_cert: &[u8], client_key: &[u8]) -> Result<Vec<u8>> {
+    let x509 = X509::from_pem(&client_cert)?;
+    let pkey = PKey::private_key_from_pem(&client_key)?;
+
+    let p12 = Pkcs12::builder().build(password, "kubeconfig", &pkey, &x509)?;
+
+    let der = p12.to_der()?;
+    // Make sure the buffer can be parsed properly but throw away the result
+    let _identity = Identity::from_pkcs12_der(&der, password)?;
+    Ok(der)
+}
+
+pub fn ca_bundle(bundle: &[u8]) -> Result<Vec<Der>> {
+    let bundle = X509::stack_from_pem(&bundle)?;
+
+    let mut stack = vec![];
+    for ca in bundle {
+        let der = ca.to_der()?;
+        stack.push(Der(der))
+    }
+    return Ok(stack);
+}
+
+pub fn sign(signature_base: &str, private_key: &str) -> Result<Vec<u8>> {
+    let key = PKey::private_key_from_pem(private_key.as_bytes())?;
+    let mut signer = Signer::new(MessageDigest::sha256(), &key)?;
+    signer.set_rsa_padding(Padding::PKCS1)?;
+    signer.update(signature_base.as_bytes())?;
+    Ok(signer.sign_to_vec()?)
+}

--- a/kube/src/tls/rustls_impl.rs
+++ b/kube/src/tls/rustls_impl.rs
@@ -1,0 +1,42 @@
+use crate::{config::Der, Error, Result};
+use reqwest::Identity;
+use rustls::{
+    internal::pemfile,
+    sign::{RSASigningKey, SigningKey},
+};
+use std::io::Cursor;
+
+pub fn sign(signature_base: &str, private_key: &str) -> Result<Vec<u8>> {
+    let keys = pemfile::pkcs8_private_keys(&mut private_key.as_bytes())
+        .map_err(|_| Error::SslError("fail to parse private key".into()))?;
+    let key = keys
+        .get(0)
+        .ok_or_else(|| Error::SslError("no usable private key found to sign with RS256".into()))?;
+    let signing_key =
+        RSASigningKey::new(key).map_err(|_| Error::SslError("fail to make RSA signing key".into()))?;
+    let signer = signing_key
+        .choose_scheme(&[rustls::SignatureScheme::RSA_PKCS1_SHA256])
+        .ok_or_else(|| Error::SslError("scheme RSA_PKCS1_SHA256 not found into private key".into()))?;
+    signer
+        .sign(signature_base.as_bytes())
+        .map_err(|e| Error::SslError(format!("{}", e)))
+}
+
+pub fn ca_bundle(bundle: &[u8]) -> Result<Vec<Der>> {
+    let mut pem = Cursor::new(bundle);
+    pem.set_position(0);
+
+    let mut stack = vec![];
+    for ca in pemfile::certs(&mut pem).map_err(|e| Error::SslError(format!("{:?}", e)))? {
+        stack.push(Der(ca.0))
+    }
+    return Ok(stack);
+}
+
+pub fn identity(_password: &str, client_cert: &[u8], client_key: &[u8]) -> Result<Vec<u8>> {
+    let mut buffer = client_key.to_vec();
+    buffer.extend_from_slice(client_cert);
+    // Make sure the buffer can be parsed properly but throw away the result
+    let _identity = Identity::from_pem(&buffer.as_slice())?;
+    Ok(buffer)
+}

--- a/tests/dapp.rs
+++ b/tests/dapp.rs
@@ -3,16 +3,13 @@ use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::batch::v1::Job;
 use serde_json::json;
 
-use kube::{
-    api::{Api, DeleteParams, ListParams, Meta, PostParams, WatchEvent},
-    Client,
-};
+use kube::{Client, Tls, api::{Api, DeleteParams, ListParams, Meta, PostParams, WatchEvent}};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "info,kube=debug");
     env_logger::init();
-    let client = Client::try_default().await?;
+    let client = Client::try_default(Tls::pick()).await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or_else(|_| "default".into());
 
     // Create a Job


### PR DESCRIPTION
Changes: create an enum with available TLS backends. Library user explicitly chooses it and passes it to kube.

Draft: I haven't updated reqwest & websocket creation code yet.