### PR TITLE
Adds a `CustomResourceExt::crd_name()` function

### DIFF
--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -12,6 +12,10 @@ pub mod v1 {
         ///
         /// This is using the stable v1::CustomResourceDefinitions (present in kubernetes >= 1.16)
         fn crd() -> super::apiexts::v1::CustomResourceDefinition;
+        /// Helper to return the name of this `CustomResourceDefinition` in kubernetes.
+        ///
+        /// This is not the name of an _instance_ of this custom resource but the definition itself.
+        fn crd_name() -> String;
         /// Helper to generate the api information type for use with the dynamic `Api`
         fn api_resource() -> crate::discovery::ApiResource;
     }
@@ -27,6 +31,10 @@ pub mod v1beta1 {
         ///
         /// This is using v1beta1::CustomResourceDefinitions (which will be removed in kubernetes 1.22)
         fn crd() -> super::apiexts::v1beta1::CustomResourceDefinition;
+        /// Helper to return the name of this `CustomResourceDefinition` in kubernetes.
+        ///
+        /// This is not the name of an _instance_ of this custom resource but the definition itself.
+        fn crd_name() -> String;
         /// Helper to generate the api information type for use with the dynamic `Api`
         fn api_resource() -> crate::discovery::ApiResource;
     }

--- a/kube-core/src/crd.rs
+++ b/kube-core/src/crd.rs
@@ -14,8 +14,8 @@ pub mod v1 {
         fn crd() -> super::apiexts::v1::CustomResourceDefinition;
         /// Helper to return the name of this `CustomResourceDefinition` in kubernetes.
         ///
-        /// This is not the name of an _instance_ of this custom resource but the definition itself.
-        fn crd_name() -> String;
+        /// This is not the name of an _instance_ of this custom resource but the `CustomResourceDefinition` object itself.
+        fn crd_name() -> &'static str;
         /// Helper to generate the api information type for use with the dynamic `Api`
         fn api_resource() -> crate::discovery::ApiResource;
     }
@@ -33,8 +33,8 @@ pub mod v1beta1 {
         fn crd() -> super::apiexts::v1beta1::CustomResourceDefinition;
         /// Helper to return the name of this `CustomResourceDefinition` in kubernetes.
         ///
-        /// This is not the name of an _instance_ of this custom resource but the definition itself.
-        fn crd_name() -> String;
+        /// This is not the name of an _instance_ of this custom resource but the `CustomResourceDefinition` object itself.
+        fn crd_name() -> &'static str;
         /// Helper to generate the api information type for use with the dynamic `Api`
         fn api_resource() -> crate::discovery::ApiResource;
     }

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -368,6 +368,10 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
                     .expect("valid custom resource from #[kube(attrs..)]")
             }
 
+            fn crd_name() -> String {
+                #crd_meta_name.to_string()
+            }
+
             fn api_resource() -> kube::core::ApiResource {
                 kube::core::ApiResource::erase::<Self>(&())
             }

--- a/kube-derive/src/custom_resource.rs
+++ b/kube-derive/src/custom_resource.rs
@@ -368,8 +368,8 @@ pub(crate) fn derive(input: proc_macro2::TokenStream) -> proc_macro2::TokenStrea
                     .expect("valid custom resource from #[kube(attrs..)]")
             }
 
-            fn crd_name() -> String {
-                #crd_meta_name.to_string()
+            fn crd_name() -> &'static str {
+                #crd_meta_name
             }
 
             fn api_resource() -> kube::core::ApiResource {

--- a/kube-derive/tests/crd_schema_test.rs
+++ b/kube-derive/tests/crd_schema_test.rs
@@ -44,6 +44,12 @@ fn default_nullable() -> Option<String> {
 }
 
 #[test]
+fn test_crd_name() {
+    use kube::core::CustomResourceExt;
+    assert_eq!("foos.clux.dev", Foo::crd_name());
+}
+
+#[test]
 fn test_crd_schema_matches_expected() {
     use kube::core::CustomResourceExt;
     assert_eq!(


### PR DESCRIPTION
This information can also be gathered from `ApiResource` but not everything that is an `ApiResource` is also a CRD so I believe it makes sense to add a convenience method here.
This information can also be gathered from `CustomResourceExt::crd().name()` but this is relatively expensive to create.