### PR TITLE
stop inferring plural from k8s-openapi structs - fixes #284

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ UNRELEASED
   - BREAKING: custom clients via `Client::new` must pass `config.default_namespace` as 2nd arg
  * `kube`: Added `CustomResourceExt` trait for `kube-derive` - #497 via #545
   - BREAKING: `kube-derive` users must import `kube::CustomResourceExt` (or `kube::core::crd::v1beta1::CustomResourceExt` if using legacy `#[kube(apiextensions = "v1beta1")]`) to use generated methods `Foo::crd` or `Foo::api_resource`
+  - BREAKING: `k8s_openapi` bumped to [0.12.0](https://github.com/Arnavion/k8s-openapi/releases/tag/v0.12.0)
+    * Generated structs simplified + `Resource` trait expanded
+    * Adds support for kubernetes `v1_21`
+ * `kube` resource plurals is no longer inferred from `k8s-openapi` structs
 
 0.56.0 / 2021-06-05
 ===================

--- a/kube-core/src/object.rs
+++ b/kube-core/src/object.rs
@@ -188,6 +188,10 @@ where
         dt.kind.as_str().into()
     }
 
+    fn plural(dt: &ApiResource) -> Cow<'_, str> {
+        dt.plural.as_str().into()
+    }
+
     fn api_version(dt: &ApiResource) -> Cow<'_, str> {
         dt.api_version.as_str().into()
     }

--- a/kube-core/src/resource.rs
+++ b/kube-core/src/resource.rs
@@ -44,15 +44,7 @@ pub trait Resource {
     /// Returns the plural name of the kind
     ///
     /// This is known as the resource in apimachinery, we rename it for disambiguation.
-    /// By default, we infer this name through pluralization.
-    ///
-    /// The pluralization process is not recommended to be relied upon, and is only used for
-    /// `k8s_openapi` types, where we maintain a list of special pluralisations for compatibility.
-    ///
-    /// Thus when used with `DynamicObject` or `kube-derive`, we override this with correct values.
-    fn plural(dt: &Self::DynamicType) -> Cow<'_, str> {
-        to_plural(&Self::kind(dt).to_ascii_lowercase()).into()
-    }
+    fn plural(dt: &Self::DynamicType) -> Cow<'_, str>;
 
     /// Creates a url path for http requests for this resource
     fn url_path(dt: &Self::DynamicType, namespace: Option<&str>) -> String {
@@ -100,6 +92,10 @@ where
 
     fn api_version(_: &()) -> Cow<'_, str> {
         K::API_VERSION.into()
+    }
+
+    fn plural(_: &()) -> Cow<'_, str> {
+        K::URL_PATH_SEGMENT.into()
     }
 
     fn meta(&self) -> &ObjectMeta {


### PR DESCRIPTION
an initial change taking advantage of the expanded `k8s-openapi` [Resource trait](https://arnavion.github.io/k8s-openapi/v0.12.x/src/k8s_openapi/lib.rs.html#505-537)

This makes the `Resource::plural` method mandatory.