### PR TITLE
Remove Inflector

### DIFF
--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -15,7 +15,6 @@ readme = "../README.md"
 proc-macro2 = "1.0.24"
 quote = "1.0.8"
 syn = { version = "1.0.57", features = ["extra-traits"] }
-Inflector = "0.11.4"
 serde_json = "1.0.61"
 darling = "0.12.1"
 

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -48,7 +48,6 @@ openssl = { version = "0.10.32", optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 tokio-rustls = { version = "0.22.0", features = ["dangerous_configuration"], optional = true }
 bytes = "1.0.0"
-Inflector = "0.11.4"
 tokio = { version = "1.0.1", features = ["time", "signal", "sync"] }
 static_assertions = "1.1.0"
 kube-derive = { path = "../kube-derive", version = "^0.51.0", optional = true }

--- a/kube/src/api/dynamic.rs
+++ b/kube/src/api/dynamic.rs
@@ -5,8 +5,6 @@ use crate::{
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{APIResource, ObjectMeta};
 use std::{borrow::Cow, convert::TryFrom, sync::Arc};
 
-use inflector::{cases::pascalcase::is_pascal_case, string::pluralize::to_plural};
-
 use std::iter;
 
 /// A dynamic builder for Resource
@@ -168,12 +166,6 @@ impl TryFrom<DynamicResource> for Resource {
         let version = rb.version.unwrap();
         let group = rb.group.unwrap();
 
-        // pedantic conventions we enforce internally in kube-derive
-        // but are broken by a few native / common custom resources such as istio, or
-        // kinds matching: CRI*, *Options, *Metrics, CSI*, ENI*, API*
-        if to_plural(&rb.kind) == rb.kind || !is_pascal_case(&rb.kind) {
-            debug!("DynamicResource '{}' should be singular + PascalCase", rb.kind);
-        }
         Ok(Self {
             api_version: if group.is_empty() {
                 version.clone()

--- a/kube/src/api/resource.rs
+++ b/kube/src/api/resource.rs
@@ -3,7 +3,6 @@ use crate::{
     api::{DynamicResource, Meta},
     Error, Result,
 };
-use inflector::string::pluralize::to_plural;
 
 /// A Kubernetes resource that can be accessed through the API
 #[derive(Clone, Debug)]
@@ -351,6 +350,100 @@ impl Resource {
         req.body(data).map_err(Error::HttpError)
     }
 }
+
+// Simple pluralizer. Handles the special cases.
+fn to_plural(word: &str) -> String {
+    if word == "endpoints" {
+        return word.to_owned();
+    }
+
+    // Words ending in s, x, z, ch, sh will be pluralized with -es (eg. foxes).
+    if word.ends_with('s')
+        || word.ends_with('x')
+        || word.ends_with('z')
+        || word.ends_with("ch")
+        || word.ends_with("sh")
+    {
+        return format!("{}es", word);
+    }
+
+    // Words ending in y that are preceded by a consonant will be pluralized by
+    // replacing y with -ies (eg. puppies).
+    if word.ends_with('y') {
+        if let Some(c) = word.chars().nth(word.len() - 2) {
+            if !matches!(c, 'a' | 'e' | 'i' | 'o' | 'u') {
+                // Remove 'y' and add `ies`
+                let mut chars = word.chars();
+                chars.next_back();
+                return format!("{}ies", chars.as_str());
+            }
+        }
+    }
+
+    // All other words will have "s" added to the end (eg. days).
+    format!("{}s", word)
+}
+
+#[test]
+fn test_to_plural_native() {
+    // Extracted from `swagger.json`
+    #[rustfmt::skip]
+    let native_kinds = vec![
+        ("APIService", "apiservices"),
+        ("Binding", "bindings"),
+        ("CertificateSigningRequest", "certificatesigningrequests"),
+        ("ClusterRole", "clusterroles"), ("ClusterRoleBinding", "clusterrolebindings"),
+        ("ComponentStatus", "componentstatuses"),
+        ("ConfigMap", "configmaps"),
+        ("ControllerRevision", "controllerrevisions"),
+        ("CronJob", "cronjobs"),
+        ("CSIDriver", "csidrivers"), ("CSINode", "csinodes"), ("CSIStorageCapacity", "csistoragecapacities"),
+        ("CustomResourceDefinition", "customresourcedefinitions"),
+        ("DaemonSet", "daemonsets"),
+        ("Deployment", "deployments"),
+        ("Endpoints", "endpoints"), ("EndpointSlice", "endpointslices"),
+        ("Event", "events"),
+        ("FlowSchema", "flowschemas"),
+        ("HorizontalPodAutoscaler", "horizontalpodautoscalers"),
+        ("Ingress", "ingresses"), ("IngressClass", "ingressclasses"),
+        ("Job", "jobs"),
+        ("Lease", "leases"),
+        ("LimitRange", "limitranges"),
+        ("LocalSubjectAccessReview", "localsubjectaccessreviews"),
+        ("MutatingWebhookConfiguration", "mutatingwebhookconfigurations"),
+        ("Namespace", "namespaces"),
+        ("NetworkPolicy", "networkpolicies"),
+        ("Node", "nodes"),
+        ("PersistentVolumeClaim", "persistentvolumeclaims"),
+        ("PersistentVolume", "persistentvolumes"),
+        ("PodDisruptionBudget", "poddisruptionbudgets"),
+        ("Pod", "pods"),
+        ("PodSecurityPolicy", "podsecuritypolicies"),
+        ("PodTemplate", "podtemplates"),
+        ("PriorityClass", "priorityclasses"),
+        ("PriorityLevelConfiguration", "prioritylevelconfigurations"),
+        ("ReplicaSet", "replicasets"),
+        ("ReplicationController", "replicationcontrollers"),
+        ("ResourceQuota", "resourcequotas"),
+        ("Role", "roles"), ("RoleBinding", "rolebindings"),
+        ("RuntimeClass", "runtimeclasses"),
+        ("Secret", "secrets"),
+        ("SelfSubjectAccessReview", "selfsubjectaccessreviews"),
+        ("SelfSubjectRulesReview", "selfsubjectrulesreviews"),
+        ("ServiceAccount", "serviceaccounts"),
+        ("Service", "services"),
+        ("StatefulSet", "statefulsets"),
+        ("StorageClass", "storageclasses"), ("StorageVersion", "storageversions"),
+        ("SubjectAccessReview", "subjectaccessreviews"),
+        ("TokenReview", "tokenreviews"),
+        ("ValidatingWebhookConfiguration", "validatingwebhookconfigurations"),
+        ("VolumeAttachment", "volumeattachments"),
+    ];
+    for (kind, plural) in native_kinds {
+        assert_eq!(to_plural(&kind.to_ascii_lowercase()), plural);
+    }
+}
+
 
 /// Extensive tests for Resource::<k8s_openapi::Resource impls>
 ///


### PR DESCRIPTION
- Use simple pluralizer (a Rust port of a popular JavaScript package [plur](https://www.npmjs.com/package/plur) minus the irregular and case matching)
- Duplicate the code in `kube-derive` without the special casing because it's short enough and didn't want to make this public. If necessary, I can publish the version in `kube-derive` as a separate crate.

This _may_ be a breaking change if a user is using some `kind` that results in different plural.

Closes #470.