### PR TITLE
Request: support arbitrary subresources

### DIFF
--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -12,8 +12,7 @@ use crate::{
 
 pub use k8s_openapi::api::autoscaling::v1::{Scale, ScaleSpec, ScaleStatus};
 
-#[cfg(feature = "ws")]
-use crate::api::remote_command::AttachedProcess;
+#[cfg(feature = "ws")] use crate::api::remote_command::AttachedProcess;
 
 /// Methods for [scale subresource](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#scale-subresource).
 impl<K> Api<K>

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -12,7 +12,8 @@ use crate::{
 
 pub use k8s_openapi::api::autoscaling::v1::{Scale, ScaleSpec, ScaleStatus};
 
-#[cfg(feature = "ws")] use crate::api::remote_command::AttachedProcess;
+#[cfg(feature = "ws")]
+use crate::api::remote_command::AttachedProcess;
 
 /// Methods for [scale subresource](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#scale-subresource).
 impl<K> Api<K>
@@ -22,7 +23,7 @@ where
     /// Fetch the scale subresource
     #[instrument(skip(self), level = "trace")]
     pub async fn get_scale(&self, name: &str) -> Result<Scale> {
-        let req = self.request.get_scale(name)?;
+        let req = self.request.get_subresource("scale", name)?;
         self.client.request::<Scale>(req).await
     }
 
@@ -34,14 +35,14 @@ where
         pp: &PatchParams,
         patch: &Patch<P>,
     ) -> Result<Scale> {
-        let req = self.request.patch_scale(name, &pp, patch)?;
+        let req = self.request.patch_subresource("scale", name, &pp, patch)?;
         self.client.request::<Scale>(req).await
     }
 
     /// Replace the scale subresource
     #[instrument(skip(self), level = "trace")]
     pub async fn replace_scale(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<Scale> {
-        let req = self.request.replace_scale(name, &pp, data)?;
+        let req = self.request.replace_subresource("scale", name, &pp, data)?;
         self.client.request::<Scale>(req).await
     }
 }
@@ -60,7 +61,7 @@ where
     /// This actually returns the whole K, with metadata, and spec.
     #[instrument(skip(self), level = "trace")]
     pub async fn get_status(&self, name: &str) -> Result<K> {
-        let req = self.request.get_status(name)?;
+        let req = self.request.get_subresource("status", name)?;
         self.client.request::<K>(req).await
     }
 
@@ -94,7 +95,7 @@ where
         pp: &PatchParams,
         patch: &Patch<P>,
     ) -> Result<K> {
-        let req = self.request.patch_status(name, &pp, patch)?;
+        let req = self.request.patch_subresource("status", name, &pp, patch)?;
         self.client.request::<K>(req).await
     }
 
@@ -119,7 +120,7 @@ where
     /// ```
     #[instrument(skip(self), level = "trace")]
     pub async fn replace_status(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<K> {
-        let req = self.request.replace_status(name, &pp, data)?;
+        let req = self.request.replace_subresource("status", name, &pp, data)?;
         self.client.request::<K>(req).await
     }
 }


### PR DESCRIPTION
This PR only changes low-level `Request`; `Api` is left untouched.

This way users can work with exotic subresources (such as `certificatesigningrequests/approval`) without directly manipulating URLs.