### PR TITLE
add a versioned CustomResourceExt trait - fixes #497

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,9 @@ authors = [
 publish = false
 edition = "2018"
 
+[package.metadata.release]
+disable-release = true
+
 [features]
 default = ["native-tls", "schema", "kubederive", "ws"]
 kubederive = ["kube/derive"] # by default import kube-derive with its default features

--- a/examples/crd_api.rs
+++ b/examples/crd_api.rs
@@ -12,6 +12,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1 as a
 use kube::{
     api::{Api, DeleteParams, ListParams, Patch, PatchParams, PostParams, ResourceExt},
     Client, CustomResource,
+    core::crd::v1beta1::CustomResourceExt
 };
 
 // Own custom resource

--- a/examples/crd_apply.rs
+++ b/examples/crd_apply.rs
@@ -8,7 +8,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1 as apiext
 
 use kube::{
     api::{Api, ListParams, Patch, PatchParams, ResourceExt, WatchEvent},
-    Client, CustomResource,
+    Client, CustomResource, CustomResourceExt
 };
 
 // NB: This example uses server side apply and beta1 customresources

--- a/examples/crd_derive.rs
+++ b/examples/crd_derive.rs
@@ -1,5 +1,5 @@
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
-use kube::{CustomResource, Resource};
+use kube::{CustomResource, CustomResourceExt, Resource};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/examples/crd_derive_no_schema.rs
+++ b/examples/crd_derive_no_schema.rs
@@ -34,9 +34,10 @@ properties:
 #[cfg(not(feature = "schema"))]
 impl Bar {
     fn crd_with_manual_schema() -> CustomResourceDefinition {
+        use kube::CustomResourceExt;
         let schema: JSONSchemaProps = serde_yaml::from_str(MANUAL_SCHEMA).expect("invalid schema");
 
-        let mut crd = Self::crd();
+        let mut crd = <Self as CustomResourceExt>::crd();
         crd.spec.versions.iter_mut().for_each(|v| {
             v.schema = Some(CustomResourceValidation {
                 open_api_v3_schema: Some(schema.clone()),

--- a/examples/crd_derive_schema.rs
+++ b/examples/crd_derive_schema.rs
@@ -6,7 +6,7 @@ use kube::{
         Api, ApiResource, DeleteParams, DynamicObject, GroupVersionKind, ListParams, Patch, PatchParams,
         PostParams, WatchEvent,
     },
-    Client, CustomResource,
+    Client, CustomResource, CustomResourceExt
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -4,8 +4,6 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions as apiexts;
 
 /// Types for v1 CustomResourceDefinitions
 pub mod v1 {
-    use super::apiexts;
-    use crate::discovery::ApiResource;
     /// Extension trait that will be implemented by kube-derive
     ///
     /// This trait variant is implemented by default (or when `#[kube(apiextensions = "v1")]`)
@@ -13,16 +11,14 @@ pub mod v1 {
         /// Helper to generate the CRD including the JsonSchema
         ///
         /// This is using the stable v1::CustomResourceDefinitions (present in kubernetes >= 1.16)
-        fn crd() -> apiexts::v1::CustomResourceDefinition;
+        fn crd() -> super::apiexts::v1::CustomResourceDefinition;
         /// Helper to generate the api information type for use with the dynamic `Api`
-        fn api_resource() -> ApiResource;
+        fn api_resource() -> crate::discovery::ApiResource;
     }
 }
 
 /// Types for legacy v1beta1 CustomResourceDefinitions
 pub mod v1beta1 {
-    use super::apiexts;
-    use crate::discovery::ApiResource;
     /// Extension trait that will be implemented by kube-derive for legacy v1beta1::CustomResourceDefinitions
     ///
     /// This trait variant is only implemented with `#[kube(apiextensions = "v1beta1")]`
@@ -30,9 +26,9 @@ pub mod v1beta1 {
         /// Helper to generate the legacy CRD without a JsonSchema
         ///
         /// This is using v1beta1::CustomResourceDefinitions (which will be removed in kubernetes 1.22)
-        fn crd() -> apiexts::v1beta1::CustomResourceDefinition;
+        fn crd() -> super::apiexts::v1beta1::CustomResourceDefinition;
         /// Helper to generate the api information type for use with the dynamic `Api`
-        fn api_resource() -> ApiResource;
+        fn api_resource() -> crate::discovery::ApiResource;
     }
 }
 

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -1,0 +1,40 @@
+//! Traits and tyes for CustomResources
+
+use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions as apiexts;
+
+/// Types for v1 CustomResourceDefinitions
+pub mod v1 {
+    use super::apiexts;
+    use crate::discovery::ApiResource;
+    /// Extension trait that will be implemented by kube-derive
+    ///
+    /// This trait variant is implemented by default (or when `#[kube(apiextensions = "v1")]`)
+    pub trait CustomResourceExt {
+        /// Helper to generate the CRD including the JsonSchema
+        ///
+        /// This is using the stable v1::CustomResourceDefinitions (present in kubernetes >= 1.16)
+        fn crd() -> apiexts::v1::CustomResourceDefinition;
+        /// Helper to generate the api information type for use with the dynamic `Api`
+        fn api_resource() -> ApiResource;
+    }
+}
+
+/// Types for legacy v1beta1 CustomResourceDefinitions
+pub mod v1beta1 {
+    use super::apiexts;
+    use crate::discovery::ApiResource;
+    /// Extension trait that will be implemented by kube-derive for legacy v1beta1::CustomResourceDefinitions
+    ///
+    /// This trait variant is only implemented with `#[kube(apiextensions = "v1beta1")]`
+    pub trait CustomResourceExt {
+        /// Helper to generate the legacy CRD without a JsonSchema
+        ///
+        /// This is using v1beta1::CustomResourceDefinitions (which will be removed in kubernetes 1.22)
+        fn crd() -> apiexts::v1beta1::CustomResourceDefinition;
+        /// Helper to generate the api information type for use with the dynamic `Api`
+        fn api_resource() -> ApiResource;
+    }
+}
+
+/// re-export the current latest version until a newer one is available in cloud providers
+pub use v1::CustomResourceExt;

--- a/kube-core/src/lib.rs
+++ b/kube-core/src/lib.rs
@@ -15,6 +15,9 @@ pub mod discovery;
 pub mod dynamic;
 pub use dynamic::DynamicObject;
 
+pub mod crd;
+pub use crd::CustomResourceExt;
+
 pub mod gvk;
 pub use gvk::{GroupVersion, GroupVersionKind, GroupVersionResource};
 

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -294,8 +294,8 @@ impl PatchParams {
         if self.force {
             qp.append_pair("force", "true");
         }
-        if let Some(ref field_manager) = self.field_manager {
-            qp.append_pair("fieldManager", &field_manager);
+        if let Some(ref fm) = self.field_manager {
+            qp.append_pair("fieldManager", fm);
         }
     }
 

--- a/kube-core/src/request.rs
+++ b/kube-core/src/request.rs
@@ -30,10 +30,10 @@ impl Request {
         let mut qp = form_urlencoded::Serializer::new(target);
 
         if let Some(fields) = &lp.field_selector {
-            qp.append_pair("fieldSelector", &fields);
+            qp.append_pair("fieldSelector", fields);
         }
         if let Some(labels) = &lp.label_selector {
-            qp.append_pair("labelSelector", &labels);
+            qp.append_pair("labelSelector", labels);
         }
         if let Some(limit) = &lp.limit {
             qp.append_pair("limit", &limit.to_string());
@@ -69,10 +69,10 @@ impl Request {
         // https://github.com/kubernetes/kubernetes/issues/6513
         qp.append_pair("timeoutSeconds", &lp.timeout.unwrap_or(290).to_string());
         if let Some(fields) = &lp.field_selector {
-            qp.append_pair("fieldSelector", &fields);
+            qp.append_pair("fieldSelector", fields);
         }
         if let Some(labels) = &lp.label_selector {
-            qp.append_pair("labelSelector", &labels);
+            qp.append_pair("labelSelector", labels);
         }
         if lp.bookmarks {
             qp.append_pair("allowWatchBookmarks", "true");
@@ -120,10 +120,10 @@ impl Request {
         let target = format!("{}?", self.url_path);
         let mut qp = form_urlencoded::Serializer::new(target);
         if let Some(fields) = &lp.field_selector {
-            qp.append_pair("fieldSelector", &fields);
+            qp.append_pair("fieldSelector", fields);
         }
         if let Some(labels) = &lp.label_selector {
-            qp.append_pair("labelSelector", &labels);
+            qp.append_pair("labelSelector", labels);
         }
         let urlstr = qp.finish();
         let body = serde_json::to_vec(&dp)?;

--- a/kube-core/src/subresource.rs
+++ b/kube-core/src/subresource.rs
@@ -45,7 +45,7 @@ impl Request {
         let mut qp = form_urlencoded::Serializer::new(target);
 
         if let Some(container) = &lp.container {
-            qp.append_pair("container", &container);
+            qp.append_pair("container", container);
         }
 
         if lp.follow {

--- a/kube-derive/src/lib.rs
+++ b/kube-derive/src/lib.rs
@@ -13,14 +13,14 @@ mod custom_resource;
 /// This root object will implement the [`kube::Resource`] trait
 /// so it can be used with [`kube::Api`].
 ///
-/// The generated type will also implement a `::crd` method to generate the crd
-/// at the specified api version (or `v1` if unspecified).
+/// The generated type will also implement kube's [`kube::CustomResourceExt`] trait to generate the crd
+/// and generate [`kube::core::ApiResource`] information for use with the dynamic api.
 ///
 /// # Example
 ///
 /// ```rust
 /// use serde::{Serialize, Deserialize};
-/// use kube::Resource;
+/// use kube::{Resource, CustomResourceExt};
 /// use kube_derive::CustomResource;
 /// use schemars::JsonSchema;
 ///
@@ -72,7 +72,8 @@ mod custom_resource;
 /// The version for `CustomResourceDefinition` desired in the `apiextensions.k8s.io` group.
 /// Default is `v1` (for clusters >= 1.17). If using kubernetes <= 1.16 please use `v1beta1`.
 ///
-/// **NOTE**: Support for `v1` requires deriving the openapi v3 `JsonSchema` via the `schemars` dependency.
+/// - **NOTE**: Support for `v1` requires deriving the openapi v3 `JsonSchema` via the `schemars` dependency.
+/// - **NOTE**: When using `v1beta` the associated `CustomResourceExt` trait lives in `kube::core::crd::v1beta`
 ///
 /// ### `#[kube(singular = "nonstandard-singular")]`
 /// To specify the singular name. Defaults to lowercased `kind`.
@@ -196,6 +197,8 @@ mod custom_resource;
 /// [`kube`]: https://docs.rs/kube
 /// [`kube::Api`]: https://docs.rs/kube/*/kube/struct.Api.html
 /// [`kube::Resource`]: https://docs.rs/kube/*/kube/trait.Resource.html
+/// [`kube::core::ApiResource`]: https://docs.rs/kube/*/kube/core/struct.ApiResource.html
+/// [`kube::CustomResourceExt`]: https://docs.rs/kube/*/kube/trait.CustomResourceExt.html
 #[proc_macro_derive(CustomResource, attributes(kube))]
 pub fn derive_custom_resource(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     custom_resource::derive(proc_macro2::TokenStream::from(input)).into()

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -44,6 +44,7 @@ fn default_nullable() -> Option<String> {
 
 #[test]
 fn test_crd_schema_matches_expected() {
+    use kube::core::CustomResourceExt;
     assert_eq!(
         Foo::crd(),
         serde_json::from_value(serde_json::json!({

--- a/kube/src/api/core_methods.rs
+++ b/kube/src/api/core_methods.rs
@@ -49,7 +49,7 @@ where
     /// }
     /// ```
     pub async fn list(&self, lp: &ListParams) -> Result<ObjectList<K>> {
-        let mut req = self.request.list(&lp)?;
+        let mut req = self.request.list(lp)?;
         req.extensions_mut().insert("list");
         self.client.request::<ObjectList<K>>(req).await
     }
@@ -75,7 +75,7 @@ where
         K: Serialize,
     {
         let bytes = serde_json::to_vec(&data)?;
-        let mut req = self.request.create(&pp, bytes)?;
+        let mut req = self.request.create(pp, bytes)?;
         req.extensions_mut().insert("create");
         self.client.request::<K>(req).await
     }
@@ -103,7 +103,7 @@ where
     /// }
     /// ```
     pub async fn delete(&self, name: &str, dp: &DeleteParams) -> Result<Either<K, Status>> {
-        let mut req = self.request.delete(name, &dp)?;
+        let mut req = self.request.delete(name, dp)?;
         req.extensions_mut().insert("delete");
         self.client.request_status::<K>(req).await
     }
@@ -140,7 +140,7 @@ where
         dp: &DeleteParams,
         lp: &ListParams,
     ) -> Result<Either<ObjectList<K>, Status>> {
-        let mut req = self.request.delete_collection(&dp, &lp)?;
+        let mut req = self.request.delete_collection(dp, lp)?;
         req.extensions_mut().insert("delete_collection");
         self.client.request_status::<ObjectList<K>>(req).await
     }
@@ -180,7 +180,7 @@ where
         pp: &PatchParams,
         patch: &Patch<P>,
     ) -> Result<K> {
-        let mut req = self.request.patch(name, &pp, patch)?;
+        let mut req = self.request.patch(name, pp, patch)?;
         req.extensions_mut().insert("patch");
         self.client.request::<K>(req).await
     }
@@ -234,7 +234,7 @@ where
         K: Serialize,
     {
         let bytes = serde_json::to_vec(&data)?;
-        let mut req = self.request.replace(name, &pp, bytes)?;
+        let mut req = self.request.replace(name, pp, bytes)?;
         req.extensions_mut().insert("replace");
         self.client.request::<K>(req).await
     }
@@ -281,7 +281,7 @@ where
         lp: &ListParams,
         version: &str,
     ) -> Result<impl Stream<Item = Result<WatchEvent<K>>>> {
-        let mut req = self.request.watch(&lp, &version)?;
+        let mut req = self.request.watch(lp, version)?;
         req.extensions_mut().insert("watch");
         self.client.request_events::<K>(req).await
     }

--- a/kube/src/api/subresource.rs
+++ b/kube/src/api/subresource.rs
@@ -38,14 +38,14 @@ where
         pp: &PatchParams,
         patch: &Patch<P>,
     ) -> Result<Scale> {
-        let mut req = self.request.patch_subresource("scale", name, &pp, patch)?;
+        let mut req = self.request.patch_subresource("scale", name, pp, patch)?;
         req.extensions_mut().insert("patch_scale");
         self.client.request::<Scale>(req).await
     }
 
     /// Replace the scale subresource
     pub async fn replace_scale(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<Scale> {
-        let mut req = self.request.replace_subresource("scale", name, &pp, data)?;
+        let mut req = self.request.replace_subresource("scale", name, pp, data)?;
         req.extensions_mut().insert("replace_scale");
         self.client.request::<Scale>(req).await
     }
@@ -98,7 +98,7 @@ where
         pp: &PatchParams,
         patch: &Patch<P>,
     ) -> Result<K> {
-        let mut req = self.request.patch_subresource("status", name, &pp, patch)?;
+        let mut req = self.request.patch_subresource("status", name, pp, patch)?;
         req.extensions_mut().insert("patch_status");
         self.client.request::<K>(req).await
     }
@@ -123,7 +123,7 @@ where
     /// }
     /// ```
     pub async fn replace_status(&self, name: &str, pp: &PostParams, data: Vec<u8>) -> Result<K> {
-        let mut req = self.request.replace_subresource("status", name, &pp, data)?;
+        let mut req = self.request.replace_subresource("status", name, pp, data)?;
         req.extensions_mut().insert("replace_status");
         self.client.request::<K>(req).await
     }

--- a/kube/src/client/auth/mod.rs
+++ b/kube/src/client/auth/mod.rs
@@ -222,9 +222,9 @@ fn token_from_gcp_provider(provider: &AuthProviderConfig) -> Result<ProviderToke
 
         if let Some(field) = provider.config.get("token-key") {
             let json_output: serde_json::Value = serde_json::from_slice(&output.stdout)?;
-            let token = extract_value(&json_output, &field)?;
+            let token = extract_value(&json_output, field)?;
             if let Some(field) = provider.config.get("expiry-key") {
-                let expiry = extract_value(&json_output, &field)?;
+                let expiry = extract_value(&json_output, field)?;
                 let expiry = expiry
                     .parse::<DateTime<Utc>>()
                     .map_err(ConfigError::MalformedTokenExpirationDate)?;

--- a/kube/src/client/tls.rs
+++ b/kube/src/client/tls.rs
@@ -24,7 +24,7 @@ pub mod native_tls {
         if let Some(ders) = root_cert {
             for der in ders {
                 builder.add_root_certificate(
-                    Certificate::from_der(&der).map_err(|e| Error::SslError(format!("{}", e)))?,
+                    Certificate::from_der(der).map_err(|e| Error::SslError(format!("{}", e)))?,
                 );
             }
         }
@@ -40,8 +40,8 @@ pub mod native_tls {
     // TODO Replace this with pure Rust implementation to avoid depending on openssl on macOS and Win
     fn pkcs12_from_pem(pem: &[u8], password: &str) -> Result<Vec<u8>> {
         use openssl::{pkcs12::Pkcs12, pkey::PKey, x509::X509};
-        let x509 = X509::from_pem(&pem)?;
-        let pkey = PKey::private_key_from_pem(&pem)?;
+        let x509 = X509::from_pem(pem)?;
+        let pkey = PKey::private_key_from_pem(pem)?;
         let p12 = Pkcs12::builder().build(password, "kubeconfig", &pkey, &x509)?;
         let der = p12.to_der()?;
         Ok(der)

--- a/kube/src/config/mod.rs
+++ b/kube/src/config/mod.rs
@@ -156,7 +156,7 @@ impl Config {
 
         if let Some(ca_bundle) = loader.ca_bundle()? {
             for ca in &ca_bundle {
-                accept_invalid_certs = hacky_cert_lifetime_for_macos(&ca);
+                accept_invalid_certs = hacky_cert_lifetime_for_macos(ca);
             }
             root_cert = Some(ca_bundle);
         }

--- a/kube/src/discovery/oneshot.rs
+++ b/kube/src/discovery/oneshot.rs
@@ -40,14 +40,14 @@ use kube_core::{
 pub async fn group(client: &Client, apigroup: &str) -> Result<ApiGroup> {
     if apigroup == ApiGroup::CORE_GROUP {
         let coreapis = client.list_core_api_versions().await?;
-        return ApiGroup::query_core(&client, coreapis).await;
+        return ApiGroup::query_core(client, coreapis).await;
     } else {
         let api_groups = client.list_api_groups().await?;
         for g in api_groups.groups {
             if g.name != apigroup {
                 continue;
             }
-            return ApiGroup::query_apis(&client, g).await;
+            return ApiGroup::query_apis(client, g).await;
         }
     }
     Err(DiscoveryError::MissingApiGroup(apigroup.to_string()).into())
@@ -77,7 +77,7 @@ pub async fn group(client: &Client, apigroup: &str) -> Result<ApiGroup> {
 /// than a single `kind`.
 /// If you only need a single `kind`, [`oneshot::pinned_kind`](crate::discovery::pinned_kind) is the best solution.
 pub async fn pinned_group(client: &Client, gv: &GroupVersion) -> Result<ApiGroup> {
-    ApiGroup::query_gv(&client, gv).await
+    ApiGroup::query_gv(client, gv).await
 }
 
 /// Single discovery for a single GVK
@@ -100,5 +100,5 @@ pub async fn pinned_group(client: &Client, gv: &GroupVersion) -> Result<ApiGroup
 /// }
 /// ```
 pub async fn pinned_kind(client: &Client, gvk: &GroupVersionKind) -> Result<(ApiResource, ApiCapabilities)> {
-    ApiGroup::query_gvk(client, &gvk).await
+    ApiGroup::query_gvk(client, gvk).await
 }

--- a/kube/src/discovery/version.rs
+++ b/kube/src/discovery/version.rs
@@ -77,7 +77,7 @@ impl Ord for Version {
 
 impl PartialOrd for Version {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 

--- a/kube/src/lib.rs
+++ b/kube/src/lib.rs
@@ -139,6 +139,7 @@ pub mod core {
     #[cfg_attr(docsrs, doc(cfg(feature = "admission")))]
     pub use kube_core::admission;
     pub use kube_core::{
+        crd::{self, CustomResourceExt},
         dynamic::{self, ApiResource, DynamicObject},
         gvk::{self, GroupVersionKind, GroupVersionResource},
         metadata::{self, ListMeta, ObjectMeta, TypeMeta},
@@ -149,4 +150,4 @@ pub mod core {
         Resource, ResourceExt,
     };
 }
-pub use crate::core::{Resource, ResourceExt};
+pub use crate::core::{CustomResourceExt, Resource, ResourceExt};

--- a/release.toml
+++ b/release.toml
@@ -1,5 +1,5 @@
 # Release process:
-# 1. cargo release minor --exclude examples --exclude tests
+# 1. cargo release minor
 # 2. verify that all crates are bumped and versions are in-line before proceeding
 # 3a. await publishing - failures can happen due to still https://github.com/sunng87/cargo-release/issues/224
 # 3b. fix failures from 3a (resume publishing manually, cd into dir, cargo publish, wait, continue for next in line)

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["clux <sszynrae@gmail.com>"]
 publish = false
 edition = "2018"
 
+[package.metadata.release]
+disable-release = true
+
 [[bin]]
 name = "dapp"
 path = "dapp.rs"


### PR DESCRIPTION
Had a bit of a go at #497, and realised it's not quite that beginner worthy because of one hairy problem:

The new trait needs to hardcode the `CustomResourceDefinition` type from `k8s_openapi` if we want to keep enforcing the struct (and we probably should).
Unfortunately, doing this effectively hardcodes the apiextensions version and makes things using `#[kube(apiextensions = "v1beta1")]` not compile.

So, a couple of options present themselves:

- immediately drop support for v1beta1 (minimally available EKS version supports v1)
- parallel traits that users must select

I think for sake of stability guarantees and #508 parallel traits actually work here:
- `#[kube(apiextensions = "v1beta1")]` can select the trait and implement the right one
- users can pick out the trait (and it wont compile unless they pick the right one)
- can export them from kube_core under versioned modules
- can still have the "main" (most recent + available) version on the main path

So, if this seems acceptable. I propose this can perhaps serve as a guiding principle for #508
- When we rely on versioned type definitions from kubernetes, we don't remove our old impls until they are removed from major cloud providers (provided we even implemented it in the first place)
- When removing older versions, we mention it in the CHANGELOG

I.e. this case: we can remove `kube_core::crd::v1beta1` when kubernetes 1.22 is the minimum EKS/AKS/GKE version.