### PR TITLE
Clean up runtime docs a bit

### DIFF
--- a/kube-runtime/src/controller/future_hash_map.rs
+++ b/kube-runtime/src/controller/future_hash_map.rs
@@ -6,8 +6,9 @@ use std::{
     task::{Context, Poll},
 };
 
-/// Variant of [`tokio::stream::StreamMap`] that only runs [`Future`]s, and uses a [`HashMap`] as
-/// the backing store, giving O(1) insertion and membership checks.
+/// Variant of [`tokio_stream::StreamMap`](https://docs.rs/tokio-stream/0.1.3/tokio_stream/struct.StreamMap.html)
+/// that only runs [`Future`]s, and uses a [`HashMap`] as the backing store, giving (amortized) O(1) insertion
+/// and membership checks.
 ///
 /// Just like for `StreamMap`'s `S`, `F` must be [`Unpin`], since [`HashMap`] is free to move
 /// entries as it pleases (for example: resizing the backing array).

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -290,6 +290,7 @@ where
     ///
     /// Configure `ListParams` and `Api` so you only get reconcile events
     /// for the correct `Api` scope (cluster/all/namespaced), or `ListParams` subset
+    #[must_use]
     pub fn new(owned_api: Api<K>, lp: ListParams) -> Self {
         let writer = Writer::<K>::default();
         let reader = writer.as_reader();

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -57,7 +57,7 @@ pub struct ReconcilerAction {
     pub requeue_after: Option<Duration>,
 }
 
-/// Helper for building custom trigger filters, see [`trigger_self`] and [`trigger_owners`] for some examples.
+/// Helper for building custom trigger filters, see the implementations of [`trigger_self`] and [`trigger_owners`] for some examples.
 pub fn trigger_with<T, K, I, S>(
     stream: S,
     mapper: impl Fn(T) -> I,

--- a/kube-runtime/src/controller/runner.rs
+++ b/kube-runtime/src/controller/runner.rs
@@ -8,8 +8,12 @@ use std::{
     task::{Context, Poll},
 };
 
-/// Pulls messages from a [`Scheduler`], and runs an action for each message in parallel,
-/// while making sure to not run the same message multiple times at once.
+/// Pulls items from a [`Scheduler`], and runs an action for each item in parallel,
+/// while making sure to not process [equal](`Eq`) items multiple times at once.
+///
+/// If an item is to be emitted from the [`Scheduler`] while an equal item is
+/// already being processed then it will be held pending until the current item
+/// is finished.
 #[pin_project]
 pub struct Runner<T, R, F, MkF> {
     #[pin]

--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -1,11 +1,12 @@
-//! Crate with kubernetes runtime components
+//! Common components for building Kubernetes operators
 //!
 //! This crate contains the core building blocks to allow users to build
 //! controllers/operators/watchers that need to synchronize/reconcile kubernetes
 //! state.
 //!
-//! Newcomers should generally get started with the [`Controller`] builder, which manages
-//! all state internals for you.
+//! Newcomers are recommended to start with the [`Controller`] builder, which gives an
+//! opinionated starting point that should be appropriate for simple operators, but all
+//! components are designed to be usable á la carte if your operator doesn't quite fit that mold.
 
 #![deny(unsafe_code)]
 #![deny(clippy::all)]

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -1,3 +1,5 @@
+//! Caches objects in memory
+
 mod object_ref;
 pub mod store;
 

--- a/kube-runtime/src/scheduler.rs
+++ b/kube-runtime/src/scheduler.rs
@@ -113,9 +113,8 @@ impl<'a, T: Hash + Eq + Clone, R> SchedulerProj<'a, T, R> {
                 );
                     if can_take_message(&msg) {
                         break Poll::Ready(Some(Ok(msg)));
-                    } else {
-                        self.pending.insert(msg);
                     }
+                    self.pending.insert(msg);
                 }
                 Poll::Ready(Some(Err(err))) => break Poll::Ready(Some(Err(err))),
                 Poll::Ready(None) => {


### PR DESCRIPTION
In particular, ensures that we at least have module-level summaries. Also tries to be a bit more consistent with the terminology (object vs resource, item vs message).