### PR TITLE
Opt-in flag for using kube_core in kube-derive

### DIFF
--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -30,6 +30,7 @@ core = []
 serde = { version = "1.0.118", features = ["derive"] }
 serde_yaml = "0.8.17"
 kube-core = { path = "../kube-core" }
+kube = { path = "../kube", version = "<1.0.0, >=0.53.0" }
 k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_20"] }
 schemars = { version = "0.8.0", features = ["chrono"] }
 chrono = "0.4.19"

--- a/kube-derive/Cargo.toml
+++ b/kube-derive/Cargo.toml
@@ -24,6 +24,7 @@ proc-macro = true
 [features]
 default = ["schema"]
 schema = []
+core = []
 
 [dev-dependencies]
 serde = { version = "1.0.118", features = ["derive"] }


### PR DESCRIPTION
Restores the original import in `kube-derive`, unless the user wishes to opt in (which requires them to add `kube-core` as a dependency). 