### PR TITLE
Add `kube::ResourceExt`

### DIFF
--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -96,7 +96,7 @@ pub mod error;
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub use kube_derive::CustomResource;
 
-pub use api::{Api, Resource};
+pub use api::{Api, Resource, ResourceExt};
 #[doc(inline)] pub use client::Client;
 #[doc(inline)] pub use config::Config;
 #[doc(inline)] pub use error::Error;


### PR DESCRIPTION
Reexport `ResourceExt` under `kube` since it's pretty common.

I think it's more natural to do
```rust
use kube::{
    api::ListParams,
    Api, Client, Resource, ResourceExt,
};
```
than
```rust
use kube::{
    api::{ListParams, ReourceExt},
    Api, Client, Resource,
};
```
or
```rust
use kube::{
    api::{ListParams, Resource, ReourceExt},
    Api, Client,
};
```