### PR TITLE
Add a newline to pem blobs if one is not present

### DIFF
--- a/kube/src/client/discovery.rs
+++ b/kube/src/client/discovery.rs
@@ -62,11 +62,14 @@ impl Discovery {
 
                 v.push(GroupVersionData::new(vers.version, resource_list));
             }
-            groups.insert(g.name.clone(), Group {
-                name: g.name,
-                versions_and_resources: v,
-                preferred_version: g.preferred_version.map(|v| v.version),
-            });
+            groups.insert(
+                g.name.clone(),
+                Group {
+                    name: g.name,
+                    versions_and_resources: v,
+                    preferred_version: g.preferred_version.map(|v| v.version),
+                },
+            );
         }
 
         let coreapis = client.list_core_api_versions().await?;
@@ -75,11 +78,14 @@ impl Discovery {
             let resource_list = client.list_core_api_resources(&core_ver).await?;
             core_v.push(GroupVersionData::new(core_ver, resource_list));
         }
-        groups.insert(Group::CORE_GROUP.to_string(), Group {
-            name: Group::CORE_GROUP.to_string(),
-            versions_and_resources: core_v,
-            preferred_version: Some("v1".to_string()),
-        });
+        groups.insert(
+            Group::CORE_GROUP.to_string(),
+            Group {
+                name: Group::CORE_GROUP.to_string(),
+                versions_and_resources: core_v,
+                preferred_version: Some("v1".to_string()),
+            },
+        );
 
         groups.values_mut().for_each(|group| group.sort_versions());
 
@@ -170,13 +176,13 @@ impl Group {
 
     /// Returns preferred version for working with given group.
     pub fn preferred_version(&self) -> Option<&str> {
-        self.preferred_version.as_deref()
+       self.preferred_version.as_deref()
     }
 
     /// Returns preferred version for working with given group.
     /// If server does not recommend one, this function picks
     /// "the most stable and the most recent" version.
-
+    
     pub fn preferred_version_or_guess(&self) -> &str {
         match &self.preferred_version {
             Some(v) => v,

--- a/kube/src/client/discovery.rs
+++ b/kube/src/client/discovery.rs
@@ -62,14 +62,11 @@ impl Discovery {
 
                 v.push(GroupVersionData::new(vers.version, resource_list));
             }
-            groups.insert(
-                g.name.clone(),
-                Group {
-                    name: g.name,
-                    versions_and_resources: v,
-                    preferred_version: g.preferred_version.map(|v| v.version),
-                },
-            );
+            groups.insert(g.name.clone(), Group {
+                name: g.name,
+                versions_and_resources: v,
+                preferred_version: g.preferred_version.map(|v| v.version),
+            });
         }
 
         let coreapis = client.list_core_api_versions().await?;
@@ -78,14 +75,11 @@ impl Discovery {
             let resource_list = client.list_core_api_resources(&core_ver).await?;
             core_v.push(GroupVersionData::new(core_ver, resource_list));
         }
-        groups.insert(
-            Group::CORE_GROUP.to_string(),
-            Group {
-                name: Group::CORE_GROUP.to_string(),
-                versions_and_resources: core_v,
-                preferred_version: Some("v1".to_string()),
-            },
-        );
+        groups.insert(Group::CORE_GROUP.to_string(), Group {
+            name: Group::CORE_GROUP.to_string(),
+            versions_and_resources: core_v,
+            preferred_version: Some("v1".to_string()),
+        });
 
         groups.values_mut().for_each(|group| group.sort_versions());
 
@@ -176,13 +170,13 @@ impl Group {
 
     /// Returns preferred version for working with given group.
     pub fn preferred_version(&self) -> Option<&str> {
-       self.preferred_version.as_deref()
+        self.preferred_version.as_deref()
     }
 
     /// Returns preferred version for working with given group.
     /// If server does not recommend one, this function picks
     /// "the most stable and the most recent" version.
-    
+
     pub fn preferred_version_or_guess(&self) -> &str {
         match &self.preferred_version {
             Some(v) => v,

--- a/kube/src/config/utils.rs
+++ b/kube/src/config/utils.rs
@@ -12,13 +12,21 @@ pub fn default_kube_path() -> Option<PathBuf> {
 }
 
 pub fn data_or_file_with_base64<P: AsRef<Path>>(data: &Option<String>, file: &Option<P>) -> Result<Vec<u8>> {
-    match (data, file) {
+    let mut blob = match (data, file) {
         (Some(d), _) => base64::decode(&d)
             .map_err(ConfigError::Base64Decode)
             .map_err(Error::Kubeconfig),
         (_, Some(f)) => read_file(f),
         _ => Err(ConfigError::NoBase64FileOrData.into()),
+    };
+    //Ensure there is a trailing newline in the blob
+    //Don't bother if the blob is empty
+    if let Ok(buf) = &mut blob {
+        if buf.last().map(|end| *end != b'\n').unwrap_or(false) {
+            buf.push(b'\n');
+        }
     }
+    blob
 }
 
 pub fn read_file<P: AsRef<Path>>(file: P) -> Result<Vec<u8>> {

--- a/kube/src/config/utils.rs
+++ b/kube/src/config/utils.rs
@@ -18,15 +18,13 @@ pub fn data_or_file_with_base64<P: AsRef<Path>>(data: &Option<String>, file: &Op
             .map_err(Error::Kubeconfig),
         (_, Some(f)) => read_file(f),
         _ => Err(ConfigError::NoBase64FileOrData.into()),
-    };
+    }?;
     //Ensure there is a trailing newline in the blob
     //Don't bother if the blob is empty
-    if let Ok(buf) = &mut blob {
-        if buf.last().map(|end| *end != b'\n').unwrap_or(false) {
-            buf.push(b'\n');
-        }
+    if blob.last().map(|end| *end != b'\n').unwrap_or(false) {
+        blob.push(b'\n');
     }
-    blob
+    Ok(blob)
 }
 
 pub fn read_file<P: AsRef<Path>>(file: P) -> Result<Vec<u8>> {

--- a/kube/src/service/auth/layer.rs
+++ b/kube/src/service/auth/layer.rs
@@ -3,7 +3,6 @@ use std::{
     task::{Context, Poll},
 };
 
-
 use futures::{ready, Future};
 use http::{header::AUTHORIZATION, Request};
 use hyper::Body;

--- a/kube/src/service/mod.rs
+++ b/kube/src/service/mod.rs
@@ -11,13 +11,12 @@ use self::{log::LogRequest, url::set_cluster_url};
 use auth::AuthLayer;
 #[cfg(feature = "gzip")] use compression::{accept_compressed, maybe_decompress};
 use headers::set_default_headers;
-use tls::HttpsConnector;
-
-use std::convert::{TryFrom, TryInto};
-
 use http::{HeaderValue, Request, Response};
 use hyper::{Body, Client as HyperClient};
 use hyper_timeout::TimeoutConnector;
+use std::convert::{TryFrom, TryInto};
+use tls::HttpsConnector;
+
 use tower::{buffer::Buffer, util::BoxService, BoxError, ServiceBuilder};
 
 use crate::{error::ConfigError, Config, Error, Result};


### PR DESCRIPTION
/fixes #504

I'm not sure where is the best place to put this routine. 
The function I chose isn't technically limited to loading PEM files, but it's currently not used for anything else. 
It's the only place I found where we'd only have to invoke the routine once. 

The only actual change is in `src/config/utils.rs`  the rest are formatting changes. 