### PR TITLE
[#459]: Make `Preconditions` public

### DIFF
--- a/kube/src/api/mod.rs
+++ b/kube/src/api/mod.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 pub struct NotUsed {}
 
 pub(crate) mod params;
-pub use params::{DeleteParams, ListParams, Patch, PatchParams, PostParams, PropagationPolicy};
+pub use params::{
+    DeleteParams, ListParams, Patch, PatchParams, PostParams, Preconditions, PropagationPolicy,
+};
 mod resource;
 pub use resource::Resource;
 
@@ -20,8 +22,10 @@ pub use typed::Api;
 mod dynamic;
 pub use dynamic::DynamicResource;
 
-#[cfg(feature = "ws")] mod remote_command;
-#[cfg(feature = "ws")] pub use remote_command::AttachedProcess;
+#[cfg(feature = "ws")]
+mod remote_command;
+#[cfg(feature = "ws")]
+pub use remote_command::AttachedProcess;
 
 mod subresource;
 #[cfg(feature = "ws")]

--- a/kube/src/api/params.rs
+++ b/kube/src/api/params.rs
@@ -395,8 +395,10 @@ mod test {
 #[derive(Default, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Preconditions {
+    /// Specifies the target ResourceVersion
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resource_version: Option<String>,
+    /// Specifies the target UID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uid: Option<String>,
 }


### PR DESCRIPTION
Assuming this was an oversight, here is the PR to make `Preconditions`, like e.g. `PropagationPolicy`.