### PR TITLE
bump k8s-openapi to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 0.48.0 / 2021-01-XX
 ===================
+  * bump `k8s-openapi` to `0.11.0` - #388
   * breaking: `kube`: no longer necessary to serialize patches yourself - #386
     - `PatchParams` removes `PatchStrategy`
     - `Api::patch*` methods now take an enum `Patch` type

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Select a version of `kube` along with the generated [k8s-openapi](https://github
 [dependencies]
 kube = "0.47.0"
 kube-runtime = "0.47.0"
-k8s-openapi = { version = "0.9.0", default-features = false, features = ["v1_17"] }
+k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_20"] }
 ```
 
 [Features are available](https://github.com/clux/kube-rs/blob/master/kube/Cargo.toml#L18).
@@ -151,7 +151,7 @@ Kube has basic support ([with caveats](https://github.com/clux/kube-rs/issues?q=
 [dependencies]
 kube = { version = "0.47.0", default-features = false, features = ["rustls-tls"] }
 kube-runtime = { version = "0.47.0", default-features = false, features = ["rustls-tls"] }
-k8s-openapi = { version = "0.9.0", default-features = false, features = ["v1_17"] }
+k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_20"] }
 ```
 
 This will pull in the variant of `reqwest` that also uses its `rustls-tls` feature.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3.8"
 kube = { path = "../kube", version = "^0.47.0", default-features = false }
 kube-derive = { path = "../kube-derive", version = "^0.47.0", default-features = false } # only needed to opt out of schema
 kube-runtime = { path = "../kube-runtime", version = "^0.47.0", default-features = false }
-k8s-openapi = { version = "0.10.0", features = ["v1_19"], default-features = false }
+k8s-openapi = { version = "0.11.0", features = ["v1_19"], default-features = false }
 log = "0.4.11"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.61"

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -28,6 +28,6 @@ schema = []
 [dev-dependencies]
 serde = { version = "1.0.118", features = ["derive"] }
 serde_yaml = "0.8.14"
-k8s-openapi = { version = "0.10.0", default-features = false, features = ["v1_19"] }
+k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_19"] }
 schemars = { version = "0.8.0", features = ["chrono"] }
 chrono = "0.4.19"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -25,7 +25,7 @@ dashmap = "4.0.1"
 tokio-util = { version = "0.6.0", features = ["time"] }
 
 [dependencies.k8s-openapi]
-version = "0.10.0"
+version = "0.11.0"
 default-features = false
 
 [features]
@@ -41,6 +41,6 @@ rand = "0.8.0"
 schemars = "0.8.0"
 
 [dev-dependencies.k8s-openapi]
-version = "0.10.0"
+version = "0.11.0"
 default-features = false
 features = ["v1_19"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -73,7 +73,7 @@ default-features = false
 features = ["json", "gzip", "stream"]
 
 [dependencies.k8s-openapi]
-version = "0.10.0"
+version = "0.11.0"
 default-features = false
 features = []
 
@@ -83,6 +83,6 @@ tokio = { version = "1.0.1", features = ["full"] }
 schemars = "0.8.0"
 
 [dev-dependencies.k8s-openapi]
-version = "0.10.0"
+version = "0.11.0"
 default-features = false
 features = ["v1_19"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.37"
 env_logger = "0.8.2"
 futures = "0.3.8"
 kube = { path = "../kube", version = "^0.47.0"}
-k8s-openapi = { version = "0.10.0", features = ["v1_19"], default-features = false }
+k8s-openapi = { version = "0.11.0", features = ["v1_19"], default-features = false }
 log = "0.4.11"
 serde_json = "1.0.61"
 tokio = { version = "1.0.1", features = ["full"] }


### PR DESCRIPTION
from the [changelog](https://github.com/Arnavion/k8s-openapi/blob/master/CHANGELOG.md)

- `k8s_openapi::WatchEvent` has less type constraints (but we implement our own)
- `bytes` bump
- support for kubernetes 1.20