### PR TITLE
Clean up type bounds after Metapocalypse

### DIFF
--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -66,7 +66,6 @@ where
     S: TryStream<Ok = T>,
     I: IntoIterator<Item = ObjectRef<K>>,
     K: Meta,
-    <K as Meta>::Family: Debug + Eq + Hash + Clone,
 {
     stream
         .map_ok(move |obj| stream::iter(mapper(obj).into_iter().map(Ok)))
@@ -78,7 +77,7 @@ pub fn trigger_self<K, S>(stream: S, family: K::Family) -> impl Stream<Item = Re
 where
     S: TryStream<Ok = K>,
     K: Meta,
-    K::Family: Debug + Eq + Hash + Clone,
+    K::Family: Clone,
 {
     trigger_with(stream, move |obj| {
         Some(ObjectRef::from_obj_with(&obj, family.clone()))
@@ -94,7 +93,7 @@ where
     S: TryStream,
     S::Ok: Meta,
     KOwner: Meta,
-    KOwner::Family: Debug + Eq + Hash + Clone,
+    KOwner::Family: Clone,
 {
     trigger_with(stream, move |obj| {
         let meta = obj.meta().clone();
@@ -156,7 +155,7 @@ pub fn applier<K, QueueStream, ReconcilerFut, T>(
 ) -> impl Stream<Item = Result<(ObjectRef<K>, ReconcilerAction), Error<ReconcilerFut::Error, QueueStream::Error>>>
 where
     K: Clone + Meta + 'static,
-    <K as Meta>::Family: Debug + Eq + Hash + Clone + Unpin,
+    K::Family: Debug + Eq + Hash + Clone + Unpin,
     ReconcilerFut: TryFuture<Ok = ReconcilerAction> + Unpin,
     ReconcilerFut::Error: std::error::Error + 'static,
     QueueStream: TryStream<Ok = ObjectRef<K>>,
@@ -294,7 +293,7 @@ where
 pub struct Controller<K>
 where
     K: Clone + Meta + Debug + 'static,
-    K::Family: Debug + Eq + Hash + Clone,
+    K::Family: Eq + Hash,
 {
     // NB: Need to Unpin for stream::select_all
     // TODO: get an arbitrary std::error::Error in here?
@@ -306,7 +305,7 @@ where
 impl<K> Controller<K>
 where
     K: Clone + Meta + DeserializeOwned + Debug + Send + Sync + 'static,
-    K::Family: Debug + Eq + Hash + Clone + Default,
+    K::Family: Eq + Hash + Clone + Default,
 {
     /// Create a Controller on a type `K`
     ///
@@ -321,7 +320,7 @@ where
 impl<K> Controller<K>
 where
     K: Clone + Meta + DeserializeOwned + Debug + Send + Sync + 'static,
-    K::Family: Debug + Eq + Hash + Clone,
+    K::Family: Eq + Hash + Clone,
 {
     /// Create a Controller on a type `K`
     ///
@@ -405,7 +404,7 @@ where
         context: Context<T>,
     ) -> impl Stream<Item = Result<(ObjectRef<K>, ReconcilerAction), Error<ReconcilerFut::Error, watcher::Error>>>
     where
-        K::Family: Unpin,
+        K::Family: Debug + Unpin,
         ReconcilerFut: TryFuture<Ok = ReconcilerAction> + Send + 'static,
         ReconcilerFut::Error: std::error::Error + Send + 'static,
     {

--- a/kube-runtime/src/lib.rs
+++ b/kube-runtime/src/lib.rs
@@ -15,6 +15,7 @@
 #![allow(clippy::pub_enum_variant_names)]
 // Triggered by many derive macros (kube-derive, derivative)
 #![allow(clippy::default_trait_access)]
+#![allow(clippy::type_repetition_in_bounds)]
 
 pub mod controller;
 pub mod reflector;

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -19,7 +19,7 @@ pub use store::Store;
 pub fn reflector<K, W>(mut store: store::Writer<K>, stream: W) -> impl Stream<Item = W::Item>
 where
     K: Meta + Clone,
-    <K as Meta>::Family: Debug + Eq + Hash + Clone,
+    K::Family: Debug + Eq + Hash + Clone,
     W: Stream<Item = watcher::Result<watcher::Event<K>>>,
 {
     stream.inspect_ok(move |event| store.apply_watcher_event(event))

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -7,7 +7,7 @@ pub use self::object_ref::ObjectRef;
 use crate::watcher;
 use futures::{Stream, TryStreamExt};
 use kube::api::Meta;
-use std::{fmt::Debug, hash::Hash};
+use std::hash::Hash;
 pub use store::Store;
 
 /// Caches objects from `watcher::Event`s to a local `Store`
@@ -19,7 +19,7 @@ pub use store::Store;
 pub fn reflector<K, W>(mut store: store::Writer<K>, stream: W) -> impl Stream<Item = W::Item>
 where
     K: Meta + Clone,
-    K::Family: Debug + Eq + Hash + Clone,
+    K::Family: Eq + Hash + Clone,
     W: Stream<Item = watcher::Result<watcher::Event<K>>>,
 {
     stream.inspect_ok(move |event| store.apply_watcher_event(event))

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -24,7 +24,7 @@ use std::{
 /// ```
 pub struct ObjectRef<K: Meta>
 where
-    <K as Meta>::Family: Debug + Eq + Hash + Clone,
+    K::Family: Debug + Eq + Hash + Clone,
 {
     family: K::Family,
     /// The name of the object
@@ -45,7 +45,7 @@ where
 
 impl<K: Meta> ObjectRef<K>
 where
-    <K as Meta>::Family: Debug + Eq + Hash + Clone + Default,
+    K::Family: Debug + Eq + Hash + Clone + Default,
 {
     #[must_use]
     pub fn new(name: &str) -> Self {
@@ -63,7 +63,7 @@ where
 
 impl<K: Meta> ObjectRef<K>
 where
-    <K as Meta>::Family: Debug + Eq + Hash + Clone,
+    K::Family: Debug + Eq + Hash + Clone,
 {
     #[must_use]
     pub fn new_with(name: &str, family: K::Family) -> Self {
@@ -143,7 +143,7 @@ where
 
 impl<K: Meta> Display for ObjectRef<K>
 where
-    <K as Meta>::Family: Debug + Eq + Hash + Clone,
+    K::Family: Debug + Eq + Hash + Clone,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -7,7 +7,13 @@ use std::{
 };
 
 #[derive(Derivative)]
-#[derivative(Debug, PartialEq, Eq, Hash, Clone)]
+#[derivative(
+    Debug(bound = "K::Family: Debug"),
+    PartialEq(bound = "K::Family: PartialEq"),
+    Eq(bound = "K::Family: Eq"),
+    Hash(bound = "K::Family: Hash"),
+    Clone(bound = "K::Family: Clone")
+)]
 /// A typed and namedspaced (if relevant) reference to a Kubernetes object
 ///
 /// `K` may be either the object type or `DynamicObject`, in which case the
@@ -22,10 +28,7 @@ use std::{
 ///     ObjectRef::<Secret>::new("a").erase(),
 /// );
 /// ```
-pub struct ObjectRef<K: Meta>
-where
-    K::Family: Debug + Eq + Hash + Clone,
-{
+pub struct ObjectRef<K: Meta> {
     family: K::Family,
     /// The name of the object
     pub name: String,
@@ -45,7 +48,7 @@ where
 
 impl<K: Meta> ObjectRef<K>
 where
-    K::Family: Debug + Eq + Hash + Clone + Default,
+    K::Family: Default,
 {
     #[must_use]
     pub fn new(name: &str) -> Self {
@@ -61,10 +64,7 @@ where
     }
 }
 
-impl<K: Meta> ObjectRef<K>
-where
-    K::Family: Debug + Eq + Hash + Clone,
-{
+impl<K: Meta> ObjectRef<K> {
     #[must_use]
     pub fn new_with(name: &str, family: K::Family) -> Self {
         Self {
@@ -117,10 +117,7 @@ where
     /// Note that no checking is done on whether this conversion makes sense. For example, every `Service`
     /// has a corresponding `Endpoints`, but it wouldn't make sense to convert a `Pod` into a `Deployment`.
     #[must_use]
-    pub fn into_kind_unchecked<K2: Meta>(self, f2: K2::Family) -> ObjectRef<K2>
-    where
-        <K2 as Meta>::Family: Debug + Eq + Hash + Clone,
-    {
+    pub fn into_kind_unchecked<K2: Meta>(self, f2: K2::Family) -> ObjectRef<K2> {
         ObjectRef {
             family: f2,
             name: self.name,
@@ -141,10 +138,7 @@ where
     }
 }
 
-impl<K: Meta> Display for ObjectRef<K>
-where
-    K::Family: Debug + Eq + Hash + Clone,
-{
+impl<K: Meta> Display for ObjectRef<K> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -13,7 +13,7 @@ use std::{collections::HashMap, fmt::Debug, hash::Hash, sync::Arc};
 #[derivative(Default(bound = "K::Family: Default"))]
 pub struct Writer<K: 'static + Meta>
 where
-    K::Family: Debug + Eq + Hash + Clone,
+    K::Family: Eq + Hash,
 {
     store: Arc<DashMap<ObjectRef<K>, K>>,
     family: K::Family,
@@ -21,7 +21,7 @@ where
 
 impl<K: 'static + Meta + Clone> Writer<K>
 where
-    K::Family: Debug + Eq + Hash + Clone,
+    K::Family: Eq + Hash,
 {
     /// Creates a new Writer with the specified family.
     ///
@@ -46,7 +46,10 @@ where
     }
 
     /// Applies a single watcher event to the store
-    pub fn apply_watcher_event(&mut self, event: &watcher::Event<K>) {
+    pub fn apply_watcher_event(&mut self, event: &watcher::Event<K>)
+    where
+        K::Family: Clone,
+    {
         match event {
             watcher::Event::Applied(obj) => {
                 self.store
@@ -77,18 +80,18 @@ where
 ///
 /// Cannot be constructed directly since one writer handle is required,
 /// use `Writer::as_reader()` instead.
-#[derive(Debug, Derivative)]
-#[derivative(Clone)]
+#[derive(Derivative)]
+#[derivative(Debug(bound = "K: Debug, K::Family: Debug"), Clone)]
 pub struct Store<K: 'static + Meta>
 where
-    K::Family: Debug + Eq + Hash + Clone,
+    K::Family: Hash + Eq,
 {
     store: Arc<DashMap<ObjectRef<K>, K>>,
 }
 
 impl<K: 'static + Clone + Meta> Store<K>
 where
-    K::Family: Debug + Eq + Hash + Clone,
+    K::Family: Eq + Hash + Clone,
 {
     /// Retrieve a `clone()` of the entry referred to by `key`, if it is in the cache.
     ///

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -10,10 +10,10 @@ use std::{collections::HashMap, fmt::Debug, hash::Hash, sync::Arc};
 /// This is exclusive since it's not safe to share a single `Store` between multiple reflectors.
 /// In particular, `Restarted` events will clobber the state of other connected reflectors.
 #[derive(Debug, Derivative)]
-#[derivative(Default(bound = "<K as Meta>::Family: Default"))]
+#[derivative(Default(bound = "K::Family: Default"))]
 pub struct Writer<K: 'static + Meta>
 where
-    <K as Meta>::Family: Debug + Eq + Hash + Clone,
+    K::Family: Debug + Eq + Hash + Clone,
 {
     store: Arc<DashMap<ObjectRef<K>, K>>,
     family: K::Family,
@@ -21,7 +21,7 @@ where
 
 impl<K: 'static + Meta + Clone> Writer<K>
 where
-    <K as Meta>::Family: Debug + Eq + Hash + Clone,
+    K::Family: Debug + Eq + Hash + Clone,
 {
     /// Creates a new Writer with the specified family.
     ///
@@ -81,14 +81,14 @@ where
 #[derivative(Clone)]
 pub struct Store<K: 'static + Meta>
 where
-    <K as Meta>::Family: Debug + Eq + Hash + Clone,
+    K::Family: Debug + Eq + Hash + Clone,
 {
     store: Arc<DashMap<ObjectRef<K>, K>>,
 }
 
 impl<K: 'static + Clone + Meta> Store<K>
 where
-    <K as Meta>::Family: Debug + Eq + Hash + Clone,
+    K::Family: Debug + Eq + Hash + Clone,
 {
     /// Retrieve a `clone()` of the entry referred to by `key`, if it is in the cache.
     ///


### PR DESCRIPTION
#385 added a bunch of constraints on `Meta::Family` that weren't actually needed. We might as well loosen them back.