### PR TITLE
rename Resource to RequestBuilder for #465

### DIFF
--- a/kube/src/api/mod.rs
+++ b/kube/src/api/mod.rs
@@ -13,8 +13,9 @@ pub(crate) mod params;
 pub use params::{
     DeleteParams, ListParams, Patch, PatchParams, PostParams, Preconditions, PropagationPolicy,
 };
+// TODO: rename files to requests.rs
 mod resource;
-pub use resource::Resource;
+pub use resource::RequestBuilder;
 
 pub(crate) mod typed;
 pub use typed::Api;

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use tracing::instrument;
 
 use crate::{
-    api::{Api, DeleteParams, Patch, PatchParams, PostParams, Resource},
+    api::{Api, DeleteParams, Patch, PatchParams, PostParams, RequestBuilder},
     client::Status,
     Error, Result,
 };
@@ -153,7 +153,7 @@ pub struct LogParams {
     pub timestamps: bool,
 }
 
-impl Resource {
+impl RequestBuilder {
     /// Get a pod logs
     pub fn logs(&self, name: &str, lp: &LogParams) -> Result<http::Request<Vec<u8>>> {
         let base_url = self.make_url() + "/" + name + "/" + "log?";
@@ -199,9 +199,9 @@ impl Resource {
 
 #[test]
 fn log_path() {
-    use crate::api::Resource;
+    use crate::api::RequestBuilder;
     use k8s_openapi::api::core::v1 as corev1;
-    let r = Resource::namespaced::<corev1::Pod>("ns");
+    let r = RequestBuilder::namespaced::<corev1::Pod>("ns");
     let lp = LogParams {
         container: Some("blah".into()),
         ..LogParams::default()
@@ -247,7 +247,7 @@ pub struct EvictParams {
     pub post_options: PostParams,
 }
 
-impl Resource {
+impl RequestBuilder {
     /// Create an eviction
     pub fn evict(&self, name: &str, ep: &EvictParams) -> Result<http::Request<Vec<u8>>> {
         let base_url = self.make_url() + "/" + name + "/" + "eviction?";
@@ -271,9 +271,9 @@ impl Resource {
 
 #[test]
 fn evict_path() {
-    use crate::api::Resource;
+    use crate::api::RequestBuilder;
     use k8s_openapi::api::core::v1 as corev1;
-    let r = Resource::namespaced::<corev1::Pod>("ns");
+    let r = RequestBuilder::namespaced::<corev1::Pod>("ns");
     let ep = EvictParams::default();
     let req = r.evict("foo", &ep).unwrap();
     assert_eq!(req.uri(), "/api/v1/namespaces/ns/pods/foo/eviction?");
@@ -462,7 +462,7 @@ impl AttachParams {
 
 #[cfg(feature = "ws")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
-impl Resource {
+impl RequestBuilder {
     /// Attach to a pod
     pub fn attach(&self, name: &str, ap: &AttachParams) -> Result<http::Request<Vec<u8>>> {
         ap.validate()?;
@@ -479,9 +479,9 @@ impl Resource {
 #[cfg(feature = "ws")]
 #[test]
 fn attach_path() {
-    use crate::api::Resource;
+    use crate::api::RequestBuilder;
     use k8s_openapi::api::core::v1 as corev1;
-    let r = Resource::namespaced::<corev1::Pod>("ns");
+    let r = RequestBuilder::namespaced::<corev1::Pod>("ns");
     let ap = AttachParams {
         container: Some("blah".into()),
         ..AttachParams::default()
@@ -522,7 +522,7 @@ where
 // ----------------------------------------------------------------------------
 #[cfg(feature = "ws")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
-impl Resource {
+impl RequestBuilder {
     /// Execute command in a pod
     pub fn exec<I, T>(&self, name: &str, command: I, ap: &AttachParams) -> Result<http::Request<Vec<u8>>>
     where
@@ -547,9 +547,9 @@ impl Resource {
 #[cfg(feature = "ws")]
 #[test]
 fn exec_path() {
-    use crate::api::Resource;
+    use crate::api::RequestBuilder;
     use k8s_openapi::api::core::v1 as corev1;
-    let r = Resource::namespaced::<corev1::Pod>("ns");
+    let r = RequestBuilder::namespaced::<corev1::Pod>("ns");
     let ap = AttachParams {
         container: Some("blah".into()),
         ..AttachParams::default()

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -5,20 +5,24 @@ use std::{fmt::Debug, iter};
 use tracing::instrument;
 
 use crate::{
-    api::{DeleteParams, ListParams, Meta, ObjectList, Patch, PatchParams, PostParams, Resource, WatchEvent},
+    api::{
+        DeleteParams, ListParams, Meta, ObjectList, Patch, PatchParams, PostParams, RequestBuilder,
+        WatchEvent,
+    },
     client::{Client, Status},
     Result,
 };
 
-/// A generic Api abstraction
+/// The generic Api abstraction
 ///
-/// This abstracts over a [`Resource`] and a type `K` so that
-/// we get automatic serialization/deserialization on the api calls
-/// implemented by the dynamic [`Resource`].
+/// This abstracts over a request builder and a resource of type `K` to provide
+/// automatic serialization/deserialization to and from `K` in api calls.
+///
+/// This abstraction takes a [`Client`] (cheap to clone) and awaits the result internally.
 #[derive(Clone)]
 pub struct Api<K> {
     /// The request creator object
-    pub(crate) resource: Resource,
+    pub(crate) resource: RequestBuilder,
     /// The client to use (from this library)
     pub(crate) client: Client,
     /// Underlying Object unstored
@@ -55,7 +59,7 @@ where
     ///
     /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
     pub fn all_with(client: Client, dyntype: &K::DynamicType) -> Self {
-        let resource = Resource::all_with::<K>(dyntype);
+        let resource = RequestBuilder::all_with::<K>(dyntype);
         Self {
             resource,
             client,
@@ -67,7 +71,7 @@ where
     ///
     /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
     pub fn namespaced_with(client: Client, ns: &str, dyntype: &K::DynamicType) -> Self {
-        let resource = Resource::namespaced_with::<K>(ns, dyntype);
+        let resource = RequestBuilder::namespaced_with::<K>(ns, dyntype);
         Self {
             resource,
             client,
@@ -78,7 +82,7 @@ where
     /// Returns reference to the underlying `Resource` object.
     /// It can be used to make low-level requests or as a `DynamicType`
     /// for a `DynamicObject`.
-    pub fn resource(&self) -> &Resource {
+    pub fn resource(&self) -> &RequestBuilder {
         &self.resource
     }
 

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -96,7 +96,7 @@ pub mod error;
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub use kube_derive::CustomResource;
 
-pub use api::{Api, DynamicResource, Resource};
+pub use api::{Api, DynamicResource, RequestBuilder};
 #[doc(inline)] pub use client::Client;
 #[doc(inline)] pub use config::Config;
 #[doc(inline)] pub use error::Error;


### PR DESCRIPTION
Done the initial rename plus some documentation, but still need a full overhaul of internal names that use the word "resource".
Also want to do a file rename of `resource.rs` to `requests.rs`.