### PR TITLE
Add example CRD derive with `Condition` from `k8s_openapi`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3.8"
 kube = { path = "../kube", version = "^0.50.0", default-features = false }
 kube-derive = { path = "../kube-derive", version = "^0.50.0", default-features = false } # only needed to opt out of schema
 kube-runtime = { path = "../kube-runtime", version = "^0.50.0", default-features = false }
-k8s-openapi = { version = "0.11.0", features = ["v1_19"], default-features = false }
+k8s-openapi = { version = "0.11.0", features = ["v1_20"], default-features = false }
 log = "0.4.11"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.61"

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -28,6 +28,6 @@ schema = []
 [dev-dependencies]
 serde = { version = "1.0.118", features = ["derive"] }
 serde_yaml = "0.8.14"
-k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_19"] }
+k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_20"] }
 schemars = { version = "0.8.0", features = ["chrono"] }
 chrono = "0.4.19"

--- a/kube-runtime/Cargo.toml
+++ b/kube-runtime/Cargo.toml
@@ -43,4 +43,4 @@ schemars = "0.8.0"
 [dev-dependencies.k8s-openapi]
 version = "0.11.0"
 default-features = false
-features = ["v1_19"]
+features = ["v1_20"]

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -80,4 +80,4 @@ tower-test = "0.4.0"
 [dev-dependencies.k8s-openapi]
 version = "0.11.0"
 default-features = false
-features = ["v1_19"]
+features = ["v1_20"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.37"
 env_logger = "0.8.2"
 futures = "0.3.8"
 kube = { path = "../kube", version = "^0.50.0"}
-k8s-openapi = { version = "0.11.0", features = ["v1_19"], default-features = false }
+k8s-openapi = { version = "0.11.0", features = ["v1_20"], default-features = false }
 log = "0.4.11"
 serde_json = "1.0.61"
 tokio = { version = "1.0.1", features = ["full"] }


### PR DESCRIPTION
Example to generate schema with `Vec<Condition>` with Kubernetes extensions required for server side apply.

This works, but I wouldn't recommend working with `Condition` from `k8s_openapi` because many fields are required and are `String`. Kubernetes doesn't care as long as it serializes to something matching the convention. This is also an example of generating schema for external types without newtype implementing `JsonSchema`.

Test with: `cargo test --example crd_derive`

---

related: #427