### PR TITLE
Change `Client::new` to take `Service`

### DIFF
--- a/examples/pod_reflector.rs
+++ b/examples/pod_reflector.rs
@@ -1,13 +1,12 @@
 use color_eyre::Result;
 use futures::prelude::*;
 use k8s_openapi::api::core::v1::Pod;
-use kube::{api::ListParams, Api, Client, Config};
+use kube::{api::ListParams, Api, Client};
 use kube_runtime::{reflector, watcher};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let config = Config::infer().await?;
-    let client = Client::new(config);
+    let client = Client::try_default().await?;
     let namespace = std::env::var("NAMESPACE").unwrap_or("default".into());
 
     let api: Api<Pod> = Api::namespaced(client, &namespace);

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -38,24 +38,16 @@ use std::convert::{TryFrom, TryInto};
 /// The best way to instantiate the client is either by
 /// inferring the configuration from the environment using
 /// [`Client::try_default`] or with an existing [`Config`]
-/// using [`Client::new`]
+/// using [`Client::try_from`].
 #[derive(Clone)]
 pub struct Client {
     inner: Service,
 }
 
 impl Client {
-    // TODO Change this to take `Service` instead after figuring out `auth_header`.
-    /// Create and initialize a [`Client`] using the given
-    /// configuration.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the configuration supplied leads to an invalid TlsConnector.
-    /// If you want to handle this error case use [`Config::try_from`](Self::try_from)
-    /// (note that this requires [`std::convert::TryFrom`] to be in scope.)
-    pub fn new(config: Config) -> Self {
-        Self::try_from(config).expect("Could not create a client from the supplied config")
+    /// Create and initialize a [`Client`] using the given `Service`.
+    pub fn new(service: Service) -> Self {
+        Self { inner: service }
     }
 
     /// Create and initialize a [`Client`] using the inferred
@@ -359,8 +351,7 @@ impl TryFrom<Config> for Client {
 
     /// Convert [`Config`] into a [`Client`]
     fn try_from(config: Config) -> Result<Self> {
-        let inner = config.try_into()?;
-        Ok(Self { inner })
+        Ok(Self::new(config.try_into()?))
     }
 }
 


### PR DESCRIPTION
Allows users to use custom service when they need something not supported out of the box. This also makes it easier to test.

~~I'll update the changelog after #399.~~ Opened a separate PR for the changelog (#402).