### PR TITLE
simplify admission controller setup even more

### DIFF
--- a/examples/admission_controller.rs
+++ b/examples/admission_controller.rs
@@ -1,18 +1,17 @@
+use kube::api::{
+    admission::{AdmissionRequest, AdmissionResponse, AdmissionReview},
+    DynamicObject, ResourceExt,
+};
 use std::{
     convert::{Infallible, TryInto},
     error::Error,
-};
-
-use kube::api::{
-    admission::{AdmissionRequest, AdmissionResponse, AdmissionReview},
-    DynamicObject,
 };
 #[macro_use] extern crate log;
 use warp::{reply, Filter, Reply};
 
 #[tokio::main]
 async fn main() {
-    std::env::set_var("RUST_LOG", "info,kube=debug");
+    std::env::set_var("RUST_LOG", "info,warp=warn,kube=debug");
     env_logger::init();
 
     let routes = warp::path("mutate")
@@ -22,19 +21,20 @@ async fn main() {
 
     // You must generate a certificate for the service / url,
     // encode the CA in the MutatingWebhookConfiguration, and terminate TLS here.
-    // See admission_setup.sh + admission_controller.yaml.tpl
-    // https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers/#tls-certificates
+    // See admission_setup.sh + admission_controller.yaml.tpl for how to do this.
     let addr = format!("{}:8443", std::env::var("ADMISSION_PRIVATE_IP").unwrap());
     warp::serve(warp::post().and(routes))
         .tls()
         .cert_path("admission-controller-tls.crt")
         .key_path("admission-controller-tls.key")
-        //.run(([0, 0, 0, 0], 8443))
-        .run(addr.parse::<std::net::SocketAddr>().unwrap())
+        //.run(([0, 0, 0, 0], 8443)) // in-cluster
+        .run(addr.parse::<std::net::SocketAddr>().unwrap()) // local-dev
         .await;
 }
 
+// A general /mutate handler, handling errors from the underlying business logic
 async fn mutate_handler(body: AdmissionReview<DynamicObject>) -> Result<impl Reply, Infallible> {
+    // Parse incoming webhook AdmissionRequest first
     let req: AdmissionRequest<_> = match body.try_into() {
         Ok(req) => req,
         Err(err) => {
@@ -45,62 +45,48 @@ async fn mutate_handler(body: AdmissionReview<DynamicObject>) -> Result<impl Rep
         }
     };
 
+    // Then construct a AdmissionResponse
     let mut res = AdmissionResponse::from(&req);
-
     if let Some(obj) = req.object {
-        info!(
-            "got request id {} to {:?} resource {}",
-            req.uid.clone(),
-            req.operation,
-            obj.metadata.name.as_ref().unwrap_or(&"unknown".to_owned())
-        );
-
-        res = match mutate(res.clone(), obj, req.dry_run) {
-            Ok(res) => res,
+        // If we actually got an Object, apply our business logic
+        res = match mutate(res.clone(), &obj) {
+            Ok(res) => {
+                info!("accepted: {:?} on Foo {}", req.operation, obj.name());
+                res
+            }
             Err(err) => {
-                error!("mutate failed: {}", err.to_string());
+                warn!("denied: {:?} on {} ({})", req.operation, obj.name(), err);
                 res.deny(err.to_string())
             }
         };
     };
-    // Need to return an AdmissionResponse wrapped in an AdmissionReview
+    // Wrap the AdmissionResponse wrapped in an AdmissionReview
     Ok(reply::json(&res.into_review()))
 }
 
-fn mutate(
-    mut res: AdmissionResponse,
-    obj: DynamicObject,
-    _dry_run: bool, // no external operations performed, no need to track dry_run
-) -> Result<AdmissionResponse, Box<dyn Error>> {
-    let labels = obj.metadata.labels.unwrap_or_default();
-
+// The main handler and core business logic, failures here implies rejected applies
+fn mutate(res: AdmissionResponse, obj: &DynamicObject) -> Result<AdmissionResponse, Box<dyn Error>> {
     // If the resource contains an "illegal" label, we reject it
-    if labels.contains_key("illegal") {
+    if obj.labels().contains_key("illegal") {
         return Err("Resource contained 'illegal' label".into());
     }
 
     // If the resource doesn't contain "admission", we add it to the resource.
-    let patches = if !labels.contains_key("admission") {
-        use json_patch::{AddOperation, PatchOperation};
-        vec![
+    if !obj.labels().contains_key("admission") {
+        let patches = vec![
             // Ensure labels exist before adding a key to it
-            PatchOperation::Add(AddOperation {
-                path: "/metadata/labels".to_string(),
+            json_patch::PatchOperation::Add(json_patch::AddOperation {
+                path: "/metadata/labels".into(),
                 value: serde_json::json!({}),
             }),
             // Add our label
-            PatchOperation::Add(AddOperation {
-                path: "/metadata/labels/admission".to_owned(),
-                value: serde_json::Value::String("modified-by-admission-controller".to_owned()),
+            json_patch::PatchOperation::Add(json_patch::AddOperation {
+                path: "/metadata/labels/admission".into(),
+                value: serde_json::Value::String("modified-by-admission-controller".into()),
             }),
-        ]
+        ];
+        Ok(res.with_patch(json_patch::Patch(patches))?)
     } else {
-        vec![]
-    };
-
-    if !patches.is_empty() {
-        res = res.with_patch(json_patch::Patch(patches))?;
+        Ok(res)
     }
-
-    Ok(res)
 }

--- a/examples/admission_controller.yaml.tpl
+++ b/examples/admission_controller.yaml.tpl
@@ -24,5 +24,5 @@ webhooks:
         resources: ["foos"]
     failurePolicy: Fail
     admissionReviewVersions: ["v1", "v1beta1"]
-    sideEffects: NoneOnDryRun
+    sideEffects: None
     timeoutSeconds: 5

--- a/examples/admission_setup.sh
+++ b/examples/admission_setup.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Require: a private ip reachable from your cluster. If running k3d, then not 0.0.0.0, but 192.168.X.X
+# This script is loosely adapting the TLS setup described in
+# https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers/#tls-certificates
+# for local development
+
+# Require: a private ip reachable from your cluster.
+# If using k3d to test locally, then probably 10.x.x.x or 192.168.X.X
+# When running behind a Service in-cluster; 0.0.0.0
 test -n "${ADMISSION_PRIVATE_IP}"
 
 # Cleanup: Remove old MutatingWebhookConfiguration if exists (immutable)

--- a/kube/src/api/admission.rs
+++ b/kube/src/api/admission.rs
@@ -142,11 +142,9 @@ pub struct AdmissionRequest<T: Resource> {
     /// The operation being performed. This may be different than the operation
     /// requested. e.g. a patch can result in either a CREATE or UPDATE
     /// Operation.
-    #[serde(default)]
-    pub operation: Option<Operation>,
+    pub operation: Operation,
     /// Information about the requesting user.
-    #[serde(default)]
-    pub user_info: Option<UserInfo>,
+    pub user_info: UserInfo,
     /// The object from the incoming request.
     pub object: Option<T>,
     ///  The existing object. Only populated for DELETE and UPDATE requests.


### PR DESCRIPTION
- structure example code to focuse on the user flow
- take advantage of new `ResourceExt` trait to simplify the `DynamicObject` interaction
- omit example `dry_run` (only applicable if the controller has side-effects)

It also changes the spec of `AdmissionRequest` to make two `UserInfo` and `Operation` mandatory because they are not marked as `+optional` in the kubernetes/api for either version:
- [v1 types](https://github.com/kubernetes/api/blob/648b77825832f4e96433407e4b406a3bdbb988bd/admission/v1/types.go#L91-L95)
- [v1beta1 types](https://github.com/kubernetes/api/blob/648b77825832f4e96433407e4b406a3bdbb988bd/admission/v1beta1/types.go#L96-L100)
