### PR TITLE
make Object a more usable

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -89,6 +89,10 @@ name = "dynamic_api"
 path = "dynamic_api.rs"
 
 [[example]]
+name = "dynamic_pod"
+path = "dynamic_pod.rs"
+
+[[example]]
 name = "event_watcher"
 path = "event_watcher.rs"
 

--- a/examples/dynamic_pod.rs
+++ b/examples/dynamic_pod.rs
@@ -1,9 +1,9 @@
 use kube::{
-    api::{Api, Object, ResourceExt, ApiResource, NotUsed},
-    Client
+    api::{Api, ApiResource, NotUsed, Object, ResourceExt},
+    Client,
 };
-use serde::Deserialize;
 use log::info;
+use serde::Deserialize;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/dynamic_pod.rs
+++ b/examples/dynamic_pod.rs
@@ -22,7 +22,9 @@ async fn main() -> anyhow::Result<()> {
     }
     type PodSimple = Object<PodSpecSimple, NotUsed>;
 
+    // Here we simply steal the type info from k8s_openapi, but we could create this from scratch.
     let ar = ApiResource::erase::<k8s_openapi::api::core::v1::Pod>(&());
+
     let pods: Api<PodSimple> = Api::namespaced_with(client, "default", &ar);
     for p in pods.list(&Default::default()).await? {
         info!("Found pod {} running: {:?}", p.name(), p.spec.containers);

--- a/examples/dynamic_pod.rs
+++ b/examples/dynamic_pod.rs
@@ -1,0 +1,32 @@
+use kube::{
+    api::{Api, Object, ResourceExt, ApiResource, NotUsed},
+    Client
+};
+use serde::Deserialize;
+use log::info;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    std::env::set_var("RUST_LOG", "info,kube=debug");
+    env_logger::init();
+    let client = Client::try_default().await?;
+
+    // Here we replace heavy type k8s_openapi::api::core::v1::PodSpec with
+    #[derive(Clone, Deserialize, Debug)]
+    struct PodSpecSimple {
+        containers: Vec<ContainerSimple>,
+    }
+    #[derive(Clone, Deserialize, Debug)]
+    struct ContainerSimple {
+        image: String,
+    }
+    type PodSimple = Object<PodSpecSimple, NotUsed>;
+
+    let ar = ApiResource::erase::<k8s_openapi::api::core::v1::Pod>(&());
+    let pods: Api<PodSimple> = Api::namespaced_with(client, "default", &ar);
+    for p in pods.list(&Default::default()).await? {
+        info!("Found pod {} running: {:?}", p.name(), p.spec.containers);
+    }
+
+    Ok(())
+}

--- a/examples/pod_api.rs
+++ b/examples/pod_api.rs
@@ -17,6 +17,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Manage pods
     let pods: Api<Pod> = Api::namespaced(client, &namespace);
+    for p in pods.list(&Default::default()).await? {
+        use kube::ResourceExt;
+        info!("found pod {}", p.name());
+    }
 
     // Create Pod blog
     info!("Creating Pod instance blog");

--- a/examples/pod_api.rs
+++ b/examples/pod_api.rs
@@ -17,10 +17,6 @@ async fn main() -> anyhow::Result<()> {
 
     // Manage pods
     let pods: Api<Pod> = Api::namespaced(client, &namespace);
-    for p in pods.list(&Default::default()).await? {
-        use kube::ResourceExt;
-        info!("found pod {}", p.name());
-    }
 
     // Create Pod blog
     info!("Creating Pod instance blog");

--- a/kube-core/src/object.rs
+++ b/kube-core/src/object.rs
@@ -118,9 +118,9 @@ where
     P: Clone,
     U: Clone,
 {
-    /// The types field of an `Object`
-    #[serde(flatten)]
-    pub types: TypeMeta,
+    /// The type fields, not always present
+    #[serde(flatten, default)]
+    pub types: Option<TypeMeta>,
 
     /// Resource metadata
     ///
@@ -149,10 +149,10 @@ where
     /// A constructor that takes Resource values from an `ApiResource`
     pub fn new(name: &str, ar: &ApiResource, spec: P) -> Self {
         Self {
-            types: TypeMeta {
+            types: Some(TypeMeta {
                 api_version: ar.api_version.clone(),
                 kind: ar.kind.clone(),
-            },
+            }),
             metadata: ObjectMeta {
                 name: Some(name.to_string()),
                 ..Default::default()
@@ -235,7 +235,7 @@ mod test {
         let mypod = PodSimple::new("blog", &ar, data).within("dev");
         assert_eq!(mypod.metadata.namespace.unwrap(), "dev");
         assert_eq!(mypod.metadata.name.unwrap(), "blog");
-        assert_eq!(mypod.types.kind, "Pod");
-        assert_eq!(mypod.types.api_version, "v1");
+        assert_eq!(mypod.types.as_ref().unwrap().kind, "Pod");
+        assert_eq!(mypod.types.as_ref().unwrap().api_version, "v1");
     }
 }

--- a/kube-core/src/object.rs
+++ b/kube-core/src/object.rs
@@ -112,7 +112,7 @@ impl<'a, T: Clone> IntoIterator for &'a mut ObjectList<T> {
 ///
 /// This can be used to tie existing resources to smaller, local struct variants to optimize for memory use.
 /// E.g. if you are only interested in a few fields, but you store tons of them in memory with reflectors.
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Object<P, U>
 where
     P: Clone,


### PR DESCRIPTION
`Object` wasn't really very usable before since it required `k8s_openapi` impls (so my past use of it had to use `Request` directly). Now though, with `DynamicType` in `Resource` trait, we can avoid that.

This implements the same `Resource` style impl when `DynamicType=ApiResource`.

This effectively lets users have a way do typed queries using `Api<Object<P,U>>` without having to do a full kube-derive setup, and reusing the erased resource from an existing type (see test example).
