### PR TITLE
Unify API error types

### DIFF
--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -72,7 +72,7 @@ async fn main() -> anyhow::Result<()> {
             info!("Created {} ({:?})", Meta::name(&o), o.status.unwrap());
             debug!("Created CRD: {:?}", o.spec);
         }
-        Err(kube::Error::Api(ae)) => assert_eq!(ae.code, 409), // if you skipped delete, for instance
+        Err(kube::Error::Api(ae)) => assert_eq!(ae.code, Some(409)), // if you skipped delete, for instance
         Err(e) => return Err(e.into()),                        // any other case is probably bad
     }
     // Wait for the api to catch up

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -125,24 +125,27 @@ async fn main() -> Result<()> {
     // Nullables defaults to `None` and only sent if it's not configured to skip.
     let bar = Foo::new("bar", FooSpec { ..FooSpec::default() });
     let bar = foos.create(&PostParams::default(), &bar).await?;
-    assert_eq!(bar.spec, FooSpec {
-        // Nonnullable without default is required.
-        non_nullable: String::default(),
-        // Defaulting didn't happen because an empty string was sent.
-        non_nullable_with_default: String::default(),
-        // `nullable_skipped` field does not exist in the object (see below).
-        nullable_skipped: None,
-        // `nullable` field exists in the object (see below).
-        nullable: None,
-        // Defaulting happened because serialization was skipped.
-        nullable_skipped_with_default: default_nullable(),
-        // Defaulting did not happen because `null` was sent.
-        // Deserialization does not apply the default either.
-        nullable_with_default: None,
-        // Empty listables to be patched in later
-        default_listable: Default::default(),
-        set_listable: Default::default(),
-    });
+    assert_eq!(
+        bar.spec,
+        FooSpec {
+            // Nonnullable without default is required.
+            non_nullable: String::default(),
+            // Defaulting didn't happen because an empty string was sent.
+            non_nullable_with_default: String::default(),
+            // `nullable_skipped` field does not exist in the object (see below).
+            nullable_skipped: None,
+            // `nullable` field exists in the object (see below).
+            nullable: None,
+            // Defaulting happened because serialization was skipped.
+            nullable_skipped_with_default: default_nullable(),
+            // Defaulting did not happen because `null` was sent.
+            // Deserialization does not apply the default either.
+            nullable_with_default: None,
+            // Empty listables to be patched in later
+            default_listable: Default::default(),
+            set_listable: Default::default(),
+        }
+    );
 
     // Set up dynamic resource to test using raw values.
     let resource = Resource::dynamic("Foo")
@@ -203,12 +206,12 @@ async fn main() -> Result<()> {
     assert!(res.is_err());
     match res.err() {
         Some(kube::Error::Api(err)) => {
-            assert_eq!(err.code, 422);
-            assert_eq!(err.reason, "Invalid");
-            assert_eq!(err.status, "Failure");
+            assert_eq!(err.code, Some(422));
+            assert_eq!(err.reason.as_deref(), Some("Invalid"));
+            assert_eq!(err.status.as_deref(), Some("Failure"));
             assert_eq!(
-                err.message,
-                "Foo.clux.dev \"qux\" is invalid: spec.non_nullable: Required value"
+                err.message.as_deref(),
+                Some("Foo.clux.dev \"qux\" is invalid: spec.non_nullable: Required value")
             );
         }
         _ => assert!(false),

--- a/examples/job_api.rs
+++ b/examples/job_api.rs
@@ -64,7 +64,7 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
             WatchEvent::Deleted(s) => info!("Deleted {}", Meta::name(&s)),
-            WatchEvent::Error(s) => error!("{}", s),
+            WatchEvent::Error(s) => error!("{:?}", s),
             _ => {}
         }
     }

--- a/examples/pod_api.rs
+++ b/examples/pod_api.rs
@@ -1,4 +1,5 @@
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 use futures::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::Pod;
 use serde_json::json;
@@ -41,8 +42,8 @@ async fn main() -> anyhow::Result<()> {
             // wait for it..
             std::thread::sleep(std::time::Duration::from_millis(5_000));
         }
-        Err(kube::Error::Api(ae)) => assert_eq!(ae.code, 409), // if you skipped delete, for instance
-        Err(e) => return Err(e.into()),                        // any other case is probably bad
+        Err(kube::Error::Api(ae)) => assert_eq!(ae.code, Some(409)), // if you skipped delete, for instance
+        Err(e) => return Err(e.into()),                              // any other case is probably bad
     }
 
     // Watch it phase for a few seconds
@@ -59,7 +60,7 @@ async fn main() -> anyhow::Result<()> {
                 info!("Modified: {} with phase: {}", Meta::name(&o), phase);
             }
             WatchEvent::Deleted(o) => info!("Deleted {}", Meta::name(&o)),
-            WatchEvent::Error(e) => error!("Error {}", e),
+            WatchEvent::Error(e) => error!("Error {:?}", e),
             _ => {}
         }
     }

--- a/kube/src/api/object.rs
+++ b/kube/src/api/object.rs
@@ -1,7 +1,7 @@
 use crate::{
     api::metadata::{ListMeta, Meta, ObjectMeta, TypeMeta},
-    error::ErrorResponse,
 };
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Status;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -27,7 +27,7 @@ where
     /// NB: This became Beta first in Kubernetes 1.16.
     Bookmark(Bookmark),
     /// There was some kind of error
-    Error(ErrorResponse),
+    Error(Status),
 }
 
 impl<K> Debug for WatchEvent<K>

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -1,10 +1,10 @@
 use bytes::Bytes;
 use futures::Stream;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Status;
 use serde::de::DeserializeOwned;
 
 use crate::{
     api::{Api, DeleteParams, Patch, PatchParams, PostParams, Resource},
-    client::Status,
     Error, Result,
 };
 

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -1,11 +1,12 @@
 use either::Either;
 use futures::Stream;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Status;
 use serde::{de::DeserializeOwned, Serialize};
 use std::iter;
 
 use crate::{
     api::{DeleteParams, ListParams, Meta, ObjectList, Patch, PatchParams, PostParams, Resource, WatchEvent},
-    client::{Client, Status},
+    client::Client,
     Result,
 };
 

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -1,7 +1,7 @@
 //! Error handling in [`kube`][crate]
 
 use http::header::InvalidHeaderValue;
-use serde::{Deserialize, Serialize};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Status;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -14,8 +14,8 @@ pub enum Error {
     /// It's also used in `WatchEvent` from watch calls.
     ///
     /// It's quite common to get a `410 Gone` when the `resourceVersion` is too old.
-    #[error("ApiError: {0} ({0:?})")]
-    Api(#[source] ErrorResponse),
+    #[error("ApiError: {0:?}")]
+    Api(Status),
 
     /// ConnectionError for when TcpStream fails to connect.
     #[error("ConnectionError: {0}")]
@@ -260,20 +260,4 @@ impl From<OAuthError> for Error {
     fn from(e: OAuthError) -> Self {
         ConfigError::OAuth(e).into()
     }
-}
-
-/// An error response from the API.
-#[derive(Error, Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
-#[error("{message}: {reason}")]
-pub struct ErrorResponse {
-    /// The status
-    pub status: String,
-    /// A message about the error
-    #[serde(default)]
-    pub message: String,
-    /// The reason for the error
-    #[serde(default)]
-    pub reason: String,
-    /// The error code
-    pub code: u16,
 }

--- a/kube/src/runtime/informer.rs
+++ b/kube/src/runtime/informer.rs
@@ -142,7 +142,7 @@ where
                     }
                     Ok(WatchEvent::Error(e)) => {
                         // 410 Gone => we need to restart from latest next call
-                        if e.code == 410 {
+                        if e.code == Some(410) {
                             warn!("Stream desynced: {:?}", e);
                             *needs_resync.lock().await = true;
                         }

--- a/tests/dapp.rs
+++ b/tests/dapp.rs
@@ -64,7 +64,7 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
             WatchEvent::Deleted(s) => info!("Deleted {}", Meta::name(&s)),
-            WatchEvent::Error(s) => error!("{}", s),
+            WatchEvent::Error(s) => error!("{:?}", s),
             _ => {}
         }
     }


### PR DESCRIPTION
Currently `kube` has two similar structs that are intended to hold API errors - `Status` and `ErrorResponse`. However, both types are incomplete. This pull request deletes both structs in favor of `metav1::Status` defined by `k8s-openapi`.