### PR TITLE
add github release action - fixes #561

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Extract release info from CHANGELOG
+        if: startsWith(github.ref, 'refs/tags/')
+        run: grep $(date +%Y-%m-%d) -A 250 CHANGELOG.md | tail -n +3 | sed '1,/===================/!d' | head -n -3 > release.txt
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          body_path: release.txt


### PR DESCRIPTION
using some awkward grep/sed/tail/head to extract it from changelog, then push it neatly into a github release on a tag event.

will need to wait till next release to truly test it, but at least the extraction seems to work locally.