### PR TITLE
docs : kube-runtime controller params disambiguation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: CI
-
 on:
-  push:
   pull_request:
 
 jobs:

--- a/kube-core/src/params.rs
+++ b/kube-core/src/params.rs
@@ -47,6 +47,7 @@ pub struct ListParams {
 }
 
 impl Default for ListParams {
+    /// Default `ListParams` without any constricting selectors
     fn default() -> Self {
         Self {
             // bookmarks stable since 1.17, and backwards compatible

--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -495,7 +495,7 @@ where
         self.owns_with(api, (), lp)
     }
 
-    /// Indicate child objets `K` owns and be notified when they change
+    /// Specify `Child` objects which `K` owns and should be watched
     ///
     /// Same as [`Controller::owns`], but accepts a `DynamicType` so it can be used with dynamic resources.
     pub fn owns_with<Child: Clone + Resource + DeserializeOwned + Debug + Send + 'static>(

--- a/kube-runtime/src/watcher.rs
+++ b/kube-runtime/src/watcher.rs
@@ -220,7 +220,7 @@ async fn step<K: Resource + Clone + DeserializeOwned + Debug + Send + 'static>(
 /// ```
 /// [`try_flatten_applied`]: super::utils::try_flatten_applied
 /// [`reflector`]: super::reflector::reflector
-/// [`Api::watch`]: https://docs.rs/kube/*/kube/struct.Api.html#method.watch
+/// [`Api::watch`]: kube::Api::watch
 ///
 /// # Recovery
 ///


### PR DESCRIPTION
got a question about possible `ListParams` interactions and realised this could be clarified a little bit.