### PR TITLE
patchparams should use correct ser for dry-run bool - fixes #511

### DIFF
--- a/kube/src/api/params.rs
+++ b/kube/src/api/params.rs
@@ -288,7 +288,7 @@ impl PatchParams {
 
     pub(crate) fn populate_qp(&self, qp: &mut url::form_urlencoded::Serializer<String>) {
         if self.dry_run {
-            qp.append_pair("dryRun", "true");
+            qp.append_pair("dryRun", "All");
         }
         if self.force {
             qp.append_pair("force", "true");


### PR DESCRIPTION
force push because thought this was a copy of serialization at first, but this is just a manually done query parameter that's probably wrong.

hopefully `All` works everywhere, `["All"]` is used in serialization when using post data