### PR TITLE
add moving with_default_namespace Client setter - fixes #543

### DIFF
--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -1,30 +1,29 @@
 // Minimal custom client example.
-use k8s_openapi::api::core::v1::ConfigMap;
-use tower::ServiceBuilder;
+use k8s_openapi::api::core::v1::Pod;
 
 use kube::{
-    api::{Api, ListParams},
+    Api, ResourceExt,
     client::ConfigExt,
     Client, Config,
 };
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    std::env::set_var("RUST_LOG", "info,kube=debug");
+    std::env::set_var("RUST_LOG", "info,kube=trace");
     tracing_subscriber::fmt::init();
 
     let config = Config::infer().await?;
     let https = config.native_tls_https_connector()?;
     let client = Client::new(
-        ServiceBuilder::new()
+        tower::ServiceBuilder::new()
             .layer(config.base_uri_layer())
             .option_layer(config.auth_layer()?)
-            .service(hyper::Client::builder().build(https)),
-    );
+            .service(hyper::Client::builder().build(https))
+    ).with_default_namespace(config.default_ns);
 
-    let cms: Api<ConfigMap> = Api::namespaced(client, "default");
-    for cm in cms.list(&ListParams::default()).await? {
-        println!("{:?}", cm);
+    let pods: Api<Pod> = Api::default_namespaced(client);
+    for p in pods.list(&Default::default()).await? {
+        println!("{}", p.name());
     }
 
     Ok(())

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -14,12 +14,11 @@ async fn main() -> anyhow::Result<()> {
 
     let config = Config::infer().await?;
     let https = config.native_tls_https_connector()?;
-    let client = Client::new(
-        tower::ServiceBuilder::new()
-            .layer(config.base_uri_layer())
-            .option_layer(config.auth_layer()?)
-            .service(hyper::Client::builder().build(https))
-    ).with_default_namespace(config.default_ns);
+    let service = tower::ServiceBuilder::new()
+        .layer(config.base_uri_layer())
+        .option_layer(config.auth_layer()?)
+        .service(hyper::Client::builder().build(https));
+    let client = Client::new(service).with_default_namespace(config.default_namespace);
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -18,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
         .layer(config.base_uri_layer())
         .option_layer(config.auth_layer()?)
         .service(hyper::Client::builder().build(https));
-    let client = Client::new(service).with_default_namespace(config.default_namespace);
+    let client = Client::new(service, config.default_namespace);
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {

--- a/examples/custom_client_tls.rs
+++ b/examples/custom_client_tls.rs
@@ -21,19 +21,17 @@ async fn main() -> anyhow::Result<()> {
     let use_rustls = std::env::var("USE_RUSTLS").map(|s| s == "1").unwrap_or(false);
     let client = (if use_rustls {
         let https = config.rustls_https_connector()?;
-        Client::new(
-            ServiceBuilder::new()
-                .layer(config.base_uri_layer())
-                .service(hyper::Client::builder().build(https)),
-        )
+        let service = ServiceBuilder::new()
+            .layer(config.base_uri_layer())
+            .service(hyper::Client::builder().build(https));
+        Client::new(service)
     } else {
         let https = config.native_tls_https_connector()?;
-        Client::new(
-            ServiceBuilder::new()
-                .layer(config.base_uri_layer())
-                .service(hyper::Client::builder().build(https)),
-        )
-    }).with_default_namespace(config.default_ns);
+        let service = ServiceBuilder::new()
+            .layer(config.base_uri_layer())
+            .service(hyper::Client::builder().build(https));
+        Client::new(service)
+    }).with_default_namespace(config.default_namespace);
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {

--- a/examples/custom_client_tls.rs
+++ b/examples/custom_client_tls.rs
@@ -19,19 +19,19 @@ async fn main() -> anyhow::Result<()> {
 
     // Pick TLS at runtime
     let use_rustls = std::env::var("USE_RUSTLS").map(|s| s == "1").unwrap_or(false);
-    let client = (if use_rustls {
+    let client = if use_rustls {
         let https = config.rustls_https_connector()?;
         let service = ServiceBuilder::new()
             .layer(config.base_uri_layer())
             .service(hyper::Client::builder().build(https));
-        Client::new(service)
+        Client::new(service, config.default_namespace)
     } else {
         let https = config.native_tls_https_connector()?;
         let service = ServiceBuilder::new()
             .layer(config.base_uri_layer())
             .service(hyper::Client::builder().build(https));
-        Client::new(service)
-    }).with_default_namespace(config.default_namespace);
+        Client::new(service, config.default_namespace)
+    };
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {

--- a/examples/custom_client_tls.rs
+++ b/examples/custom_client_tls.rs
@@ -1,11 +1,11 @@
 // Custom client supporting both native-tls and rustls-tls
 // Must enable `rustls-tls` feature to run this.
 // Run with `USE_RUSTLS=1` to pick rustls.
-use k8s_openapi::api::core::v1::ConfigMap;
+use k8s_openapi::api::core::v1::Pod;
 use tower::ServiceBuilder;
 
 use kube::{
-    api::{Api, ListParams},
+    Api, ResourceExt,
     client::ConfigExt,
     Client, Config,
 };
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Pick TLS at runtime
     let use_rustls = std::env::var("USE_RUSTLS").map(|s| s == "1").unwrap_or(false);
-    let client = if use_rustls {
+    let client = (if use_rustls {
         let https = config.rustls_https_connector()?;
         Client::new(
             ServiceBuilder::new()
@@ -33,11 +33,11 @@ async fn main() -> anyhow::Result<()> {
                 .layer(config.base_uri_layer())
                 .service(hyper::Client::builder().build(https)),
         )
-    };
+    }).with_default_namespace(config.default_ns);
 
-    let cms: Api<ConfigMap> = Api::namespaced(client, "default");
-    for cm in cms.list(&ListParams::default()).await? {
-        println!("{:?}", cm);
+    let pods: Api<Pod> = Api::default_namespaced(client);
+    for p in pods.list(&Default::default()).await? {
+        println!("{}", p.name());
     }
 
     Ok(())

--- a/examples/custom_client_trace.rs
+++ b/examples/custom_client_trace.rs
@@ -54,7 +54,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .service(hyper::Client::builder().build(https));
 
-    let client = Client::new(service).with_default_namespace(config.default_namespace);
+    let client = Client::new(service, config.default_namespace);
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {

--- a/examples/custom_client_trace.rs
+++ b/examples/custom_client_trace.rs
@@ -21,40 +21,40 @@ async fn main() -> anyhow::Result<()> {
 
     let config = Config::infer().await?;
     let https = config.native_tls_https_connector()?;
-    let client = Client::new(
-        ServiceBuilder::new()
-            .layer(config.base_uri_layer())
-            // Add `DecompressionLayer` to make request headers interesting.
-            .layer(DecompressionLayer::new())
-            .layer(
-                // Attribute names follow [Semantic Conventions].
-                // [Semantic Conventions]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-client
-                TraceLayer::new_for_http()
-                    .make_span_with(|request: &Request<Body>| {
-                        tracing::debug_span!(
-                            "HTTP",
-                            http.method = %request.method(),
-                            http.url = %request.uri(),
-                            http.status_code = tracing::field::Empty,
-                            otel.name = %format!("HTTP {}", request.method()),
-                            otel.kind = "client",
-                            otel.status_code = tracing::field::Empty,
-                        )
-                    })
-                    .on_request(|request: &Request<Body>, _span: &Span| {
-                        tracing::debug!("payload: {:?} headers: {:?}", request.body(), request.headers())
-                    })
-                    .on_response(|response: &Response<Body>, latency: Duration, span: &Span| {
-                        let status = response.status();
-                        span.record("http.status_code", &status.as_u16());
-                        if status.is_client_error() || status.is_server_error() {
-                            span.record("otel.status_code", &"ERROR");
-                        }
-                        tracing::debug!("finished in {}ms", latency.as_millis())
-                    }),
-            )
-            .service(hyper::Client::builder().build(https)),
-    ).with_default_namespace(config.default_ns);
+    let service = ServiceBuilder::new()
+        .layer(config.base_uri_layer())
+        // Add `DecompressionLayer` to make request headers interesting.
+        .layer(DecompressionLayer::new())
+        .layer(
+            // Attribute names follow [Semantic Conventions].
+            // [Semantic Conventions]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-client
+            TraceLayer::new_for_http()
+                .make_span_with(|request: &Request<Body>| {
+                    tracing::debug_span!(
+                        "HTTP",
+                        http.method = %request.method(),
+                        http.url = %request.uri(),
+                        http.status_code = tracing::field::Empty,
+                        otel.name = %format!("HTTP {}", request.method()),
+                        otel.kind = "client",
+                        otel.status_code = tracing::field::Empty,
+                    )
+                })
+                .on_request(|request: &Request<Body>, _span: &Span| {
+                    tracing::debug!("payload: {:?} headers: {:?}", request.body(), request.headers())
+                })
+                .on_response(|response: &Response<Body>, latency: Duration, span: &Span| {
+                    let status = response.status();
+                    span.record("http.status_code", &status.as_u16());
+                    if status.is_client_error() || status.is_server_error() {
+                        span.record("otel.status_code", &"ERROR");
+                    }
+                    tracing::debug!("finished in {}ms", latency.as_millis())
+                }),
+        )
+        .service(hyper::Client::builder().build(https));
+
+    let client = Client::new(service).with_default_namespace(config.default_namespace);
 
     let pods: Api<Pod> = Api::default_namespaced(client);
     for p in pods.list(&Default::default()).await? {

--- a/examples/custom_client_trace.rs
+++ b/examples/custom_client_trace.rs
@@ -3,13 +3,13 @@ use std::time::Duration;
 
 use http::{Request, Response};
 use hyper::Body;
-use k8s_openapi::api::core::v1::ConfigMap;
+use k8s_openapi::api::core::v1::Pod;
 use tower::ServiceBuilder;
 use tower_http::{decompression::DecompressionLayer, trace::TraceLayer};
 use tracing::Span;
 
 use kube::{
-    api::{Api, ListParams},
+    Api, ResourceExt,
     client::ConfigExt,
     Client, Config,
 };
@@ -54,11 +54,11 @@ async fn main() -> anyhow::Result<()> {
                     }),
             )
             .service(hyper::Client::builder().build(https)),
-    );
+    ).with_default_namespace(config.default_ns);
 
-    let cms: Api<ConfigMap> = Api::namespaced(client, "default");
-    for cm in cms.list(&ListParams::default()).await? {
-        println!("{:?}", cm);
+    let pods: Api<Pod> = Api::default_namespaced(client);
+    for p in pods.list(&Default::default()).await? {
+        println!("{}", p.name());
     }
 
     Ok(())

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -439,7 +439,7 @@ impl TryFrom<Config> for Client {
         use tracing::Span;
 
         let timeout = config.timeout;
-        let default_ns = config.default_ns.clone();
+        let default_ns = config.default_namespace.clone();
 
         let client: hyper::Client<_, Body> = {
             let mut connector = HttpConnector::new();
@@ -525,7 +525,7 @@ impl TryFrom<Config> for Client {
                     }),
             )
             .service(client);
-        Ok(Self::new_with_default_ns(service, default_ns))
+        Ok(Self::new(service).with_default_namespace(default_ns))
     }
 }
 

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -137,6 +137,13 @@ impl Client {
     pub(crate) fn default_ns(&self) -> &str {
         &self.default_ns
     }
+    /// Set the default namespace on a [`Client`]
+    ///
+    /// This is done by default in [`Client::try_default`], but must be done manually with custom clients.
+    pub fn with_default_namespace<T: Into<String>>(mut self, ns: T) -> Self {
+        self.default_ns = ns.into();
+        self
+    }
 
     async fn send(&self, request: Request<Body>) -> Result<Response<Body>> {
         let mut svc = self.inner.clone();

--- a/kube/src/client/mod.rs
+++ b/kube/src/client/mod.rs
@@ -99,7 +99,7 @@ impl Client {
         T: Into<String>
     {
         // Transform response body to `hyper::Body` and use type erased error to avoid type parameters.
-            let service = MapResponseBodyLayer::new(|b: B| Body::wrap_stream(b.into_stream()))
+        let service = MapResponseBodyLayer::new(|b: B| Body::wrap_stream(b.into_stream()))
             .layer(service)
             .map_err(|e| e.into());
         Self {

--- a/kube/src/config/mod.rs
+++ b/kube/src/config/mod.rs
@@ -23,7 +23,7 @@ pub struct Config {
     /// The configured cluster url
     pub cluster_url: http::Uri,
     /// The configured default namespace
-    pub default_ns: String,
+    pub default_namespace: String,
     /// The configured root certificate
     pub root_cert: Option<Vec<Vec<u8>>>,
     /// Timeout for calls to the Kubernetes API.
@@ -51,7 +51,7 @@ impl Config {
     pub fn new(cluster_url: http::Uri) -> Self {
         Self {
             cluster_url,
-            default_ns: String::from("default"),
+            default_namespace: String::from("default"),
             root_cert: None,
             timeout: Some(DEFAULT_TIMEOUT),
             accept_invalid_certs: false,
@@ -97,7 +97,7 @@ impl Config {
         })?;
         let cluster_url = cluster_url.parse::<http::Uri>()?;
 
-        let default_ns = incluster_config::load_default_ns()
+        let default_namespace = incluster_config::load_default_ns()
             .map_err(Box::new)
             .map_err(ConfigError::InvalidInClusterNamespace)?;
 
@@ -109,7 +109,7 @@ impl Config {
 
         Ok(Self {
             cluster_url,
-            default_ns,
+            default_namespace,
             root_cert: Some(root_cert),
             timeout: Some(DEFAULT_TIMEOUT),
             accept_invalid_certs: false,
@@ -144,7 +144,7 @@ impl Config {
     async fn new_from_loader(loader: ConfigLoader) -> Result<Self> {
         let cluster_url = loader.cluster.server.parse::<http::Uri>()?;
 
-        let default_ns = loader
+        let default_namespace = loader
             .current_context
             .namespace
             .clone()
@@ -175,7 +175,7 @@ impl Config {
 
         Ok(Self {
             cluster_url,
-            default_ns,
+            default_namespace,
             root_cert,
             timeout: Some(DEFAULT_TIMEOUT),
             accept_invalid_certs,


### PR DESCRIPTION
Follow up to #534 after custom client support in #540.

- ~~add moving `Client::with_default_namespace` setter~~
- [x] require `default_namespace` as an `Into<String>` arg in `Client::new`
- [x] update custom_client* examples to use default namespaces on pods (which are more likely to exist in default)
- [x] rename `Config::default_ns` to `Config::default_namespace`
- [x] remove `Client::new_with_default_namespace` alloc)

