### PR TITLE
Support v1beta1 only admission controllers

### DIFF
--- a/examples/admission_controller.rs
+++ b/examples/admission_controller.rs
@@ -41,7 +41,7 @@ async fn main() {
 }
 
 async fn mutate_handler(body: AdmissionReview<DynamicObject>) -> Result<impl Reply, Infallible> {
-    let req: AdmissionRequest<DynamicObject> = match body.try_into() {
+    let req: AdmissionRequest<_> = match body.try_into() {
         Ok(req) => req,
         Err(err) => {
             error!("invalid request: {}", err.to_string());


### PR DESCRIPTION
For clusters which only support the `admission.k8s.io/v1beta1` api
version, the hardcoded version in the `AdmissionResponse::into_review`
caused responses to fail. This patches the constructors to pass through
the original `TypeMeta` from the request into the response.

Also adds some doc code snippets under the `Admission{Request,Response}`
types. Hopefully they're useful.