### PR TITLE
Specify type for dummy exit signal future

### DIFF
--- a/kube-runtime/src/controller/mod.rs
+++ b/kube-runtime/src/controller/mod.rs
@@ -701,7 +701,7 @@ where
                     .boxed(),
                 // Assume that ctrl_c is enough on non-Unix platforms (such as Windows)
                 #[cfg(not(unix))]
-                futures::future::pending(),
+                futures::future::pending::<()>(),
             )
             .await;
         }


### PR DESCRIPTION
This PR specifies the type for the dummy exit signal future on non-Unix platforms, since rustc seems unable to figure it out