### PR TITLE
move discovery types and admission types into kube-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ UNRELEASED
  * see https://github.com/clux/kube-rs/compare/0.53.0...master
  * `kube`: `api` `discovery` module now uses a new `ApiResource` struct #495
  * `kube`: `api` BREAKING: `DynamicObject` now takes an `ApiResource` rather than a `GroupVersionKind`
- * `kube`: `api` `discovery` module's `Group` renamed to `ApiGroup`
+ * `kube`: `api` BREAKING: `discovery` module's `Group` renamed to `ApiGroup`
  * `kube-core` crate factored out of `kube` to reduce dependencies - #516 via #517
 
 0.53.0 / 2021-05-15

--- a/examples/admission_controller.rs
+++ b/examples/admission_controller.rs
@@ -1,4 +1,4 @@
-use kube::api::{
+use kube_core::{
     admission::{AdmissionRequest, AdmissionResponse, AdmissionReview},
     DynamicObject, ResourceExt,
 };

--- a/kube-core/Cargo.toml
+++ b/kube-core/Cargo.toml
@@ -13,6 +13,7 @@ readme = "../README.md"
 
 [features]
 ws = []
+admission = ["json-patch"]
 
 [dependencies]
 serde = { version = "1.0.118", features = ["derive"] }
@@ -22,6 +23,7 @@ once_cell = "1.7.2"
 url = "2.2.0"
 log = "0.4.11"
 http = "0.2.2"
+json-patch = { version = "0.2.6", optional = true }
 
 [dependencies.k8s-openapi]
 version = "0.11.0"

--- a/kube-core/src/admission.rs
+++ b/kube-core/src/admission.rs
@@ -6,7 +6,10 @@
 //! https://github.com/kubernetes/api/blob/master/admission/v1/types.go
 
 use crate::{
-    api::{DynamicObject, GroupVersionKind, GroupVersionResource, Resource, TypeMeta},
+    dynamic::DynamicObject,
+    gvk::{GroupVersionKind, GroupVersionResource},
+    metadata::TypeMeta,
+    resource::Resource,
     Error, Result,
 };
 
@@ -338,8 +341,8 @@ mod test {
     use std::convert::TryInto;
 
     use crate::{
-        api::admission::{AdmissionResponse, AdmissionReview, DynamicObject},
-        Result,
+        admission::{AdmissionResponse, AdmissionReview},
+        DynamicObject, Result,
     };
 
     #[test]

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -1,11 +1,26 @@
+#[cfg(feature = "admission")] pub mod admission;
+
 pub mod api_resource;
+pub use api_resource::ApiResource;
 pub mod dynamic;
+pub use dynamic::DynamicObject;
+
 pub mod gvk;
+pub use gvk::{GroupVersionKind, GroupVersionResource};
+
 pub mod metadata;
+
 pub mod object;
+pub use object::WatchEvent;
+
 pub mod params;
+
 pub mod request;
-pub mod resource;
+pub use request::Request;
+
+mod resource;
+pub use resource::{Resource, ResourceExt};
+
 pub mod subresource;
 
 #[macro_use] extern crate log;

--- a/kube-core/src/object.rs
+++ b/kube-core/src/object.rs
@@ -215,3 +215,12 @@ impl<'a, T: Clone> IntoIterator for &'a mut ObjectList<T> {
         self.items.iter_mut()
     }
 }
+
+// -------------------------------------------------------
+
+/// Empty struct for when data should be discarded
+///
+/// Not using [`()`](https://doc.rust-lang.org/stable/std/primitive.unit.html), because serde's
+/// [`Deserialize`](serde::Deserialize) `impl` is too strict.
+#[derive(Clone, Deserialize, Serialize, Default, Debug)]
+pub struct NotUsed {}

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -164,8 +164,8 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
         impl #rootident {
             pub fn new(name: &str, spec: #ident) -> Self {
                 Self {
-                    api_version: <#rootident as kube_core::resource::Resource>::api_version(&()).to_string(),
-                    kind: <#rootident as kube_core::resource::Resource>::kind(&()).to_string(),
+                    api_version: <#rootident as kube_core::Resource>::api_version(&()).to_string(),
+                    kind: <#rootident as kube_core::Resource>::kind(&()).to_string(),
                     metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
                         name: Some(name.to_string()),
                         ..Default::default()
@@ -184,7 +184,7 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
 
     let api_ver = format!("{}/{}", group, version);
     let impl_resource = quote! {
-        impl kube_core::resource::Resource for #rootident {
+        impl kube_core::Resource for #rootident {
             type DynamicType = ();
 
             fn group(_: &()) -> std::borrow::Cow<'_, str> {
@@ -223,8 +223,8 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
             impl Default for #rootident {
                 fn default() -> Self {
                     Self {
-                        api_version: <#rootident as kube_core::resource::Resource>::api_version(&()).to_string(),
-                        kind: <#rootident as kube_core::resource::Resource>::kind(&()).to_string(),
+                        api_version: <#rootident as kube_core::Resource>::api_version(&()).to_string(),
+                        kind: <#rootident as kube_core::Resource>::kind(&()).to_string(),
                         metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta::default(),
                         spec: Default::default(),
                         #statusdef

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -20,7 +20,7 @@ mod custom_resource;
 ///
 /// ```rust
 /// use serde::{Serialize, Deserialize};
-/// use kube_core::resource::Resource;
+/// use kube_core::Resource;
 /// use kube_derive::CustomResource;
 /// use schemars::JsonSchema;
 ///

--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -24,7 +24,7 @@ jsonpatch = ["json-patch"]
 ws = ["tokio-tungstenite", "rand", "kube-core/ws"]
 oauth = ["tame-oauth"]
 gzip = ["async-compression"]
-admission = ["json-patch"]
+admission = ["json-patch", "kube-core/admission"]
 
 [package.metadata.docs.rs]
 features = ["derive", "ws", "oauth", "jsonpatch"]

--- a/kube/src/client/discovery.rs
+++ b/kube/src/client/discovery.rs
@@ -1,7 +1,8 @@
 //! High-level utilities for runtime API discovery.
 
-use crate::{api::ApiResource, Client};
+use crate::Client;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::APIResourceList;
+use kube_core::ApiResource;
 use std::{cmp::Reverse, collections::HashMap};
 
 /// Resource scope


### PR DESCRIPTION
can write an admission controller without pulling in kube with this.

this reduces kube/src/api to 4 files:
- core_methods.rs: `Api` core main methods (previously typed.rs)
- mod.rs: `Api` struct and re-exports
- remote_command.rs: `Api` methods using `ws`
- subresource.rs: `Api` subresource methods and marker traits
