### PR TITLE
ObjectRef: Do not store dynamic type

### DIFF
--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -15,20 +15,7 @@ use std::{
     Hash(bound = "K::DynamicType: Hash"),
     Clone(bound = "K::DynamicType: Clone")
 )]
-/// A typed and namedspaced (if relevant) reference to a Kubernetes object
-///
-/// `K` may be either the object type or `DynamicObject`, in which case the
-/// type is stored at runtime. Erased `ObjectRef`s pointing to different types
-/// are still considered different.
-///
-/// ```
-/// use kube_runtime::reflector::ObjectRef;
-/// use k8s_openapi::api::core::v1::{ConfigMap, Secret};
-/// assert_ne!(
-///     ObjectRef::<ConfigMap>::new("a").erase(),
-///     ObjectRef::<Secret>::new("a").erase(),
-/// );
-/// ```
+/// A namedspaced (if relevant) reference to a Kubernetes object
 pub struct ObjectRef<K: Resource> {
     dyntype: PhantomData<K::DynamicType>,
     /// The name of the object

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -169,10 +169,7 @@ mod tests {
             ),
             "my-deploy.my-namespace"
         );
-        assert_eq!(
-            format!("{}", ObjectRef::<Node>::new("my-node")),
-            "my-node"
-        );
+        assert_eq!(format!("{}", ObjectRef::<Node>::new("my-node")), "my-node");
     }
 
     #[test]

--- a/kube-runtime/src/reflector/object_ref.rs
+++ b/kube-runtime/src/reflector/object_ref.rs
@@ -160,18 +160,18 @@ mod tests {
     fn display_should_follow_expected_format() {
         assert_eq!(
             format!("{}", ObjectRef::<Pod>::new("my-pod").within("my-namespace")),
-            "Pod.v1./my-pod.my-namespace"
+            "my-pod.my-namespace"
         );
         assert_eq!(
             format!(
                 "{}",
                 ObjectRef::<Deployment>::new("my-deploy").within("my-namespace")
             ),
-            "Deployment.v1.apps/my-deploy.my-namespace"
+            "my-deploy.my-namespace"
         );
         assert_eq!(
             format!("{}", ObjectRef::<Node>::new("my-node")),
-            "Node.v1./my-node"
+            "my-node"
         );
     }
 


### PR DESCRIPTION
It seems that `dyntype`, despite being stored in ObjectRef, is only used in its `Display` implementation. This PR currently just replaces `dyntype` with PhantomData. If behavior changes (group, version and kind no longer reported in Display, and reference itself is less typed) are OK, then I'll add further changes.