### PR TITLE
add default_namespaced - for #209

### DIFF
--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -53,6 +53,20 @@ where
         }
     }
 
+    /// Namespaced resource in the default namespace
+    ///
+    /// The default namespace is either "default" out of cluster,
+    /// or the service account's namespace in cluster.
+    pub fn default_namespaced(client: Client) -> Self {
+        // DEFAULT_NS marker is an illegal namespace, and is replaced by service::set_cluster_url
+        let resource = Resource::namespaced::<K>("DEFAULT_NS");
+        Self {
+            resource,
+            client,
+            phantom: iter::empty(),
+        }
+    }
+
     /// Consume self and return the [`Client`]
     pub fn into_client(self) -> Client {
         self.into()

--- a/kube/src/service/mod.rs
+++ b/kube/src/service/mod.rs
@@ -71,6 +71,7 @@ impl TryFrom<Config> for Service {
         let cluster_url = config.cluster_url.clone();
         let mut default_headers = config.headers.clone();
         let timeout = config.timeout;
+        let default_ns = config.default_ns.clone();
 
         // AuthLayer is not necessary unless `RefreshableToken`
         let maybe_auth = match Authentication::try_from(&config.auth_info)? {
@@ -93,7 +94,7 @@ impl TryFrom<Config> for Service {
         };
 
         let common = ServiceBuilder::new()
-            .map_request(move |r| set_cluster_url(r, &cluster_url))
+            .map_request(move |r| set_cluster_url(r, &cluster_url, &default_ns))
             .map_request(move |r| set_default_headers(r, default_headers.clone()))
             .into_inner();
 

--- a/kube/src/service/url.rs
+++ b/kube/src/service/url.rs
@@ -1,11 +1,18 @@
 use http::Request;
 use hyper::Body;
 
-/// Set cluster URL.
-pub fn set_cluster_url(req: Request<Body>, url: &url::Url) -> Request<Body> {
+/// Set cluster URL
+///
+/// This also propagates `Config::default_ns` if requested via `Api::default_namespaced`
+/// `"DEFAULT_NS"` is the placeholder from `Api::default_namespaced` which it's kept up to date with
+/// This cannot clash with a legal namespace as it contains an underscore
+pub fn set_cluster_url(req: Request<Body>, url: &url::Url, default_ns: &str) -> Request<Body> {
     let (mut parts, body) = req.into_parts();
     let pandq = parts.uri.path_and_query().expect("valid path+query from kube");
-    parts.uri = finalize_url(url, &pandq).parse().expect("valid URL");
+    parts.uri = finalize_url(url, &pandq)
+        .replace("DEFAULT_NS", default_ns)
+        .parse()
+        .expect("valid URL");
     Request::from_parts(parts, body)
 }
 


### PR DESCRIPTION
based on suggestion in https://github.com/clux/kube-rs/pull/394#discussion_r571590716

WIP. POC there, but missing some tests. And probably need to test through `Api`, which makes this a completely new test path.