### PR TITLE
add plural to Resource and GroupVersionKind

### DIFF
--- a/examples/crd_derive_no_schema.rs
+++ b/examples/crd_derive_no_schema.rs
@@ -60,14 +60,14 @@ fn main() {
 #[cfg(not(feature = "schema"))]
 #[test]
 fn verify_bar_is_a_custom_resource() {
-    use k8s_openapi::Resource;
+    use kube::Resource;
     use schemars::JsonSchema; // only for ensuring it's not implemented
     use static_assertions::{assert_impl_all, assert_not_impl_any};
 
-    println!("Kind {}", Bar::KIND);
+    println!("Kind {}", Bar::kind(&()));
     let bar = Bar::new("five", MyBar { bars: 5 });
     println!("Spec: {:?}", bar.spec);
-    assert_impl_all!(Bar: k8s_openapi::Resource, k8s_openapi::Metadata);
+    assert_impl_all!(Bar: kube::Resource);
     assert_not_impl_any!(MyBar: JsonSchema); // but no schemars schema implemented
 
     let crd = Bar::crd_with_manual_schema();

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -28,6 +28,7 @@ schema = []
 [dev-dependencies]
 serde = { version = "1.0.118", features = ["derive"] }
 serde_yaml = "0.8.17"
+kube = { path = "../kube", version = "^0.51.0"}
 k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_20"] }
 schemars = { version = "0.8.0", features = ["chrono"] }
 chrono = "0.4.19"

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -178,29 +178,33 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
     };
 
     // 2. Implement Resource trait
+    let name = singular.unwrap_or_else(|| kind.to_ascii_lowercase());
+    let plural = plural.unwrap_or_else(|| to_plural(&name));
+    let scope = if namespaced { "Namespaced" } else { "Cluster" };
+
     let api_ver = format!("{}/{}", group, version);
     let impl_resource = quote! {
         impl kube::Resource for #rootident {
             type DynamicType = ();
 
-            fn kind<'a>(_: &'a ()) -> std::borrow::Cow<'a, str> {
-                #kind.into()
-            }
-
-            fn plural<'a>(_: &'a ()) -> std::borrow::Cow<'a, str> {
-                #plural.into()
-            }
-
-            fn group<'a>(_: &'a ()) -> std::borrow::Cow<'a, str> {
+            fn group(_: &()) -> std::borrow::Cow<'_, str> {
                #group.into()
             }
 
-            fn version<'a>(_: &'a ()) -> std::borrow::Cow<'a, str> {
+            fn kind(_: &()) -> std::borrow::Cow<'_, str> {
+                #kind.into()
+            }
+
+            fn version(_: &()) -> std::borrow::Cow<'_, str> {
                 #version.into()
             }
 
-            fn api_version<'a>(_: &'a ()) -> std::borrow::Cow<'a, str> {
+            fn api_version(_: &()) -> std::borrow::Cow<'_, str> {
                 #api_ver.into()
+            }
+
+            fn plural(_: &()) -> std::borrow::Cow<'_, str> {
+                #plural.into()
             }
 
             fn meta(&self) -> &kube::api::ObjectMeta {
@@ -241,9 +245,6 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
     };
 
     // 4. Implement CustomResource
-    let name = singular.unwrap_or_else(|| kind.to_ascii_lowercase());
-    let plural = plural.unwrap_or_else(|| to_plural(&name));
-    let scope = if namespaced { "Namespaced" } else { "Cluster" };
 
     // Compute a bunch of crd props
     let mut printers = format!("[ {} ]", printcolums.join(",")); // hacksss

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -20,7 +20,7 @@ mod custom_resource;
 ///
 /// ```rust
 /// use serde::{Serialize, Deserialize};
-/// use k8s_openapi::Resource;
+/// use kube::Resource;
 /// use kube_derive::CustomResource;
 /// use schemars::JsonSchema;
 ///
@@ -30,7 +30,7 @@ mod custom_resource;
 ///     info: String,
 /// }
 ///
-/// println!("kind = {}", Foo::KIND); // impl k8s_openapi::Resource
+/// println!("kind = {}", Foo::kind(&())); // impl kube::Resource
 /// let f = Foo::new("foo-1", FooSpec {
 ///     info: "informative info".into(),
 /// });

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -10,8 +10,8 @@ mod custom_resource;
 /// A custom derive for kubernetes custom resource definitions.
 ///
 /// This will generate a **root object** containing your spec and metadata.
-/// This root object will implement the [`k8s_openapi::Metadata`] + [`k8s_openapi::Resource`]
-/// traits so it can be used with [`kube::Api`].
+/// This root object will implement the [`kube::Resource`] trait
+/// so it can be used with [`kube::Api`].
 ///
 /// The generated type will also implement a `::crd` method to generate the crd
 /// at the specified api version (or `v1` if unspecified).
@@ -149,8 +149,7 @@ mod custom_resource;
 ///     spec: FooSpec,
 ///     status: Option<FooStatus>,
 /// }
-/// impl k8s_openapi::Resource for FooCrd {...}
-/// impl k8s_openapi::Metadata for FooCrd {...}
+/// impl kube::Resource for FooCrd {...}
 ///
 /// impl FooCrd {
 ///     pub fn new(name: &str, spec: FooSpec) -> Self { ... }
@@ -196,8 +195,7 @@ mod custom_resource;
 ///
 /// [`kube`]: https://docs.rs/kube
 /// [`kube::Api`]: https://docs.rs/kube/*/kube/struct.Api.html
-/// [`k8s_openapi::Metadata`]: https://docs.rs/k8s-openapi/*/k8s_openapi/trait.Metadata.html
-/// [`k8s_openapi::Resource`]: https://docs.rs/k8s-openapi/*/k8s_openapi/trait.Resource.html
+/// [`kube::Resource`]: https://docs.rs/kube/*/kube/trait.Resource.html
 #[proc_macro_derive(CustomResource, attributes(kube))]
 pub fn derive_custom_resource(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     custom_resource::derive(proc_macro2::TokenStream::from(input)).into()

--- a/kube/src/api/dynamic.rs
+++ b/kube/src/api/dynamic.rs
@@ -166,7 +166,7 @@ impl Resource for DynamicObject {
         dt.api_version.as_str().into()
     }
 
-    fn plural<'a>(dt: &'a Self::DynamicType) -> Cow<'a, str> {
+    fn plural(dt: &Self::DynamicType) -> Cow<'_, str> {
         if let Some(plural) = &dt.plural {
             plural.into()
         } else {

--- a/kube/src/api/dynamic.rs
+++ b/kube/src/api/dynamic.rs
@@ -54,12 +54,13 @@ impl GroupVersionKind {
         } else {
             format!("{}/{}", group, version)
         };
+        let plural = Some(ar.name.clone());
         Self {
             group,
             version,
             kind,
             api_version,
-            plural: None,
+            plural,
         }
     }
 
@@ -149,20 +150,29 @@ impl DynamicObject {
 impl Resource for DynamicObject {
     type DynamicType = GroupVersionKind;
 
-    fn group(f: &GroupVersionKind) -> Cow<'_, str> {
-        f.group.as_str().into()
+    fn group(dt: &GroupVersionKind) -> Cow<'_, str> {
+        dt.group.as_str().into()
     }
 
-    fn version(f: &GroupVersionKind) -> Cow<'_, str> {
-        f.version.as_str().into()
+    fn version(dt: &GroupVersionKind) -> Cow<'_, str> {
+        dt.version.as_str().into()
     }
 
-    fn kind(f: &GroupVersionKind) -> Cow<'_, str> {
-        f.kind.as_str().into()
+    fn kind(dt: &GroupVersionKind) -> Cow<'_, str> {
+        dt.kind.as_str().into()
     }
 
-    fn api_version(f: &GroupVersionKind) -> Cow<'_, str> {
-        f.api_version.as_str().into()
+    fn api_version(dt: &GroupVersionKind) -> Cow<'_, str> {
+        dt.api_version.as_str().into()
+    }
+
+    fn plural<'a>(dt: &'a Self::DynamicType) -> Cow<'a, str> {
+        if let Some(plural) = &dt.plural {
+            plural.into()
+        } else {
+            // fallback to inference
+            crate::api::metadata::to_plural(&Self::kind(dt).to_ascii_lowercase()).into()
+        }
     }
 
     fn meta(&self) -> &ObjectMeta {

--- a/kube/src/api/dynamic.rs
+++ b/kube/src/api/dynamic.rs
@@ -16,6 +16,8 @@ pub struct GroupVersionKind {
     kind: String,
     /// Concatenation of group and version
     api_version: String,
+    /// Optional plural/resource
+    plural: Option<String>,
 }
 
 impl GroupVersionKind {
@@ -57,6 +59,7 @@ impl GroupVersionKind {
             version,
             kind,
             api_version,
+            plural: None,
         }
     }
 
@@ -87,7 +90,14 @@ impl GroupVersionKind {
             version,
             kind,
             api_version,
+            plural: None,
         })
+    }
+
+    /// Set an explicit plural/resource value to avoid relying on inferred pluralisation.
+    pub fn plural(mut self, plural: &str) -> Self {
+        self.plural = Some(plural.to_string());
+        self
     }
 }
 

--- a/kube/src/api/dynamic.rs
+++ b/kube/src/api/dynamic.rs
@@ -228,6 +228,7 @@ mod test {
     #[tokio::test]
     #[ignore] // circle has no kubeconfig
     async fn convenient_custom_resource() {
+        use crate as kube; // derive macro needs kube in scope
         use crate::{Api, Client, CustomResource};
         use schemars::JsonSchema;
         use serde::{Deserialize, Serialize};

--- a/kube/src/api/metadata.rs
+++ b/kube/src/api/metadata.rs
@@ -137,7 +137,7 @@ pub struct TypeMeta {
 }
 
 // Simple pluralizer. Handles the special cases.
-fn to_plural(word: &str) -> String {
+pub(crate) fn to_plural(word: &str) -> String {
     if word == "endpoints" || word == "endpointslices" {
         return word.to_owned();
     } else if word == "nodemetrics" {

--- a/kube/src/api/metadata.rs
+++ b/kube/src/api/metadata.rs
@@ -50,7 +50,7 @@ pub trait Resource {
     /// `k8s_openapi` types, where we maintain a list of special pluralisations for compatibility.
     ///
     /// Thus when used with `DynamicObject` or `kube-derive`, we override this with correct values.
-    fn plural<'a>(dt: &'a Self::DynamicType) -> Cow<'a, str> {
+    fn plural(dt: &Self::DynamicType) -> Cow<'_, str> {
         to_plural(&Self::kind(dt).to_ascii_lowercase()).into()
     }
 

--- a/kube/src/api/metadata.rs
+++ b/kube/src/api/metadata.rs
@@ -90,15 +90,15 @@ where
 {
     type DynamicType = ();
 
-    fn kind<'a>(_: &()) -> Cow<'_, str> {
+    fn kind(_: &()) -> Cow<'_, str> {
         K::KIND.into()
     }
 
-    fn group<'a>(_: &()) -> Cow<'_, str> {
+    fn group(_: &()) -> Cow<'_, str> {
         K::GROUP.into()
     }
 
-    fn version<'a>(_: &()) -> Cow<'_, str> {
+    fn version(_: &()) -> Cow<'_, str> {
         K::VERSION.into()
     }
 

--- a/kube/src/api/typed.rs
+++ b/kube/src/api/typed.rs
@@ -89,6 +89,11 @@ impl<K: Resource> Api<K> {
     pub fn into_client(self) -> Client {
         self.into()
     }
+
+    /// Return a reference to the current resource url path
+    pub fn resource_url(&self) -> &str {
+        &self.request.url_path
+    }
 }
 
 /// PUSH/PUT/POST/GET abstractions


### PR DESCRIPTION
replaces #468.
closes #467

This changes kube-derive to no longer implement `k8s_openapi` traits.
We now instead implement `kube::Resource` instead so we can control the plural.

Because the trait now picks up on an override when it is generating the `path_url`, it is now correct in the `Api` urls.