### PR TITLE
Add `Api::default_namespaced`

### DIFF
--- a/kube/src/api/mod.rs
+++ b/kube/src/api/mod.rs
@@ -72,6 +72,21 @@ impl<K: Resource> Api<K> {
         }
     }
 
+    /// Namespaced resource within the default namespace
+    ///
+    /// This function accepts `K::DynamicType` so it can be used with dynamic resources.
+    ///
+    /// Unless configured explicitly, the default namespace is either "default"
+    /// out of cluster, or the service account's namespace in cluster.
+    pub fn default_namespaced_with(client: Client, dyntype: &K::DynamicType) -> Self {
+        let url = K::url_path(dyntype, Some(client.default_ns()));
+        Self {
+            client,
+            request: Request::new(url),
+            phantom: std::iter::empty(),
+        }
+    }
+
     /// Consume self and return the [`Client`]
     pub fn into_client(self) -> Client {
         self.into()
@@ -104,6 +119,19 @@ where
     /// Namespaced resource within a given namespace
     pub fn namespaced(client: Client, ns: &str) -> Self {
         let url = K::url_path(&Default::default(), Some(ns));
+        Self {
+            client,
+            request: Request::new(url),
+            phantom: std::iter::empty(),
+        }
+    }
+
+    /// Namespaced resource within the default namespace
+    ///
+    /// Unless configured explicitly, the default namespace is either "default"
+    /// out of cluster, or the service account's namespace in cluster.
+    pub fn default_namespaced(client: Client) -> Self {
+        let url = K::url_path(&Default::default(), Some(client.default_ns()));
         Self {
             client,
             request: Request::new(url),

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -68,7 +68,7 @@ impl Client {
     }
 
     /// Create and initialize a [`Client`] using the given `Service` and the default namespace.
-    pub fn new_with_default_ns<S, T: Into<String>>(service: S, default_ns: T) -> Self
+    fn new_with_default_ns<S, T: Into<String>>(service: S, default_ns: T) -> Self
     where
         S: Service<Request<Body>, Response = Response<Body>, Error = BoxError> + Send + 'static,
         S::Future: Send + 'static,


### PR DESCRIPTION
This is the cleanest I can think of at the moment.

- `Client` gets the default namespace from `Config` (most users)
- ~~`Client` with custom `Service` defaults to `"default"`, but can specify explicitly with `Client::new_with_default_ns(service, default_ns)`~~

Supersedes #413