### PR TITLE
rename Meta::Family to Meta::DynamicType - for #465

### DIFF
--- a/examples/configmapgen_controller.rs
+++ b/examples/configmapgen_controller.rs
@@ -36,7 +36,7 @@ struct ConfigMapGeneratorSpec {
     content: String,
 }
 
-fn object_to_owner_reference<K: Meta<Family = ()>>(meta: ObjectMeta) -> Result<OwnerReference, Error> {
+fn object_to_owner_reference<K: Meta<DynamicType = ()>>(meta: ObjectMeta) -> Result<OwnerReference, Error> {
     Ok(OwnerReference {
         api_version: K::api_version(&()).to_string(),
         kind: K::kind(&()).to_string(),

--- a/examples/dynamic_watcher.rs
+++ b/examples/dynamic_watcher.rs
@@ -4,6 +4,7 @@ use kube::{
     Api, Client,
 };
 use kube_runtime::{utils::try_flatten_applied, watcher};
+use std::env;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -12,13 +13,13 @@ async fn main() -> anyhow::Result<()> {
     let client = Client::try_default().await?;
 
     // Take dynamic resource identifiers:
-    let group = "clux.dev";
-    let version = "v1";
-    let kind = "Foo";
+    let group = env::var("GROUP").unwrap_or_else(|_| "clux.dev".into());
+    let version = env::var("VERSION").unwrap_or_else(|_| "v1".into());
+    let kind = env::var("KIND").unwrap_or_else(|_| "Foo".into());
 
     // Turn them into a GVK
-    let gvk = GroupVersionKind::from_dynamic_gvk(group, version, kind);
-    // Use them in an Api with the dynamic family
+    let gvk = GroupVersionKind::from_dynamic_gvk(&group, &version, &kind);
+    // Use them in an Api with the GVK as its DynamicType
     let api = Api::<DynamicObject>::all_with(client, &gvk);
 
     // Fully compatible with kube-runtime

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -73,36 +73,39 @@ where
 }
 
 /// Enqueues the object itself for reconciliation
-pub fn trigger_self<K, S>(stream: S, family: K::Family) -> impl Stream<Item = Result<ObjectRef<K>, S::Error>>
+pub fn trigger_self<K, S>(
+    stream: S,
+    dyntype: K::DynamicType,
+) -> impl Stream<Item = Result<ObjectRef<K>, S::Error>>
 where
     S: TryStream<Ok = K>,
     K: Meta,
-    K::Family: Clone,
+    K::DynamicType: Clone,
 {
     trigger_with(stream, move |obj| {
-        Some(ObjectRef::from_obj_with(&obj, family.clone()))
+        Some(ObjectRef::from_obj_with(&obj, dyntype.clone()))
     })
 }
 
 /// Enqueues any owners of type `KOwner` for reconciliation
 pub fn trigger_owners<KOwner, S>(
     stream: S,
-    owner_family: KOwner::Family,
+    owner_type: KOwner::DynamicType,
 ) -> impl Stream<Item = Result<ObjectRef<KOwner>, S::Error>>
 where
     S: TryStream,
     S::Ok: Meta,
     KOwner: Meta,
-    KOwner::Family: Clone,
+    KOwner::DynamicType: Clone,
 {
     trigger_with(stream, move |obj| {
         let meta = obj.meta().clone();
         let ns = meta.namespace;
-        let owner_family = owner_family.clone();
+        let owner_rtt = owner_type.clone();
         meta.owner_references
             .into_iter()
             .flatten()
-            .flat_map(move |owner| ObjectRef::from_owner_ref(ns.as_deref(), &owner, owner_family.clone()))
+            .flat_map(move |owner| ObjectRef::from_owner_ref(ns.as_deref(), &owner, owner_rtt.clone()))
     })
 }
 
@@ -155,7 +158,7 @@ pub fn applier<K, QueueStream, ReconcilerFut, T>(
 ) -> impl Stream<Item = Result<(ObjectRef<K>, ReconcilerAction), Error<ReconcilerFut::Error, QueueStream::Error>>>
 where
     K: Clone + Meta + 'static,
-    K::Family: Debug + Eq + Hash + Clone + Unpin,
+    K::DynamicType: Debug + Eq + Hash + Clone + Unpin,
     ReconcilerFut: TryFuture<Ok = ReconcilerAction> + Unpin,
     ReconcilerFut::Error: std::error::Error + 'static,
     QueueStream: TryStream<Ok = ObjectRef<K>>,
@@ -293,19 +296,19 @@ where
 pub struct Controller<K>
 where
     K: Clone + Meta + Debug + 'static,
-    K::Family: Eq + Hash,
+    K::DynamicType: Eq + Hash,
 {
     // NB: Need to Unpin for stream::select_all
     // TODO: get an arbitrary std::error::Error in here?
     selector: SelectAll<BoxStream<'static, Result<ObjectRef<K>, watcher::Error>>>,
-    family: K::Family,
+    dyntype: K::DynamicType,
     reader: Store<K>,
 }
 
 impl<K> Controller<K>
 where
     K: Clone + Meta + DeserializeOwned + Debug + Send + Sync + 'static,
-    K::Family: Eq + Hash + Clone + Default,
+    K::DynamicType: Eq + Hash + Clone + Default,
 {
     /// Create a Controller on a type `K`
     ///
@@ -320,29 +323,29 @@ where
 impl<K> Controller<K>
 where
     K: Clone + Meta + DeserializeOwned + Debug + Send + Sync + 'static,
-    K::Family: Eq + Hash + Clone,
+    K::DynamicType: Eq + Hash + Clone,
 {
     /// Create a Controller on a type `K`
     ///
     /// Configure `ListParams` and `Api` so you only get reconcile events
     /// for the correct `Api` scope (cluster/all/namespaced), or `ListParams` subset
     ///
-    /// Unlike `new`, this function accepts `K::Family` so it can be used with dynamic
+    /// Unlike `new`, this function accepts `K::DynamicType` so it can be used with dynamic
     /// resources.
-    pub fn new_with(owned_api: Api<K>, lp: ListParams, family: K::Family) -> Self {
-        let writer = Writer::<K>::new(family.clone());
+    pub fn new_with(owned_api: Api<K>, lp: ListParams, dyntype: K::DynamicType) -> Self {
+        let writer = Writer::<K>::new(dyntype.clone());
         let reader = writer.as_reader();
         let mut selector = stream::SelectAll::new();
         let self_watcher = trigger_self(
             try_flatten_applied(reflector(writer, watcher(owned_api, lp))),
-            family.clone(),
+            dyntype.clone(),
         )
         .boxed();
         selector.push(self_watcher);
         Self {
             selector,
             reader,
-            family,
+            dyntype,
         }
     }
 
@@ -365,9 +368,9 @@ where
         lp: ListParams,
     ) -> Self
     where
-        Child::Family: Debug + Eq + Hash + Clone,
+        Child::DynamicType: Debug + Eq + Hash + Clone,
     {
-        let child_watcher = trigger_owners(try_flatten_touched(watcher(api, lp)), self.family.clone());
+        let child_watcher = trigger_owners(try_flatten_touched(watcher(api, lp)), self.dyntype.clone());
         self.selector.push(child_watcher.boxed());
         self
     }
@@ -404,7 +407,7 @@ where
         context: Context<T>,
     ) -> impl Stream<Item = Result<(ObjectRef<K>, ReconcilerAction), Error<ReconcilerFut::Error, watcher::Error>>>
     where
-        K::Family: Debug + Unpin,
+        K::DynamicType: Debug + Unpin,
         ReconcilerFut: TryFuture<Ok = ReconcilerAction> + Send + 'static,
         ReconcilerFut::Error: std::error::Error + Send + 'static,
     {

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -101,11 +101,11 @@ where
     trigger_with(stream, move |obj| {
         let meta = obj.meta().clone();
         let ns = meta.namespace;
-        let owner_rtt = owner_type.clone();
+        let dt = owner_type.clone();
         meta.owner_references
             .into_iter()
             .flatten()
-            .flat_map(move |owner| ObjectRef::from_owner_ref(ns.as_deref(), &owner, owner_rtt.clone()))
+            .flat_map(move |owner| ObjectRef::from_owner_ref(ns.as_deref(), &owner, dt.clone()))
     })
 }
 

--- a/kube-runtime/src/reflector/mod.rs
+++ b/kube-runtime/src/reflector/mod.rs
@@ -19,7 +19,7 @@ pub use store::Store;
 pub fn reflector<K, W>(mut store: store::Writer<K>, stream: W) -> impl Stream<Item = W::Item>
 where
     K: Meta + Clone,
-    K::Family: Eq + Hash + Clone,
+    K::DynamicType: Eq + Hash + Clone,
     W: Stream<Item = watcher::Result<watcher::Event<K>>>,
 {
     stream.inspect_ok(move |event| store.apply_watcher_event(event))

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -23,9 +23,9 @@ impl<K: 'static + Meta + Clone> Writer<K>
 where
     K::DynamicType: Eq + Hash,
 {
-    /// Creates a new Writer with the specified family.
+    /// Creates a new Writer with the specified dynamic type.
     ///
-    /// If family is default-able (for example when writer is used with
+    /// If the dynamic type is default-able (for example when writer is used with
     /// `k8s_openapi` types) you can use `Default` instead.
     pub fn new(family: K::DynamicType) -> Self {
         Writer {

--- a/kube-runtime/src/reflector/store.rs
+++ b/kube-runtime/src/reflector/store.rs
@@ -10,24 +10,24 @@ use std::{collections::HashMap, fmt::Debug, hash::Hash, sync::Arc};
 /// This is exclusive since it's not safe to share a single `Store` between multiple reflectors.
 /// In particular, `Restarted` events will clobber the state of other connected reflectors.
 #[derive(Debug, Derivative)]
-#[derivative(Default(bound = "K::Family: Default"))]
+#[derivative(Default(bound = "K::DynamicType: Default"))]
 pub struct Writer<K: 'static + Meta>
 where
-    K::Family: Eq + Hash,
+    K::DynamicType: Eq + Hash,
 {
     store: Arc<DashMap<ObjectRef<K>, K>>,
-    family: K::Family,
+    family: K::DynamicType,
 }
 
 impl<K: 'static + Meta + Clone> Writer<K>
 where
-    K::Family: Eq + Hash,
+    K::DynamicType: Eq + Hash,
 {
     /// Creates a new Writer with the specified family.
     ///
     /// If family is default-able (for example when writer is used with
     /// `k8s_openapi` types) you can use `Default` instead.
-    pub fn new(family: K::Family) -> Self {
+    pub fn new(family: K::DynamicType) -> Self {
         Writer {
             store: Default::default(),
             family,
@@ -48,7 +48,7 @@ where
     /// Applies a single watcher event to the store
     pub fn apply_watcher_event(&mut self, event: &watcher::Event<K>)
     where
-        K::Family: Clone,
+        K::DynamicType: Clone,
     {
         match event {
             watcher::Event::Applied(obj) => {
@@ -81,17 +81,17 @@ where
 /// Cannot be constructed directly since one writer handle is required,
 /// use `Writer::as_reader()` instead.
 #[derive(Derivative)]
-#[derivative(Debug(bound = "K: Debug, K::Family: Debug"), Clone)]
+#[derivative(Debug(bound = "K: Debug, K::DynamicType: Debug"), Clone)]
 pub struct Store<K: 'static + Meta>
 where
-    K::Family: Hash + Eq,
+    K::DynamicType: Hash + Eq,
 {
     store: Arc<DashMap<ObjectRef<K>, K>>,
 }
 
 impl<K: 'static + Clone + Meta> Store<K>
 where
-    K::Family: Eq + Hash + Clone,
+    K::DynamicType: Eq + Hash + Clone,
 {
     /// Retrieve a `clone()` of the entry referred to by `key`, if it is in the cache.
     ///

--- a/kube/src/api/dynamic.rs
+++ b/kube/src/api/dynamic.rs
@@ -254,21 +254,21 @@ pub struct DynamicObject {
 }
 
 impl Meta for DynamicObject {
-    type Family = GroupVersionKind;
+    type DynamicType = GroupVersionKind;
 
-    fn group<'a>(f: &'a GroupVersionKind) -> Cow<'a, str> {
+    fn group(f: &GroupVersionKind) -> Cow<'_, str> {
         f.group.as_str().into()
     }
 
-    fn version<'a>(f: &'a GroupVersionKind) -> Cow<'a, str> {
+    fn version(f: &GroupVersionKind) -> Cow<'_, str> {
         f.version.as_str().into()
     }
 
-    fn kind<'a>(f: &'a GroupVersionKind) -> Cow<'a, str> {
+    fn kind(f: &GroupVersionKind) -> Cow<'_, str> {
         f.kind.as_str().into()
     }
 
-    fn api_version<'a>(f: &'a GroupVersionKind) -> Cow<'a, str> {
+    fn api_version(f: &GroupVersionKind) -> Cow<'_, str> {
         f.api_version.as_str().into()
     }
 

--- a/kube/src/api/metadata.rs
+++ b/kube/src/api/metadata.rs
@@ -16,18 +16,23 @@ use std::borrow::Cow;
 ///
 /// This avoids a bunch of the unnecessary unwrap mechanics for apps.
 pub trait Meta {
-    /// Types that know their metadata at compile time should select `Family = ()`.
-    /// Types that require some information at runtime should select `Family`
+    /// Type information for types that do not know their resource information at compile time.
+    ///
+    /// Types that know their metadata at compile time should select `DynamicType = ()`.
+    /// Types that require some information at runtime should select `DynamicType`
     /// as type of this information.
-    type Family: Send + Sync + 'static;
+    ///
+    /// See [`DynamicObject`] for a valid implementation of non-k8s-openapi resources.
+    type DynamicType: Send + Sync + 'static;
+
     /// Returns kind of this object
-    fn kind<'a>(f: &'a Self::Family) -> Cow<'a, str>;
+    fn kind(f: &Self::DynamicType) -> Cow<'_, str>;
     /// Returns group of this object
-    fn group<'a>(f: &'a Self::Family) -> Cow<'a, str>;
+    fn group(f: &Self::DynamicType) -> Cow<'_, str>;
     /// Returns version of this object
-    fn version<'a>(f: &'a Self::Family) -> Cow<'a, str>;
+    fn version(f: &Self::DynamicType) -> Cow<'_, str>;
     /// Returns apiVersion of this object
-    fn api_version<'a>(f: &'a Self::Family) -> Cow<'a, str> {
+    fn api_version<'a>(f: &'a Self::DynamicType) -> Cow<'_, str> {
         let group = Self::group(f);
         if group.is_empty() {
             return Self::version(f);
@@ -52,21 +57,21 @@ impl<K> Meta for K
 where
     K: Metadata<Ty = ObjectMeta>,
 {
-    type Family = ();
+    type DynamicType = ();
 
-    fn kind<'a>(_: &'a ()) -> Cow<'a, str> {
+    fn kind<'a>(_: &()) -> Cow<'_, str> {
         K::KIND.into()
     }
 
-    fn group<'a>(_: &'a ()) -> Cow<'a, str> {
+    fn group<'a>(_: &()) -> Cow<'_, str> {
         K::GROUP.into()
     }
 
-    fn version<'a>(_: &'a ()) -> Cow<'a, str> {
+    fn version<'a>(_: &()) -> Cow<'_, str> {
         K::VERSION.into()
     }
 
-    fn api_version<'a>(_: &'a ()) -> Cow<'a, str> {
+    fn api_version<'a>(_: &'a ()) -> Cow<'_, str> {
         K::API_VERSION.into()
     }
 

--- a/kube/src/api/metadata.rs
+++ b/kube/src/api/metadata.rs
@@ -32,7 +32,7 @@ pub trait Meta {
     /// Returns version of this object
     fn version(f: &Self::DynamicType) -> Cow<'_, str>;
     /// Returns apiVersion of this object
-    fn api_version<'a>(f: &'a Self::DynamicType) -> Cow<'_, str> {
+    fn api_version(f: &Self::DynamicType) -> Cow<'_, str> {
         let group = Self::group(f);
         if group.is_empty() {
             return Self::version(f);
@@ -71,7 +71,7 @@ where
         K::VERSION.into()
     }
 
-    fn api_version<'a>(_: &'a ()) -> Cow<'_, str> {
+    fn api_version(_: &()) -> Cow<'_, str> {
         K::API_VERSION.into()
     }
 

--- a/kube/src/api/resource.rs
+++ b/kube/src/api/resource.rs
@@ -34,6 +34,8 @@ pub struct Resource {
 
 impl Resource {
     /// Cluster level resources, or resources viewed across all namespaces
+    ///
+    /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
     pub fn all_with<K: Meta>(rtt: &K::DynamicType) -> Self {
         Self {
             api_version: K::api_version(rtt).into_owned(),
@@ -45,6 +47,8 @@ impl Resource {
     }
 
     /// Namespaced resource within a given namespace
+    ///
+    /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
     pub fn namespaced_with<K: Meta>(ns: &str, rtt: &K::DynamicType) -> Self {
         let kind = K::kind(rtt);
         match kind.as_ref() {

--- a/kube/src/api/resource.rs
+++ b/kube/src/api/resource.rs
@@ -34,19 +34,19 @@ pub struct Resource {
 
 impl Resource {
     /// Cluster level resources, or resources viewed across all namespaces
-    pub fn all_with<K: Meta>(f: &K::Family) -> Self {
+    pub fn all_with<K: Meta>(rtt: &K::DynamicType) -> Self {
         Self {
-            api_version: K::api_version(f).into_owned(),
-            kind: K::kind(f).into_owned(),
-            group: K::group(f).into_owned(),
-            version: K::version(f).into_owned(),
+            api_version: K::api_version(rtt).into_owned(),
+            kind: K::kind(rtt).into_owned(),
+            group: K::group(rtt).into_owned(),
+            version: K::version(rtt).into_owned(),
             namespace: None,
         }
     }
 
     /// Namespaced resource within a given namespace
-    pub fn namespaced_with<K: Meta>(ns: &str, f: &K::Family) -> Self {
-        let kind = K::kind(f);
+    pub fn namespaced_with<K: Meta>(ns: &str, rtt: &K::DynamicType) -> Self {
+        let kind = K::kind(rtt);
         match kind.as_ref() {
             "Node" | "Namespace" | "ClusterRole" | "CustomResourceDefinition" => {
                 panic!("{} is not a namespace scoped resource", kind)
@@ -54,10 +54,10 @@ impl Resource {
             _ => {}
         }
         Self {
-            api_version: K::api_version(f).into_owned(),
+            api_version: K::api_version(rtt).into_owned(),
             kind: kind.into_owned(),
-            group: K::group(f).into_owned(),
-            version: K::version(f).into_owned(),
+            group: K::group(rtt).into_owned(),
+            version: K::version(rtt).into_owned(),
             namespace: Some(ns.to_string()),
         }
     }
@@ -65,7 +65,7 @@ impl Resource {
     /// Cluster level resources, or resources viewed across all namespaces
     pub fn all<K: Meta>() -> Self
     where
-        <K as Meta>::Family: Default,
+        <K as Meta>::DynamicType: Default,
     {
         Self::all_with::<K>(&Default::default())
     }
@@ -73,7 +73,7 @@ impl Resource {
     /// Namespaced resource within a given namespace
     pub fn namespaced<K: Meta>(ns: &str) -> Self
     where
-        <K as Meta>::Family: Default,
+        <K as Meta>::DynamicType: Default,
     {
         Self::namespaced_with::<K>(ns, &Default::default())
     }

--- a/kube/src/api/resource.rs
+++ b/kube/src/api/resource.rs
@@ -36,12 +36,12 @@ impl Resource {
     /// Cluster level resources, or resources viewed across all namespaces
     ///
     /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
-    pub fn all_with<K: Meta>(rtt: &K::DynamicType) -> Self {
+    pub fn all_with<K: Meta>(dyntype: &K::DynamicType) -> Self {
         Self {
-            api_version: K::api_version(rtt).into_owned(),
-            kind: K::kind(rtt).into_owned(),
-            group: K::group(rtt).into_owned(),
-            version: K::version(rtt).into_owned(),
+            api_version: K::api_version(dyntype).into_owned(),
+            kind: K::kind(dyntype).into_owned(),
+            group: K::group(dyntype).into_owned(),
+            version: K::version(dyntype).into_owned(),
             namespace: None,
         }
     }
@@ -49,8 +49,8 @@ impl Resource {
     /// Namespaced resource within a given namespace
     ///
     /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
-    pub fn namespaced_with<K: Meta>(ns: &str, rtt: &K::DynamicType) -> Self {
-        let kind = K::kind(rtt);
+    pub fn namespaced_with<K: Meta>(ns: &str, dyntype: &K::DynamicType) -> Self {
+        let kind = K::kind(dyntype);
         match kind.as_ref() {
             "Node" | "Namespace" | "ClusterRole" | "CustomResourceDefinition" => {
                 panic!("{} is not a namespace scoped resource", kind)
@@ -58,10 +58,10 @@ impl Resource {
             _ => {}
         }
         Self {
-            api_version: K::api_version(rtt).into_owned(),
+            api_version: K::api_version(dyntype).into_owned(),
             kind: kind.into_owned(),
-            group: K::group(rtt).into_owned(),
-            version: K::version(rtt).into_owned(),
+            group: K::group(dyntype).into_owned(),
+            version: K::version(dyntype).into_owned(),
             namespace: Some(ns.to_string()),
         }
     }

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -33,7 +33,7 @@ pub struct Api<K> {
 impl<K> Api<K>
 where
     K: Meta,
-    <K as Meta>::Family: Default,
+    <K as Meta>::DynamicType: Default,
 {
     /// Cluster level resources, or resources viewed across all namespaces
     pub fn all(client: Client) -> Self {
@@ -53,9 +53,9 @@ where
 {
     /// Cluster level resources, or resources viewed across all namespaces
     ///
-    /// This function accepts `K::Family` so it can be used with dynamic resources.
-    pub fn all_with(client: Client, family: &K::Family) -> Self {
-        let resource = Resource::all_with::<K>(family);
+    /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
+    pub fn all_with(client: Client, rtt: &K::DynamicType) -> Self {
+        let resource = Resource::all_with::<K>(rtt);
         Self {
             resource,
             client,
@@ -65,9 +65,9 @@ where
 
     /// Namespaced resource within a given namespace
     ///
-    /// This function accepts `K::Family` so it can be used with dynamic resources.
-    pub fn namespaced_with(client: Client, ns: &str, family: &K::Family) -> Self {
-        let resource = Resource::namespaced_with::<K>(ns, family);
+    /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
+    pub fn namespaced_with(client: Client, ns: &str, rtt: &K::DynamicType) -> Self {
+        let resource = Resource::namespaced_with::<K>(ns, rtt);
         Self {
             resource,
             client,
@@ -76,7 +76,7 @@ where
     }
 
     /// Returns reference to the underlying `Resource` object.
-    /// It can be used to make low-level requests or as a `Family`
+    /// It can be used to make low-level requests or as a `DynamicType`
     /// for a `DynamicObject`.
     pub fn resource(&self) -> &Resource {
         &self.resource

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -54,8 +54,8 @@ where
     /// Cluster level resources, or resources viewed across all namespaces
     ///
     /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
-    pub fn all_with(client: Client, rtt: &K::DynamicType) -> Self {
-        let resource = Resource::all_with::<K>(rtt);
+    pub fn all_with(client: Client, dyntype: &K::DynamicType) -> Self {
+        let resource = Resource::all_with::<K>(dyntype);
         Self {
             resource,
             client,
@@ -66,8 +66,8 @@ where
     /// Namespaced resource within a given namespace
     ///
     /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
-    pub fn namespaced_with(client: Client, ns: &str, rtt: &K::DynamicType) -> Self {
-        let resource = Resource::namespaced_with::<K>(ns, rtt);
+    pub fn namespaced_with(client: Client, ns: &str, dyntype: &K::DynamicType) -> Self {
+        let resource = Resource::namespaced_with::<K>(ns, dyntype);
         Self {
             resource,
             client,


### PR DESCRIPTION
Was originally thinking to rename it `RuntimeGVK` because we only ever set it to `()` or `GroupVersionKind` internally (and if someone else were to implement it, the associated type needs to have ways to access GVK params to complete the parts of the trait).

However, seeing these acronyms in type names everywhere, I changed my mind.

Currently, thinking just `RuntimeType` is better. So here's a PR doing that, just to see how much it touches.
