### PR TITLE
Update jsonpath_lib to v0.3.0

### DIFF
--- a/kube/Cargo.toml
+++ b/kube/Cargo.toml
@@ -57,7 +57,7 @@ tokio = { version = "1.0.1", features = ["time", "signal", "sync"], optional = t
 static_assertions = "1.1.0"
 kube-derive = { path = "../kube-derive", version = "^0.55.0", optional = true }
 kube-core = { path = "../kube-core", version = "^0.55.0"}
-jsonpath_lib = { version = "0.2.6", optional = true }
+jsonpath_lib = { version = "0.3.0", optional = true }
 tokio-util = { version = "0.6.0", optional = true, features = ["io", "codec"] }
 hyper = { version = "0.14.2", optional = true, features = ["client", "http1", "stream", "tcp"] }
 hyper-tls = { version = "0.5.0", optional = true }


### PR DESCRIPTION
`jsonpath_lib` v0.2 unnecessarily depends on an older version of the
`env_logger` crate, which raises conflicts in tools like `cargo-deny`.

v0.3.0 fixes this by removing this dependency.