### PR TITLE
Add stacked `KUBECONFIG` support

### DIFF
--- a/kube/src/config/incluster_config.rs
+++ b/kube/src/config/incluster_config.rs
@@ -25,18 +25,17 @@ fn kube_port() -> Option<String> {
 
 /// Returns token from specified path in cluster.
 pub fn load_token() -> Result<String> {
-    utils::data_or_file(&None, &Some(SERVICE_TOKENFILE))
+    utils::read_file_to_string(SERVICE_TOKENFILE)
 }
 
 /// Returns certification from specified path in cluster.
 pub fn load_cert() -> Result<Vec<Vec<u8>>> {
-    let ca = utils::data_or_file_with_base64(&None, &Some(SERVICE_CERTFILE))?;
-    Ok(utils::certs(&ca))
+    Ok(utils::certs(&utils::read_file(SERVICE_CERTFILE)?))
 }
 
 /// Returns the default namespace from specified path in cluster.
 pub fn load_default_ns() -> Result<String> {
-    utils::data_or_file(&None, &Some(SERVICE_DEFAULT_NS))
+    utils::read_file_to_string(SERVICE_DEFAULT_NS)
 }
 
 #[test]

--- a/kube/src/config/mod.rs
+++ b/kube/src/config/mod.rs
@@ -12,7 +12,7 @@ mod utils;
 use crate::{error::ConfigError, Result};
 use file_loader::ConfigLoader;
 pub use file_loader::KubeConfigOptions;
-pub(crate) use utils::data_or_file;
+pub(crate) use utils::read_file_to_string;
 
 use http::header::HeaderMap;
 

--- a/kube/src/config/utils.rs
+++ b/kube/src/config/utils.rs
@@ -35,14 +35,6 @@ pub fn data_or_file_with_base64<P: AsRef<Path>>(data: &Option<String>, file: &Op
     }
 }
 
-pub fn data_or_file<P: AsRef<Path>>(data: &Option<String>, file: &Option<P>) -> Result<String> {
-    match (data, file) {
-        (Some(d), _) => Ok(d.to_string()),
-        (_, Some(f)) => read_file_to_string(f),
-        _ => Err(ConfigError::NoFileOrData.into()),
-    }
-}
-
 pub fn read_file<P: AsRef<Path>>(file: P) -> Result<Vec<u8>> {
     let f = file.as_ref();
     let abs_file = if f.is_absolute() {
@@ -91,30 +83,11 @@ pub fn certs(data: &[u8]) -> Vec<Vec<u8>> {
 mod tests {
     extern crate tempfile;
     use super::*;
-    use crate::config::utils;
-    use std::io::Write;
 
     #[test]
     fn test_kubeconfig_path() {
         let expect_str = "/fake/.kube/config";
         env::set_var(KUBECONFIG, expect_str);
         assert_eq!(PathBuf::from(expect_str), kubeconfig_path().unwrap());
-    }
-
-    #[test]
-    fn test_data_or_file() {
-        let data = "fake_data";
-        let file = "fake_file";
-        let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "{}", file).unwrap();
-
-        let actual = utils::data_or_file(&Some(data.to_string()), &Some(tmpfile.path()));
-        assert_eq!(actual.ok().unwrap(), data.to_string());
-
-        let actual = utils::data_or_file(&None, &Some(tmpfile.path()));
-        assert_eq!(actual.ok().unwrap(), file.to_string());
-
-        let actual = utils::data_or_file(&None, &None::<String>);
-        assert!(actual.is_err());
     }
 }

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -120,6 +120,14 @@ pub enum ConfigError {
         kubeconfig: Box<Error>,
     },
 
+    #[error("Failed to determine current context")]
+    CurrentContextNotSet,
+
+    #[error("Merging kubeconfig with mismatching kind")]
+    KindMismatch,
+    #[error("Merging kubeconfig with mismatching apiVersion")]
+    ApiVersionMismatch,
+
     #[error("Unable to load in cluster config, {hostenv} and {portenv} must be defined")]
     /// One or more required in-cluster config options are missing
     MissingInClusterVariables {


### PR DESCRIPTION
- Cleaned up `config::util`
- `current_context` in `KubeConfig` is now `Option<String>`
- File paths in `Kubeconfig` are now remapped to absolute path after reading to support relative paths in stacked config. Assumes paths are unicode (should be fine because Go doesn't have OsString concept).
- Kubeconfigs are fully merged according to <https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#merging-kubeconfig-files> even if `kube` only needs `current_context`, `contexts`, `clusters`, and `auth_infos`. If we don't need them, we should remove other fields from `Kubeconfig` as well because it'll be misleading. I think it's fine to keep.
  - For `Option<Preferences>` and `Option<Vec<NamedExtension>>`, we're just taking the first `Some` because it's unclear what should be done.
- Returns error when `apiVersion`/`kind` is set and mismatches. Not sure if this is correct behavior.

Closes #132