### PR TITLE
Automate `cargo +nightly fmt` on push

### DIFF
--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,5 +1,9 @@
-on: [push]
+# When pushed to `master`, run `cargo +nightly fmt --all` and commit any changes.
 name: rustfmt
+on:
+  push:
+    branches:
+      - master
 jobs:
   rustfmt_nightly:
     runs-on: ubuntu-latest
@@ -18,4 +22,9 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --all
+
+      - name: Commit any changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: rustfmt

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,9 +1,6 @@
-# When pushed to `master`, run `cargo +nightly fmt --all` and commit any changes.
+# When pushed, run `cargo +nightly fmt --all` and commit any changes.
 name: rustfmt
-on:
-  push:
-    branches:
-      - master
+on: [push]
 jobs:
   rustfmt_nightly:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Automate what @clux has been doing after merging PRs (https://github.com/clux/kube-rs/pull/505#issuecomment-829955828). Uses https://github.com/marketplace/actions/git-auto-commit to commit any changes after `cargo +nightly fmt --all`.

---

It's also possible to do this when PRs are opened. But to handle PRs from forks, we need to use [`pull_request_target`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) event and forks needs to have GitHub Actions enabled.