### PR TITLE
Separate GVK from ApiResource

### DIFF
--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -148,7 +148,7 @@ async fn main() -> Result<()> {
     });
 
     // Set up dynamic resource to test using raw values.
-    let gvk = GroupVersionKind::gvk("clux.dev", "v1", "Foo")?;
+    let gvk = GroupVersionKind::gvk("clux.dev", "v1", "Foo");
     let api_resource = ApiResource::from_gvk(&gvk);
     let dynapi: Api<DynamicObject> = Api::namespaced_with(client.clone(), &namespace, &api_resource);
 

--- a/examples/dynamic_api.rs
+++ b/examples/dynamic_api.rs
@@ -3,7 +3,10 @@
 
 use kube::{
     api::{Api, DynamicObject, ResourceExt},
-    client::{Client, Discovery, Scope},
+    client::{
+        discovery::{verbs, Discovery, Scope},
+        Client,
+    },
 };
 use log::info;
 
@@ -23,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
     for group in discovery.groups() {
         let ver = group.preferred_version_or_guess();
         for (api_res, extras) in group.resources_by_version(ver) {
-            if !extras.operations.list {
+            if !extras.supports_operation(verbs::LIST) {
                 continue;
             }
             let api: Api<DynamicObject> = if extras.scope == Scope::Namespaced {

--- a/examples/dynamic_api.rs
+++ b/examples/dynamic_api.rs
@@ -2,9 +2,8 @@
 //! to `kubectl get all --all-namespaces`.
 
 use kube::{
-    api::{Api, DynamicObject, Resource, ResourceExt},
-    client::Discovery,
-    Client,
+    api::{Api, ApiResource, DynamicObject, Resource, ResourceExt},
+    client::{Client, Discovery},
 };
 use log::{info, warn};
 

--- a/examples/dynamic_watcher.rs
+++ b/examples/dynamic_watcher.rs
@@ -18,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
     let kind = env::var("KIND").unwrap_or_else(|_| "Foo".into());
 
     // Turn them into a GVK
-    let gvk = GroupVersionKind::gvk(&group, &version, &kind)?;
+    let gvk = GroupVersionKind::gvk(&group, &version, &kind);
     let api_resource = ApiResource::from_gvk(&gvk);
     // Use them in an Api with the GVK as its DynamicType
     let api = Api::<DynamicObject>::all_with(client, &api_resource);

--- a/examples/dynamic_watcher.rs
+++ b/examples/dynamic_watcher.rs
@@ -1,6 +1,6 @@
 use futures::prelude::*;
 use kube::{
-    api::{DynamicObject, GroupVersionKind, ListParams, ResourceExt},
+    api::{ApiResource, DynamicObject, GroupVersionKind, ListParams, ResourceExt},
     Api, Client,
 };
 use kube_runtime::{utils::try_flatten_applied, watcher};
@@ -19,8 +19,9 @@ async fn main() -> anyhow::Result<()> {
 
     // Turn them into a GVK
     let gvk = GroupVersionKind::gvk(&group, &version, &kind)?;
+    let api_resource = ApiResource::from_gvk(&gvk);
     // Use them in an Api with the GVK as its DynamicType
-    let api = Api::<DynamicObject>::all_with(client, &gvk);
+    let api = Api::<DynamicObject>::all_with(client, &api_resource);
 
     // Fully compatible with kube-runtime
     let watcher = watcher(api, ListParams::default());

--- a/examples/dynamic_watcher.rs
+++ b/examples/dynamic_watcher.rs
@@ -19,7 +19,17 @@ async fn main() -> anyhow::Result<()> {
 
     // Turn them into a GVK
     let gvk = GroupVersionKind::gvk(&group, &version, &kind);
-    let api_resource = ApiResource::from_gvk(&gvk);
+    let mut api_resource = ApiResource::from_gvk(&gvk);
+
+    if let Some(resource) = env::var("RESOURCE").ok() {
+        api_resource.plural = resource;
+    } else {
+        println!(
+            "Using inferred plural name (use RESOURCE to override): {}",
+            api_resource.plural
+        );
+    }
+
     // Use them in an Api with the GVK as its DynamicType
     let api = Api::<DynamicObject>::all_with(client, &api_resource);
 

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -329,7 +329,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         }
     };
 
-    // Implement the ::crd method (fine to not have in a trait as its a generated type)
+    // Implement the ::crd and ::api_resource methods (fine to not have in a trait as its a generated type)
     let impl_crd = quote! {
         impl #rootident {
             pub fn crd() -> #apiext::CustomResourceDefinition {
@@ -356,6 +356,10 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
                 #jsondata
                 serde_json::from_value(jsondata)
                     .expect("valid custom resource from #[kube(attrs..)]")
+            }
+
+            pub fn api_resource() -> kube::api::ApiResource {
+                kube::api::ApiResource::erase::<Self>(&())
             }
         }
     };

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -129,14 +129,6 @@ impl<K: Resource> ObjectRef<K> {
     }
 
     pub fn erase(self) -> ObjectRef<DynamicObject> {
-        let gvk = kube::api::GroupVersionKind::gvk(
-            K::group(&self.dyntype).as_ref(),
-            K::version(&self.dyntype).as_ref(),
-            K::kind(&self.dyntype).as_ref(),
-        )
-        .expect("valid gvk");
-        let mut res = kube::api::ApiResource::from_gvk(&gvk);
-        res.plural = K::plural(&self.dyntype).to_string();
         ObjectRef {
             dyntype: kube::api::ApiResource::erase::<K>(&self.dyntype),
             name: self.name,

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -129,13 +129,16 @@ impl<K: Resource> ObjectRef<K> {
     }
 
     pub fn erase(self) -> ObjectRef<DynamicObject> {
+        let gvk = kube::api::GroupVersionKind::gvk(
+            K::group(&self.dyntype).as_ref(),
+            K::version(&self.dyntype).as_ref(),
+            K::kind(&self.dyntype).as_ref(),
+        )
+        .expect("valid gvk");
+        let mut res = kube::api::ApiResource::from_gvk(&gvk);
+        res.plural_name = K::plural(&self.dyntype).to_string();
         ObjectRef {
-            dyntype: kube::api::GroupVersionKind::gvk(
-                K::group(&self.dyntype).as_ref(),
-                K::version(&self.dyntype).as_ref(),
-                K::kind(&self.dyntype).as_ref(),
-            )
-            .expect("valid gvk"),
+            dyntype: res,
             name: self.name,
             namespace: self.namespace,
         }

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -136,9 +136,9 @@ impl<K: Resource> ObjectRef<K> {
         )
         .expect("valid gvk");
         let mut res = kube::api::ApiResource::from_gvk(&gvk);
-        res.plural_name = K::plural(&self.dyntype).to_string();
+        res.plural = K::plural(&self.dyntype).to_string();
         ObjectRef {
-            dyntype: res,
+            dyntype: kube::api::ApiResource::erase::<K>(&self.dyntype),
             name: self.name,
             namespace: self.namespace,
         }

--- a/kube/src/api/dynamic.rs
+++ b/kube/src/api/dynamic.rs
@@ -301,7 +301,7 @@ mod test {
     };
     #[test]
     fn raw_custom_resource() {
-        let gvk = GroupVersionKind::gvk("clux.dev", "v1", "Foo").unwrap();
+        let gvk = GroupVersionKind::gvk("clux.dev", "v1", "Foo");
         let res = ApiResource::from_gvk(&gvk);
         let url = DynamicObject::url_path(&res, Some("myns"));
 
@@ -318,7 +318,7 @@ mod test {
 
     #[test]
     fn raw_resource_in_default_group() -> Result<()> {
-        let gvk = GroupVersionKind::gvk("", "v1", "Service").unwrap();
+        let gvk = GroupVersionKind::gvk("", "v1", "Service");
         let api_resource = ApiResource::from_gvk(&gvk);
         let url = DynamicObject::url_path(&api_resource, None);
         let pp = PostParams::default();
@@ -342,7 +342,7 @@ mod test {
         }
         let client = Client::try_default().await.unwrap();
 
-        let gvk = GroupVersionKind::gvk("clux.dev", "v1", "Foo").unwrap();
+        let gvk = GroupVersionKind::gvk("clux.dev", "v1", "Foo");
         let api_resource = ApiResource::from_gvk(&gvk);
         let a1: Api<DynamicObject> = Api::namespaced_with(client.clone(), "myns", &api_resource);
         let a2: Api<Foo> = Api::namespaced(client.clone(), "myns");

--- a/kube/src/api/dynamic.rs
+++ b/kube/src/api/dynamic.rs
@@ -1,5 +1,5 @@
 use crate::api::{metadata::TypeMeta, GroupVersionKind, Resource};
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::{APIResource, APIResourceList, ObjectMeta};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{APIResource, ObjectMeta};
 use std::borrow::Cow;
 
 /// Contains information about Kubernetes API resources
@@ -178,116 +178,6 @@ impl Resource for DynamicObject {
 
     fn meta_mut(&mut self) -> &mut ObjectMeta {
         &mut self.metadata
-    }
-}
-
-/// Resource scope
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub enum Scope {
-    /// Objects are global
-    Cluster,
-    /// Each object lives in namespace.
-    Namespaced,
-}
-
-/// Operations that are supported on the resource
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct Operations {
-    /// Object can be created
-    pub create: bool,
-    /// Single object can be queried
-    pub get: bool,
-    /// Multiple objects can be queried
-    pub list: bool,
-    /// A watch can be started
-    pub watch: bool,
-    /// A single object can be deleted
-    pub delete: bool,
-    /// Multiple objects can be deleted
-    pub delete_collection: bool,
-    /// Object can be updated
-    pub update: bool,
-    /// Object can be patched
-    pub patch: bool,
-    /// All other verbs
-    pub other: Vec<String>,
-}
-
-impl Operations {
-    /// Returns empty `Operations`
-    pub fn empty() -> Self {
-        Operations {
-            create: false,
-            get: false,
-            list: false,
-            watch: false,
-            delete: false,
-            delete_collection: false,
-            update: false,
-            patch: false,
-            other: Vec::new(),
-        }
-    }
-}
-/// Contains additional, detailed information abount API resource
-pub struct ApiResourceExtras {
-    /// Scope of the resource
-    pub scope: Scope,
-    /// Available subresources. Please note that returned ApiResources are not
-    /// standalone resources. Their name will be of form `subresource_name`,
-    /// not `resource_name/subresource_name`.
-    /// To work with subresources, use `Request` methods.
-    pub subresources: Vec<(ApiResource, ApiResourceExtras)>,
-    /// Supported operations on this resource
-    pub operations: Operations,
-}
-
-impl ApiResourceExtras {
-    /// Creates ApiResourceExtras from `meta::v1::APIResourceList` instance.
-    /// This function correctly sets all fields except `subresources`.
-    /// # Panics
-    /// Panics if list does not contain resource named `name`.
-    pub fn from_apiresourcelist(list: &APIResourceList, name: &str) -> Self {
-        let ar = list
-            .resources
-            .iter()
-            .find(|r| r.name == name)
-            .expect("resource not found in APIResourceList");
-        let scope = if ar.namespaced {
-            Scope::Namespaced
-        } else {
-            Scope::Cluster
-        };
-        let mut operations = Operations::empty();
-        for verb in &ar.verbs {
-            match verb.as_str() {
-                "create" => operations.create = true,
-                "get" => operations.get = true,
-                "list" => operations.list = true,
-                "watch" => operations.watch = true,
-                "delete" => operations.delete = true,
-                "deletecollection" => operations.delete_collection = true,
-                "update" => operations.update = true,
-                "patch" => operations.patch = true,
-                _ => operations.other.push(verb.clone()),
-            }
-        }
-        let mut subresources = Vec::new();
-        let subresource_name_prefix = format!("{}/", name);
-        for res in &list.resources {
-            if let Some(subresource_name) = res.name.strip_prefix(&subresource_name_prefix) {
-                let mut api_resource = ApiResource::from_apiresource(res, &list.group_version);
-                api_resource.plural = subresource_name.to_string();
-                let extra = ApiResourceExtras::from_apiresourcelist(list, &res.name);
-                subresources.push((api_resource, extra));
-            }
-        }
-
-        ApiResourceExtras {
-            scope,
-            subresources,
-            operations,
-        }
     }
 }
 

--- a/kube/src/api/gvk.rs
+++ b/kube/src/api/gvk.rs
@@ -47,7 +47,7 @@ impl GroupVersionResource {
         } else {
             format!("{}/{}", group, version)
         };
-        
+
         Self {
             group,
             version,

--- a/kube/src/api/gvk.rs
+++ b/kube/src/api/gvk.rs
@@ -1,0 +1,83 @@
+use crate::{Error, Result};
+use serde::{Deserialize, Serialize};
+
+
+/// Contains enough information to identify API Resource.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GroupVersionKind {
+    /// API group
+    pub group: String,
+    /// Version
+    pub version: String,
+    /// Kind
+    pub kind: String,
+}
+
+impl GroupVersionKind {
+    /// Set the api group, version, and kind for a resource
+    pub fn gvk(group_: &str, version_: &str, kind_: &str) -> Result<Self> {
+        let version = version_.to_string();
+        let group = group_.to_string();
+        let kind = kind_.to_string();
+        if version.is_empty() {
+            return Err(Error::DynamicType(format!(
+                "GroupVersionKind '{}' must have a version",
+                kind
+            )));
+        }
+        if kind.is_empty() {
+            return Err(Error::DynamicType(format!(
+                "GroupVersionKind '{}' must have a kind",
+                kind
+            )));
+        }
+        Ok(Self { group, version, kind })
+    }
+}
+
+
+/// Represents a type-erased object resource.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GroupVersionResource {
+    /// API group
+    pub group: String,
+    /// Version
+    pub version: String,
+    /// Resource
+    pub resource: String,
+    /// Concatenation of group and version
+    #[serde(default)]
+    api_version: String,
+}
+
+impl GroupVersionResource {
+    /// Set the api group, version, and the plural resource name.
+    pub fn gvr(group_: &str, version_: &str, resource_: &str) -> Result<Self> {
+        let version = version_.to_string();
+        let group = group_.to_string();
+        let resource = resource_.to_string();
+        let api_version = if group.is_empty() {
+            version.to_string()
+        } else {
+            format!("{}/{}", group, version)
+        };
+        if version.is_empty() {
+            return Err(Error::DynamicType(format!(
+                "GroupVersionResource '{}' must have a version",
+                resource
+            )));
+        }
+        if resource.is_empty() {
+            return Err(Error::DynamicType(format!(
+                "GroupVersionResource '{}' must have a resource",
+                resource
+            )));
+        }
+        Ok(Self {
+            group,
+            version,
+            resource,
+            api_version,
+        })
+    }
+}

--- a/kube/src/api/gvk.rs
+++ b/kube/src/api/gvk.rs
@@ -1,6 +1,4 @@
-use crate::{Error, Result};
 use serde::{Deserialize, Serialize};
-
 
 /// Contains enough information to identify API Resource.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
@@ -15,26 +13,14 @@ pub struct GroupVersionKind {
 
 impl GroupVersionKind {
     /// Set the api group, version, and kind for a resource
-    pub fn gvk(group_: &str, version_: &str, kind_: &str) -> Result<Self> {
+    pub fn gvk(group_: &str, version_: &str, kind_: &str) -> Self {
         let version = version_.to_string();
         let group = group_.to_string();
         let kind = kind_.to_string();
-        if version.is_empty() {
-            return Err(Error::DynamicType(format!(
-                "GroupVersionKind '{}' must have a version",
-                kind
-            )));
-        }
-        if kind.is_empty() {
-            return Err(Error::DynamicType(format!(
-                "GroupVersionKind '{}' must have a kind",
-                kind
-            )));
-        }
-        Ok(Self { group, version, kind })
+
+        Self { group, version, kind }
     }
 }
-
 
 /// Represents a type-erased object resource.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, Hash)]
@@ -52,7 +38,7 @@ pub struct GroupVersionResource {
 
 impl GroupVersionResource {
     /// Set the api group, version, and the plural resource name.
-    pub fn gvr(group_: &str, version_: &str, resource_: &str) -> Result<Self> {
+    pub fn gvr(group_: &str, version_: &str, resource_: &str) -> Self {
         let version = version_.to_string();
         let group = group_.to_string();
         let resource = resource_.to_string();
@@ -61,23 +47,12 @@ impl GroupVersionResource {
         } else {
             format!("{}/{}", group, version)
         };
-        if version.is_empty() {
-            return Err(Error::DynamicType(format!(
-                "GroupVersionResource '{}' must have a version",
-                resource
-            )));
-        }
-        if resource.is_empty() {
-            return Err(Error::DynamicType(format!(
-                "GroupVersionResource '{}' must have a resource",
-                resource
-            )));
-        }
-        Ok(Self {
+        
+        Self {
             group,
             version,
             resource,
             api_version,
-        })
+        }
     }
 }

--- a/kube/src/api/mod.rs
+++ b/kube/src/api/mod.rs
@@ -19,8 +19,11 @@ pub use request::Request;
 pub(crate) mod typed;
 pub use typed::Api;
 
+mod gvk;
+pub use gvk::{GroupVersionKind, GroupVersionResource};
+
 mod dynamic;
-pub use dynamic::{DynamicObject, GroupVersionKind, GroupVersionResource};
+pub use dynamic::{ApiResource, DynamicObject};
 
 #[cfg(feature = "ws")] mod remote_command;
 #[cfg(feature = "ws")] pub use remote_command::AttachedProcess;

--- a/kube/src/api/mod.rs
+++ b/kube/src/api/mod.rs
@@ -23,7 +23,7 @@ mod gvk;
 pub use gvk::{GroupVersionKind, GroupVersionResource};
 
 mod dynamic;
-pub use dynamic::{ApiResource, DynamicObject};
+pub use dynamic::{ApiResource, ApiResourceExtras, DynamicObject, Operations, Scope};
 
 #[cfg(feature = "ws")] mod remote_command;
 #[cfg(feature = "ws")] pub use remote_command::AttachedProcess;

--- a/kube/src/api/mod.rs
+++ b/kube/src/api/mod.rs
@@ -23,7 +23,7 @@ mod gvk;
 pub use gvk::{GroupVersionKind, GroupVersionResource};
 
 mod dynamic;
-pub use dynamic::{ApiResource, ApiResourceExtras, DynamicObject, Operations, Scope};
+pub use dynamic::{ApiResource, DynamicObject};
 
 #[cfg(feature = "ws")] mod remote_command;
 #[cfg(feature = "ws")] pub use remote_command::AttachedProcess;

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -7,7 +7,7 @@
 //! interaction with the kuberneres API.
 mod discovery;
 
-pub use discovery::{Discovery, Group};
+pub use discovery::{ApiResourceExtras, Discovery, Group, Operations, Scope};
 
 use crate::{api::WatchEvent, config::Config, error::ErrorResponse, service::Service, Error, Result};
 

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -5,9 +5,7 @@
 //! This client can be used on its own or in conjuction with
 //! the [`Api`][crate::api::Api] type for more structured
 //! interaction with the kuberneres API.
-mod discovery;
-
-pub use discovery::{ApiResourceExtras, Discovery, Group, Operations, Scope};
+pub mod discovery;
 
 use crate::{api::WatchEvent, config::Config, error::ErrorResponse, service::Service, Error, Result};
 

--- a/kube/src/error.rs
+++ b/kube/src/error.rs
@@ -70,10 +70,6 @@ pub enum Error {
     #[error("Request validation failed with {0}")]
     RequestValidation(String),
 
-    /// A dynamic type conversion failure
-    #[error("Dynamic type conversion failed {0}")]
-    DynamicType(String),
-
     /// Configuration error
     #[error("Error loading kubeconfig: {0}")]
     Kubeconfig(#[from] ConfigError),


### PR DESCRIPTION
This pull request shrinks GVK (so that it contains only G, V and K :smile: ), additionally making GVK fields public. It introduces a new ApiResource type which is much bigger (maybe it even contains too much stuff and should be split further). Also, two ways to obtain ApiResource are provided:
 - from GVK (with some guessing)
 - from `APIResource`
 
This PR also affects #491, because `Discovery` would contain a method to go from `GVK` to `ApiResource` (using discovered information), and this is intended to be both a simple and correct way to get an ApiResource.