### PR TITLE
Make gzip opt-in

### DIFF
--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -23,6 +23,7 @@ derive = ["kube-derive"]
 jsonpatch = ["json-patch"]
 ws = ["tokio-tungstenite"]
 oauth = ["tame-oauth"]
+gzip = ["async-compression"]
 
 [package.metadata.docs.rs]
 features = ["derive", "ws"]
@@ -62,7 +63,7 @@ hyper-tls = { version = "0.5.0", optional = true }
 hyper-rustls = { version = "0.22.1", optional = true }
 tokio-tungstenite = { version = "0.13.0", optional = true }
 tower = { version = "0.4.4", features = ["buffer", "util"] }
-async-compression = { version = "0.3.7", features = ["gzip", "tokio"] }
+async-compression = { version = "0.3.7", features = ["gzip", "tokio"], optional = true }
 hyper-timeout = "0.4.1"
 tame-oauth = { version = "0.4.7", features = ["gcp"], optional = true }
 pin-project = "1.0.4"


### PR DESCRIPTION
Make `gzip` opt-in for now because Kubernetes doesn't have it enabled by default yet and requires more dependencies.
It's behind `APIResponseCompression` feature gate which is in `Beta` since 1.16.
See <https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/>.

Also, I haven't tested this with compressed response at all.