### PR TITLE
publish code coverage on release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
-on: push
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:
@@ -24,13 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install stable toolchain
-        if: startsWith(github.ref, 'refs/tags/')
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
       - name: Run cargo-tarpaulin
-        if: startsWith(github.ref, 'refs/tags/')
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.18.0'
@@ -39,7 +40,6 @@ jobs:
           args: '--all -e tests -- --test-threads 1'
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./lcov.info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Extract release info from CHANGELOG
-        if: startsWith(github.ref, 'refs/tags/')
         run: grep $(date +%Y-%m-%d) -A 250 CHANGELOG.md | tail -n +3 | sed '1,/===================/!d' | head -n -3 > release.txt
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           version: '0.18.0'
           out-type: Lcov
           timeout: 600
-          args: '--all -- --test-threads 1'
+          args: '--all -e tests -- --test-threads 1'
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,22 +24,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install stable toolchain
-        #if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
       - name: Run cargo-tarpaulin
-        #if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.18.0'
           out-type: Lcov
-          timeout: 500
+          timeout: 600
           args: '--all -- --test-threads 1'
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master
-        #if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./lcov.info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           body_path: release.txt
+  code-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        #if: startsWith(github.ref, 'refs/tags/')
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run cargo-tarpaulin
+        #if: startsWith(github.ref, 'refs/tags/')
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          version: '0.18.0'
+          out-type: Lcov
+          args: '--all -- --test-threads 1'
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        #if: startsWith(github.ref, 'refs/tags/')
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./lcov.info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           version: '0.18.0'
           out-type: Lcov
+          timeout: 500
           args: '--all -- --test-threads 1'
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master

--- a/kube/src/client/auth/mod.rs
+++ b/kube/src/client/auth/mod.rs
@@ -213,7 +213,7 @@ fn token_from_gcp_provider(provider: &AuthProviderConfig) -> Result<ProviderToke
 
         if !output.status.success() {
             return Err(ConfigError::AuthExecRun {
-                cmd: format! {"{} {}", cmd, params},
+                cmd: format!("{} {}", cmd, params),
                 status: output.status,
                 out: output,
             }


### PR DESCRIPTION
Tried the [tarpaulin action](https://github.com/actions-rs/tarpaulin) for a simple code coverage, effectively running `cargo tarpaulin --all`.

Results at https://coveralls.io/github/clux/kube-rs [![Coverage Status](https://coveralls.io/repos/github/clux/kube-rs/badge.svg?branch=codecov)](https://coveralls.io/github/clux/kube-rs?branch=codecov)
I have only used coveralls before, so there may be better solutions. This is OK, not amazing for rust, but you can browse around and see. Possibly codecov.io is better.

Run took about 7minutes, only wanted this as a quick thing to look at every now and then so didn't bother with caching:
https://github.com/clux/kube-rs/runs/2985127374?check_suite_focus=true
figured for now, once per release is better than nothing, don't really feel like we need the whole "your code coverage decreased" notifications on prs, but it's nice to have an lcov browser.

<small>also bundled in with this is a clippy change</small>