### PR TITLE
kube-config - Allow arbitrary 'extension' objects

### DIFF
--- a/kube/src/config/file_config.rs
+++ b/kube/src/config/file_config.rs
@@ -52,16 +52,12 @@ pub struct NamedCluster {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Cluster {
     pub server: String,
-    #[serde(rename = "tls-server-name")]
-    pub tls_server_name: Option<String>,
     #[serde(rename = "insecure-skip-tls-verify")]
     pub insecure_skip_tls_verify: Option<bool>,
     #[serde(rename = "certificate-authority")]
     pub certificate_authority: Option<String>,
     #[serde(rename = "certificate-authority-data")]
     pub certificate_authority_data: Option<String>,
-    #[serde(rename = "proxy-url")]
-    pub proxy_url: Option<String>,
     pub extensions: Option<Vec<NamedExtension>>,
 }
 

--- a/kube/src/config/file_config.rs
+++ b/kube/src/config/file_config.rs
@@ -38,7 +38,7 @@ pub struct Preferences {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NamedExtension {
     pub name: String,
-    pub extension: serde_yaml::Mapping,
+    pub extension: serde_json::Value,
 }
 
 /// NamedCluster associates name with cluster.
@@ -294,7 +294,7 @@ impl AuthInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_yaml::Value;
+    use serde_json::Value;
 
     #[test]
     fn kubeconfig_merge() {
@@ -409,7 +409,7 @@ users:
         assert_eq!(
             config.clusters[1].cluster.extensions.as_ref().unwrap()[0]
                 .extension
-                .get(&Value::String("provider".to_owned())),
+                .get("provider"),
             Some(&Value::String("minikube.sigs.k8s.io".to_owned()))
         );
     }


### PR DESCRIPTION
Prior to this change the type of `NamedExtension.extension` was `String`.

However, the k8s golang type defines this as a `runtime.RawExtension`,
which allows for setting arbitrary objects as the value of the extension
key.

For example, `minikube` sets the value to:

```
- extension:
     last-update: 'Thu, 18 Feb 2021 16:59:26 PST'
     provider: minikube.sigs.k8s.io
     version: v1.17.1
  name: context_info
```

When `kube-rs` tries to parse this as a `String` you'll end up with an error like this:

```
thread 'config::file_config::tests::kubeconfig_deserialize' panicked at 'called `Result::unwrap()`
on an `Err` value: ParseYaml(Message("invalid type: map, expected a string", 
Some(Pos { marker: Marker { index: 312, line: 12, col: 23 }, path: 
"clusters[1].cluster.extensions[0].extension" })))', kube/src/config/file_config.rs:407:14
```

This PR changes the type from `String` to `serde_yaml::Value`
to allow for parsing, reading, writing, and round-tripping any
valid yaml value.

Further, the `Cluster` struct is filled with all known existing fields defined here: https://github.com/kubernetes/client-go/blob/30548acd0a9e231d42d406433aef55b111b36240/tools/clientcmd/api/v1/types.go#L63 , with the `extensions` field most relevant to this PR as it is set by `minikube`.